### PR TITLE
Add startDelay property to DistributionExtension

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -23,6 +23,7 @@ class DistributionExtension {
     private List<String> defaultJvmOpts = []
     private boolean enableManifestClasspath = false
     private String javaHome = null
+    private int startDelay = 1
 
     public void serviceName(String serviceName) {
         this.serviceName = serviceName
@@ -48,6 +49,10 @@ class DistributionExtension {
         this.javaHome = javaHome
     }
 
+    public void startDelay(int startDelay) {
+        this.startDelay = startDelay
+    }
+
     public String getServiceName() {
         return serviceName
     }
@@ -70,6 +75,10 @@ class DistributionExtension {
 
     public String getJavaHome() {
         return javaHome
+    }
+
+    public int getStartDelay() {
+        return startDelay
     }
 
 }

--- a/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
@@ -66,7 +66,8 @@ class JavaDistributionPlugin implements Plugin<Project> {
                 JavaDistributionPlugin.class.getResourceAsStream('/init.sh'),
                 Paths.get("${project.buildDir}/scripts/init.sh"),
                 ['@serviceName@': ext.serviceName,
-                 '@args@': ext.args.iterator().join(' ')])
+                 '@args@': ext.args.iterator().join(' '),
+                 '@startDelay@': ext.startDelay.toString()])
             .toFile()
             .setExecutable(true)
         }

--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -46,7 +46,7 @@ start)
     mkdir -p "var/log"
     mkdir -p "var/run"
     PID=$($SERVICE_CMD $ARGS > var/log/$SERVICE-startup.log 2>&1 & echo $!)
-    sleep 1
+    sleep @startDelay@
     if [ $(is_process_active $PID) -eq 0 ]; then
         echo $PID > $PIDFILE
         printf "%s\n" "Started ($PID)"


### PR DESCRIPTION
Configures wait delay before checking liveness of the application
process.
