### PR TITLE
Add -XX:+PerfDisableSharedMem flag by default

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -20,7 +20,7 @@ class DistributionExtension {
     private static final List<String> requiredJvmOpts = [
         '-Djava.security.egd=file:/dev/./urandom',
         '-Djava.io.tmpdir=var/data/tmp',
-        '-XX:+PerfDisableSharedMem'
+        '-XX:+PerfDisableSharedMem' // avoid memory-mapped IO during GC: http://www.evanjones.ca/jvm-mmap-pause.html
     ]
 
     private String serviceName

--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -19,7 +19,8 @@ class DistributionExtension {
 
     private static final List<String> requiredJvmOpts = [
         '-Djava.security.egd=file:/dev/./urandom',
-        '-Djava.io.tmpdir=var/data/tmp'
+        '-Djava.io.tmpdir=var/data/tmp',
+        '-XX:+PerfDisableSharedMem'
     ]
 
     private String serviceName

--- a/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
@@ -220,7 +220,7 @@ class JavaDistributionPluginTests extends GradleTestSpec {
 
         then:
         String startScript = file('dist/service-name-0.1/service/bin/service-name', projectDir).text
-        startScript.contains('DEFAULT_JVM_OPTS=\'"-Djava.security.egd=file:/dev/./urandom" "-Djava.io.tmpdir=var/data/tmp" "-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
+        startScript.contains('DEFAULT_JVM_OPTS=\'"-Djava.security.egd=file:/dev/./urandom" "-Djava.io.tmpdir=var/data/tmp" "-XX:+PerfDisableSharedMem" "-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
     }
 
     def 'produce distribution bundle that populates launcher-static.yml and launcher-check.yml' () {
@@ -250,6 +250,7 @@ class JavaDistributionPluginTests extends GradleTestSpec {
         expectedStaticConfig.setJvmOpts([
                 '-Djava.security.egd=file:/dev/./urandom',
                 '-Djava.io.tmpdir=var/data/tmp',
+                '-XX:+PerfDisableSharedMem',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
         def actualStaticConfig = new ObjectMapper(new YAMLFactory()).readValue(


### PR DESCRIPTION
This change improves performance by avoiding GC pauses when writing stats to
a memory-mapped file under /tmp: http://www.evanjones.ca/jvm-mmap-pause.html.

Note that this behaviour can be overridden by users via '-XX:-PerfDisableSharedMem'.
