### PR TITLE
Windows start scripts use pathing jar instead of explicit classpath

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,12 @@ content of the package. The package will follow this structure:
 
     [service-name]-[service-version]/
         deployment/
-            manifest.yaml        # simple package manifest
+            manifest.yaml            # simple package manifest
         service/
             bin/
-                [service-name]   # start script
-                init.sh          # daemonizing script
+                [service-name]       # start script
+                [service-name.bat]   # Windows start script
+                init.sh              # daemonizing script
             lib/
                 [jars]
         var/
@@ -41,13 +42,17 @@ program for a default run configuration:
         mainClass 'com.palantir.foo.bar.MyServiceMainClass'
         args 'server', 'var/conf/my-service.yml'
     }
-    
+
 The `distribution` block offers the following options:
 
  * `serviceName` the name of this service, used to construct the final artifact's file name.
  * `mainClass` class containing the entry point to start the program.
  * (optional) `args` a list of arguments to supply when running `start`.
  * (optional) `defaultJvmOpts` a list of default JVM options to set on the program.
+ * (optional) `enableManifestClasspath` a boolean flag; if set to true, then the explicit Java
+   classpath is omitted from the generated Windows start script and instead infered
+   from a JAR file whose MANIFEST contains the classpath entries
+
 
 Packaging
 ---------

--- a/src/main/groovy/com/palantir/gradle/javadist/DistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistTarTask.groovy
@@ -48,6 +48,12 @@ class DistTarTask extends Tar {
             from(project.configurations.runtime)
         }
 
+        if (ext.isEnableManifestClasspath()) {
+            into("${archiveRootDir}/service/lib") {
+                from(project.tasks.getByName("manifestClasspathJar"))
+            }
+        }
+
         into("${archiveRootDir}/service/bin") {
             from("${project.buildDir}/scripts")
             fileMode = 0755

--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -21,6 +21,7 @@ class DistributionExtension {
     private String mainClass
     private List<String> args = []
     private List<String> defaultJvmOpts = []
+    private boolean enableManifestClasspath = false
 
     public void serviceName(String serviceName) {
         this.serviceName = serviceName
@@ -38,6 +39,10 @@ class DistributionExtension {
         this.defaultJvmOpts = Arrays.asList(defaultJvmOpts)
     }
 
+    public void enableManifestClasspath(boolean enableManifestClasspath) {
+        this.enableManifestClasspath = enableManifestClasspath
+    }
+
     public String getServiceName() {
         return serviceName;
     }
@@ -52,6 +57,10 @@ class DistributionExtension {
 
     public List<String> getDefaultJvmOpts() {
         return defaultJvmOpts;
+    }
+
+    public boolean isEnableManifestClasspath() {
+        return enableManifestClasspath;
     }
 
 }

--- a/src/main/groovy/com/palantir/gradle/javadist/ManifestClasspathJarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/ManifestClasspathJarTask.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * <http://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.javadist
+
+import org.gradle.api.tasks.bundling.Jar
+
+/**
+ * Produces a JAR whose manifest's {@code Class-Path} entry lists exactly the JARs produced by the project's runtime
+ * configuration.
+ */
+class ManifestClasspathJarTask extends Jar {
+
+    public ManifestClasspathJarTask() {
+        appendix = 'manifest-classpath'
+    }
+
+    public void configure(DistributionExtension ext) {
+        manifest.attributes("Class-Path": project.files(project.configurations.runtime)
+            .collect { it.getName() }
+            .join(' ') + ' ' + project.tasks.jar.archiveName
+        )
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
@@ -210,6 +210,51 @@ class JavaDistributionPluginTests extends Specification {
         startScript.contains('DEFAULT_JVM_OPTS=\'"-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
     }
 
+    def 'produces manifest-classpath jar and windows start script with no classpath length limitations' () {
+        given:
+        createUntarBuildFile(buildFile)
+        buildFile << '''
+            distribution {
+                enableManifestClasspath true
+            }
+        '''.stripIndent()
+
+        when:
+        BuildResult buildResult = run('build', 'distTar', 'untar').build()
+
+        then:
+        buildResult.task(':build').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':distTar').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':untar').outcome == TaskOutcome.SUCCESS
+
+        new File(projectDir, 'dist/service-name-0.1/service/bin/service-name.bat').exists()
+        String startScript = readFully('dist/service-name-0.1/service/bin/service-name.bat')
+        startScript.contains("-manifest-classpath-0.1.jar")
+        !startScript.contains("-classpath \"%CLASSPATH%\"")
+        new File(projectDir, 'dist/service-name-0.1/service/lib/').listFiles()
+            .find({it.name.endsWith("-manifest-classpath-0.1.jar")})
+    }
+
+    def 'does not produce manifest-classpath jar when disabled in extension'() {
+        given:
+        createUntarBuildFile(buildFile)
+
+        when:
+        BuildResult buildResult = run('build', 'distTar', 'untar').build()
+
+        then:
+        buildResult.task(':build').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':distTar').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':untar').outcome == TaskOutcome.SUCCESS
+
+        new File(projectDir, 'dist/service-name-0.1/service/bin/service-name.bat').exists()
+        String startScript = readFully('dist/service-name-0.1/service/bin/service-name.bat')
+        !startScript.contains("-manifest-classpath-0.1.jar")
+        startScript.contains("-classpath \"%CLASSPATH%\"")
+        !new File(projectDir, 'dist/service-name-0.1/service/lib/').listFiles()
+            .find({it.name.endsWith("-manifest-classpath-0.1.jar")})
+    }
+
     private def createUntarBuildFile(buildFile) {
         buildFile << '''
             plugins {


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/25)

<!-- Reviewable:end -->
