### PR TITLE
Exclude `var/log` and `var/run` from distribution

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/DistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistTarTask.groovy
@@ -31,6 +31,8 @@ class DistTarTask extends Tar {
 
         from("${project.projectDir}/var") {
             into "${archiveRootDir}/var"
+            exclude 'log'
+            exclude 'run'
         }
 
         from("${project.projectDir}/service") {


### PR DESCRIPTION
Fixes #19
