### PR TITLE
Remove special /dev/urandom java option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,9 +79,6 @@ concatenating the following list of hard-coded *required options* and the list o
 `distribution.defaultJvmOpts`:
 
 Hard-coded required JVM options:
-- `-Djava.security.egd=file:/dev/./urandom`: urandom is the
-  [preferred source of cryptographic randomness on modern Linux systems](http://www.2uo.de/myths-about-urandom/). Note
-  that some Java implementations override `/dev/urandom` internally; we thus set it to `/dev/./urandom`.
 - `-Djava.io.tmpdir=var/data/tmp`: Allocates temporary files inside the application installation folder rather than on
   `/tmp`; the latter is often space-constrained on cloud hosts.
 

--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -18,7 +18,6 @@ package com.palantir.gradle.javadist;
 class DistributionExtension {
 
     static final List<String> requiredJvmOpts = [
-            '-Djava.security.egd=file:/dev/./urandom',
             '-Djava.io.tmpdir=var/data/tmp',
             '-XX:+PrintGCDateStamps',
             '-XX:+PrintGCDetails',

--- a/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
@@ -259,7 +259,7 @@ class JavaDistributionPluginTests extends GradleTestSpec {
 
         then:
         String startScript = file('dist/service-name-0.1/service/bin/service-name', projectDir).text
-        startScript.contains('DEFAULT_JVM_OPTS=\'"-Djava.security.egd=file:/dev/./urandom" "-Djava.io.tmpdir=var/data/tmp" "-XX:+PrintGCDateStamps" "-XX:+PrintGCDetails" "-XX:-TraceClassUnloading" "-XX:+UseGCLogFileRotation" "-XX:GCLogFileSize=10M" "-XX:NumberOfGCLogFiles=10" "-Xloggc:var/log/gc.log" "-verbose:gc" "-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
+        startScript.contains('DEFAULT_JVM_OPTS=\'"-Djava.io.tmpdir=var/data/tmp" "-XX:+PrintGCDateStamps" "-XX:+PrintGCDetails" "-XX:-TraceClassUnloading" "-XX:+UseGCLogFileRotation" "-XX:GCLogFileSize=10M" "-XX:NumberOfGCLogFiles=10" "-Xloggc:var/log/gc.log" "-verbose:gc" "-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
     }
 
     def 'produce distribution bundle that populates launcher-static.yml and launcher-check.yml'() {
@@ -287,7 +287,6 @@ class JavaDistributionPluginTests extends GradleTestSpec {
         expectedStaticConfig.setArgs(['myArg1', 'myArg2'])
         expectedStaticConfig.setClasspath(['service/lib/internal-0.1.jar', 'service/lib/external.jar'])
         expectedStaticConfig.setJvmOpts([
-                '-Djava.security.egd=file:/dev/./urandom',
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-XX:+PrintGCDateStamps',
                 '-XX:+PrintGCDetails',


### PR DESCRIPTION
Java8 uses urandom by default: https://docs.oracle.com/javase/8/docs/technotes/guides/security/enhancements-8.html
Java7 users can still manually set the option.
