### PR TITLE
Feature/add additional jvm params at runtime through an optional wrapper.conf file

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -21,6 +21,7 @@ class DistributionExtension {
     private String mainClass
     private List<String> args = []
     private List<String> defaultJvmOpts = []
+    private String wrapperConfPath = "bin/wrapper.conf"
     private boolean enableManifestClasspath = false
 
     public void serviceName(String serviceName) {
@@ -29,6 +30,10 @@ class DistributionExtension {
 
     public void mainClass(String mainClass) {
         this.mainClass = mainClass
+    }
+
+    public void wrapperConfPath(String wrapperConfPath) {
+        this.wrapperConfPath = wrapperConfPath
     }
 
     public List<String> args(String... args) {
@@ -61,6 +66,10 @@ class DistributionExtension {
 
     public boolean isEnableManifestClasspath() {
         return enableManifestClasspath;
+    }
+
+    public String getWrapperConfPath() {
+        return wrapperConfPath;
     }
 
 }

--- a/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
@@ -61,9 +61,9 @@ class JavaDistributionPlugin implements Plugin<Project> {
             description = "Generates daemonizing init.sh script."
         }) << {
             EmitFiles.replaceVars(
-                    JavaDistributionPlugin.class.getResourceAsStream('/wrapper.conf'),
-                    Paths.get("${project.buildDir}/" + ext.wrapperConfPath),
-                    ['@applicationNameOpts@': GUtil.toConstant(ext.serviceName)+ '_OPTS'])
+                JavaDistributionPlugin.class.getResourceAsStream('/wrapper.conf'),
+                Paths.get("${project.buildDir}/" + ext.wrapperConfPath),
+                ['@applicationNameOpts@': GUtil.toConstant(ext.serviceName)+ '_OPTS'])
             .toFile()
 
             EmitFiles.replaceVars(

--- a/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
@@ -18,6 +18,7 @@ package com.palantir.gradle.javadist
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.util.GUtil
 
 import java.nio.file.Paths
 
@@ -60,10 +61,17 @@ class JavaDistributionPlugin implements Plugin<Project> {
             description = "Generates daemonizing init.sh script."
         }) << {
             EmitFiles.replaceVars(
+                    JavaDistributionPlugin.class.getResourceAsStream('/wrapper.conf'),
+                    Paths.get("${project.buildDir}/" + ext.wrapperConfPath),
+                    ['@applicationNameOpts@': GUtil.toConstant(ext.serviceName)+ '_OPTS'])
+            .toFile()
+
+            EmitFiles.replaceVars(
                 JavaDistributionPlugin.class.getResourceAsStream('/init.sh'),
                 Paths.get("${project.buildDir}/scripts/init.sh"),
                 ['@serviceName@': ext.serviceName,
-                 '@args@':  ext.args.iterator().join(' ')])
+                 '@args@':  ext.args.iterator().join(' '),
+                 '@wrapperConfigPath@': ext.wrapperConfPath ])
             .toFile()
             .setExecutable(true)
         }

--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -19,10 +19,16 @@ ACTION=$1
 SERVICE="@serviceName@"
 PIDFILE="var/run/$SERVICE.pid"
 ARGS="@args@"
+WRAPPER_CONFIG_PATH="@wrapperConfigPath@"
 
 # uses SERVICE_HOME when set, else, traverse up two directories respecting symlinks
 SERVICE_HOME=${SERVICE_HOME:-$(cd "$(dirname "$0")/../../" && pwd)}
 cd "$SERVICE_HOME"
+
+# Load the wrapper config if it exists
+if [ -f "$WRAPPER_CONFIG_PATH" ] ; then
+    source $WRAPPER_CONFIG_PATH
+fi
 
 is_process_active() {
    local PID=$1

--- a/src/main/resources/wrapper.conf
+++ b/src/main/resources/wrapper.conf
@@ -1,0 +1,41 @@
+#
+# Copyright 2015 Palantir Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# <http://www.apache.org/licenses/LICENSE-2.0>
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Uncomment to customize JVM options
+# JAVA_OPTS="-Djava.awt.headless=true \
+#                -Dlog4j.defaultInitOverride=true \
+#                -Dsun.rmi.dgc.client.gcInterval=3600000 \
+#                -Dsun.rmi.dgc.server.gcInterval=3600000 \
+#                -XX:+UseParallelOldGC \
+#                -XX:+DisableExplicitGC \
+#                -XX:+HeapDumpOnOutOfMemoryError \
+#                -XX:+PrintGCDetails \
+#                -XX:+PrintGCDateStamps \
+#                -XX:PermSize=192m \
+#                -XX:MaxPermSize=192m \
+#                -XX:SoftRefLRUPolicyMSPerMB=10 \
+#                -Xloggc:var/log/${SERVICE}-gc.log-`date +%Y-%m-%d-%H-%M` \
+#                -verbose:gc \
+#                -XX:-TraceClassUnloading \
+#                -server \
+#                -Djava.security.egd=file:/dev/./urandom \
+#                -Dsun.net.inetaddr.ttl=172800 \
+#                -Dsun.net.inetaddr.negative.ttl=172800 \
+#                -XX:+UseNUMA \
+#                -Djavax.net.ssl.trustStore=${SERVICE_HOME}/var/conf/trustStore.jks"
+
+# Uncomment to customize application specific JVM options
+# @applicationNameOpts@="-Djavax.net.ssl.trustStore=${SERVICE_HOME}/var/conf/trustStore.jks"


### PR DESCRIPTION
The location for the wrapper conf is currently in $SERVICE_HOME/bin. Not convinced on the location but that can be changed later.

Note - we may not actually need this as $JAVA_OPTS etc. can be set manually to add additional args. Leaving this here for archival purposes - in case we need to revive it later.

NB: I didn't add support for this in the windows startup scripts yet. 
