### PR TITLE
Update go-java-launcher to 1.0.1

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
@@ -35,7 +35,7 @@ class JavaDistributionPlugin implements Plugin<Project> {
 
         project.configurations.create('goJavaLauncherBinaries')
         project.dependencies {
-            goJavaLauncherBinaries 'com.palantir.launching:go-java-launcher:1.0.0'
+            goJavaLauncherBinaries 'com.palantir.launching:go-java-launcher:1.0.1'
         }
 
         DistributionExtension ext = project.extensions.create('distribution', DistributionExtension)


### PR DESCRIPTION
Provides better error handling when Java binary cannot be found.
