### PR TITLE
enableManifestClasspath should also affect linux and init.sh start scripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ The `distribution` block offers the following options:
    no monitoring script will be generated.
  * (optional) `defaultJvmOpts` a list of default JVM options to set on the program.
  * (optional) `enableManifestClasspath` a boolean flag; if set to true, then the explicit Java
-   classpath is omitted from the generated Windows start script and instead inferred
+   classpath is omitted from the generated start scripts and instead inferred
    from a JAR file whose MANIFEST contains the classpath entries.
  * (optional) `excludeFromVar` a list of directories (relative to `${projectDir}/var`) to exclude from the distribution,
    defaulting to `['log', 'run']`.

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateStartScriptsTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateStartScriptsTask.groovy
@@ -15,14 +15,15 @@
  */
 package com.palantir.gradle.javadist.tasks
 
-import com.palantir.gradle.javadist.DistributionExtension
-import com.palantir.gradle.javadist.JavaDistributionPlugin
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.jvm.application.tasks.CreateStartScripts
+
+import com.palantir.gradle.javadist.DistributionExtension
+import com.palantir.gradle.javadist.JavaDistributionPlugin
 
 class CreateStartScriptsTask extends CreateStartScripts {
 
@@ -48,8 +49,15 @@ class CreateStartScriptsTask extends CreateStartScripts {
                 winFileText = winFileText.replaceAll(
                         '("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)',
                         '$1%APP_HOME%\\\\lib\\\\' + manifestClasspathJarTask.archiveName + '$2')
-
                 winScriptFile.text = winFileText
+
+                def unixScriptFile = project.file getUnixScript()
+                def unixFileText = unixScriptFile.text
+
+                unixFileText = unixFileText.replaceAll(
+                        'CLASSPATH=\\$APP_HOME.*',
+                        'CLASSPATH=\\$APP_HOME/lib/' + manifestClasspathJarTask.archiveName)
+                unixScriptFile.text = unixFileText
             }
         }
     }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/LaunchConfigTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/LaunchConfigTask.groovy
