### PR TITLE
Exclude var/data from distTar

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/DistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistTarTask.groovy
@@ -31,6 +31,10 @@ class DistTarTask extends Tar {
         this.distributionExtension = ext
     }
 
+    public DistributionExtension getDistributionExtension() {
+        return this.distributionExtension
+    }
+
     @Override
     public String getBaseName() {
         // works around a bug where something in the tar task hierarchy either resolves the wrong
@@ -44,8 +48,13 @@ class DistTarTask extends Tar {
 
         from("${project.projectDir}/var") {
             into "${archiveRootDir}/var"
+
             exclude 'log'
             exclude 'run'
+
+            distributionExtension.excludeFromVar.each {
+                exclude it
+            }
         }
 
         from("${project.projectDir}/deployment") {

--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -25,6 +25,7 @@ class DistributionExtension {
     private List<String> defaultJvmOpts = []
     private boolean enableManifestClasspath = false
     private String javaHome = null
+    private List<String> excludeFromVar = []
 
     public void serviceName(String serviceName) {
         this.serviceName = serviceName
@@ -48,6 +49,10 @@ class DistributionExtension {
 
     public void javaHome(String javaHome) {
         this.javaHome = javaHome
+    }
+
+    public void excludeFromVar(String... excludeFromVar) {
+        this.excludeFromVar = Arrays.asList(excludeFromVar);
     }
 
     public String getServiceName() {
@@ -74,4 +79,7 @@ class DistributionExtension {
         return javaHome
     }
 
+    public List<String> getExcludeFromVar() {
+        return excludeFromVar
+    }
 }


### PR DESCRIPTION
Same rationale as #21 

This is assuming that `var/data` is the right place for the service to place persistent data, in contrast to `var/run` which is for stuff that should only persist until the service is stopped - is that right?