@@ -16,17 +16,19 @@
 
 package com.palantir.gradle.javadist.tasks
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.palantir.gradle.javadist.JavaDistributionPlugin
-import groovy.transform.EqualsAndHashCode
+import java.nio.file.Files
+
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
-import java.nio.file.Files
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.palantir.gradle.javadist.JavaDistributionPlugin
+
+import groovy.transform.EqualsAndHashCode
 
 class LaunchConfigTask extends BaseTask {
 
@@ -87,8 +89,13 @@ class LaunchConfigTask extends BaseTask {
         config.mainClass = distributionExtension().mainClass
         config.javaHome = distributionExtension().javaHome ?: ""
         config.args = args
-        config.classpath = relativizeToServiceLibDirectory(
-                project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtime)
+        if (distributionExtension().isEnableManifestClasspath()) {
+            config.classpath = relativizeToServiceLibDirectory(
+                    project.tasks.getByName('manifestClasspathJar').outputs.files)
+        } else {
+            config.classpath = relativizeToServiceLibDirectory(
+                    project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtime)
+        }
         config.jvmOpts = distributionExtension().defaultJvmOpts
         return config
     }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/ManifestClasspathJarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/ManifestClasspathJarTask.groovy
@@ -16,9 +16,10 @@
 
 package com.palantir.gradle.javadist.tasks
 
+import org.gradle.api.tasks.bundling.Jar
+
 import com.palantir.gradle.javadist.DistributionExtension
 import com.palantir.gradle.javadist.JavaDistributionPlugin
-import org.gradle.api.tasks.bundling.Jar
 
 /**
  * Produces a JAR whose manifest's {@code Class-Path} entry lists exactly the JARs produced by the project's runtime
@@ -29,7 +30,7 @@ class ManifestClasspathJarTask extends Jar {
     public ManifestClasspathJarTask() {
         group = JavaDistributionPlugin.GROUP_NAME
         description = "Creates a jar containing a Class-Path manifest entry specifying the classpath using pathing " +
-                "jar rather than command line argument on Windows, since Windows path sizes are limited."
+                "jar rather than command line argument to work around long path sizes."
         appendix = 'manifest-classpath'
 
         doFirst {

--- a/src/test/groovy/com/palantir/gradle/javadist/GradleTestSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/javadist/GradleTestSpec.groovy
@@ -16,14 +16,16 @@
 
 package com.palantir.gradle.javadist
 
-import com.energizedwork.spock.extensions.TempDirectory
-import groovy.transform.CompileStatic
-import groovy.transform.TypeCheckingMode
-import nebula.test.multiproject.MultiProjectIntegrationHelper
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
+
+import com.energizedwork.spock.extensions.TempDirectory
+
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
+import nebula.test.multiproject.MultiProjectIntegrationHelper
 import spock.lang.Specification
 
 public class GradleTestSpec extends Specification {
@@ -60,7 +62,7 @@ public class GradleTestSpec extends Specification {
         Process proc = new ProcessBuilder().command(tasks).directory(projectDir).start()
         proc.consumeProcessOutput(sout, serr)
         int result = proc.waitFor()
-        Assert.assertEquals(sprintf("Expected command '%s' to be successful", tasks.join(' ')), result, 0)
+        Assert.assertEquals(sprintf("Expected command '%s' to be successful", tasks.join(' ')), 0, result)
         sleep 1000 // wait for the Java process to actually run
         return sout.toString()
     }

--- a/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
@@ -15,13 +15,14 @@
  */
 package com.palantir.gradle.javadist
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.palantir.gradle.javadist.tasks.LaunchConfigTask
+import java.nio.file.Files
+
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
-import java.nio.file.Files
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.palantir.gradle.javadist.tasks.LaunchConfigTask
 
 class JavaDistributionPluginTests extends GradleTestSpec {
 
@@ -334,10 +335,37 @@ class JavaDistributionPluginTests extends GradleTestSpec {
         file('dist/service-name-0.1/service/monitoring/bin/check.sh').exists()
     }
 
-    def 'produces manifest-classpath jar and windows start script with no classpath length limitations'() {
+    def 'test manifest-classpath unix start script'() {
         given:
         createUntarBuildFile(buildFile)
         buildFile << '''
+            distribution {
+                enableManifestClasspath true
+            }
+        '''.stripIndent()
+        file('src/main/java/test/Test.java') << '''
+        package test;
+        public class Test {
+            public static void main(String[] args) {
+                while(true);
+            }
+        }
+        '''.stripIndent()
+
+        when:
+        runSuccessfully(':build', ':distTar', ':untar')
+
+        then:
+        exec('dist/service-name-0.1/service/bin/init.sh', 'start') ==~ /(?m)Running 'service-name'\.\.\.\s+Started \(\d+\)\n/
+        exec('dist/service-name-0.1/service/bin/init.sh', 'status') ==~ /(?m)Checking 'service-name'\.\.\.\s+Running \(\d+\)\n/
+        exec('dist/service-name-0.1/service/bin/init.sh', 'stop') ==~ /(?m)Stopping 'service-name'\.\.\.\s+Stopped \(\d+\)\n/
+    }
+
+    def 'produces manifest-classpath jar and start script with no classpath length limitations'() {
+        given:
+        createUntarBuildFile(buildFile)
+        buildFile << '''
+            dependencies { compile files("external.jar") }
             distribution {
                 enableManifestClasspath true
             }
@@ -347,26 +375,41 @@ class JavaDistributionPluginTests extends GradleTestSpec {
         runSuccessfully(':build', ':distTar', ':untar')
 
         then:
-        String startScript = file('dist/service-name-0.1/service/bin/service-name.bat', projectDir).text
-        startScript.contains("-manifest-classpath-0.1.jar")
-        !startScript.contains("-classpath \"%CLASSPATH%\"")
+        String winStartScript = file('dist/service-name-0.1/service/bin/service-name.bat', projectDir).text
+        winStartScript.contains("-manifest-classpath-0.1.jar")
+        !winStartScript.contains("-classpath \"%CLASSPATH%\"")
+        String unixStartScript = file('dist/service-name-0.1/service/bin/service-name', projectDir).text
+        unixStartScript.contains("-manifest-classpath-0.1.jar")
+        !unixStartScript.contains("external.jar")
         file('dist/service-name-0.1/service/lib/').listFiles()
                 .find({ it.name.endsWith("-manifest-classpath-0.1.jar") })
+        String launcher = file('dist/service-name-0.1/service/bin/launcher-static.yml', projectDir).text
+        !launcher.contains("external.jar")
     }
 
     def 'does not produce manifest-classpath jar when disabled in extension'() {
         given:
         createUntarBuildFile(buildFile)
+        buildFile << '''
+            dependencies { compile files("external.jar") }
+        '''.stripIndent()
 
         when:
         runSuccessfully(':build', ':distTar', ':untar')
 
         then:
-        String startScript = file('dist/service-name-0.1/service/bin/service-name.bat', projectDir).text
-        !startScript.contains("-manifest-classpath-0.1.jar")
-        startScript.contains("-classpath \"%CLASSPATH%\"")
+        String winStartScript = file('dist/service-name-0.1/service/bin/service-name.bat', projectDir).text
+        !winStartScript.contains("-manifest-classpath-0.1.jar")
+        winStartScript.contains("-classpath \"%CLASSPATH%\"")
+
+        String unixStartScript = file('dist/service-name-0.1/service/bin/service-name', projectDir).text
+        !unixStartScript.contains("-manifest-classpath-0.1.jar")
+        unixStartScript.contains("external.jar")
+
         !new File(projectDir, 'dist/service-name-0.1/service/lib/').listFiles()
                 .find({ it.name.endsWith("-manifest-classpath-0.1.jar") })
+        String launcher = file('dist/service-name-0.1/service/bin/launcher-static.yml', projectDir).text
+        launcher.contains("external.jar")
     }
 
     def 'distTar artifact name is set during appropriate lifecycle events'() {


### PR DESCRIPTION
You can now define a customClasspath for the distribution which will
override the expansion of all *.jar files in the runtime configuration.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/128)

<!-- Reviewable:end -->
