### PR TITLE
Do not force dependency resolution during configuration phase

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/JavaDistributionPlugin.groovy
@@ -34,16 +34,20 @@ class JavaDistributionPlugin implements Plugin<Project> {
             goJavaLauncherBinaries 'com.palantir.launching:go-java-launcher:1.0.1'
         }
 
+        project.ext.set ("distributionExtension", {
+            return project.extensions.findByType(DistributionExtension)
+        })
+
         // Create tasks
-        ManifestClasspathJarTask manifestClasspathJar = project.tasks.create("manifestClasspathJar", ManifestClasspathJarTask)
-        CreateStartScriptsTask startScripts = project.tasks.create('createStartScripts', CreateStartScriptsTask)
-        CopyLauncherBinariesTask copyLauncherBinaries = project.tasks.create('copyLauncherBinaries', CopyLauncherBinariesTask)
-        LaunchConfigTask launchConfig = project.tasks.create('createLaunchConfig', LaunchConfigTask)
+        Task manifestClasspathJar = ManifestClasspathJarTask.createManifestClasspathJarTask(project, 'manifestClasspathJar')
+        Task startScripts = project.tasks.create('createStartScripts', CreateStartScriptsTask)
+        Task copyLauncherBinaries = CopyLauncherBinariesTask.createCopyLauncherBinariesTask(project, 'copyLauncherBinaries')
+        Task launchConfig = project.tasks.create('createLaunchConfig', LaunchConfigTask)
         Task initScript = project.tasks.create('createInitScript', CreateInitScriptTask)
         Task checkScript = project.tasks.create('createCheckScript', CreateCheckScriptTask)
         Task manifest = project.tasks.create('createManifest', CreateManifestTask)
-        DistTarTask distTar = project.tasks.create('distTar', DistTarTask)
-        RunTask run = project.tasks.create('run', RunTask)
+        Task distTar = DistTarTask.createDistTarTask(project, 'distTar')
+        Task run = RunTask.createRunTask(project, 'run')
 
         // Create configuration and exported artifacts
         project.configurations.create(SLS_CONFIGURATION_NAME)

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CopyLauncherBinariesTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CopyLauncherBinariesTask.groovy
@@ -17,31 +17,33 @@
 package com.palantir.gradle.javadist.tasks
 
 import com.palantir.gradle.javadist.JavaDistributionPlugin
+import org.gradle.api.Project
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.Copy
 
-class CopyLauncherBinariesTask extends Copy {
-    CopyLauncherBinariesTask() {
-        group = JavaDistributionPlugin.GROUP_NAME
-        description = "Creates go-java-launcher binaries."
+class CopyLauncherBinariesTask {
+    public static Copy createCopyLauncherBinariesTask(Project project, String taskName) {
+        def copyLauncherBinaries = project.tasks.create(taskName, Copy.class)
+        copyLauncherBinaries.group = JavaDistributionPlugin.GROUP_NAME
+        copyLauncherBinaries.description = "Creates go-java-launcher binaries."
 
-        project.afterEvaluate {
-            def zipPath = project.configurations.goJavaLauncherBinaries.find {
-                it.name.startsWith("go-java-launcher")
-            }
-            def zipFile = project.file(zipPath)
-
-            from project.tarTree(zipFile)
-            into "${project.buildDir}/scripts"
-            includeEmptyDirs = false
-
-            // remove first three levels of directory structure from Tar container
-            eachFile { FileCopyDetails fcp ->
-                fcp.relativePath = new RelativePath(
-                        !fcp.file.isDirectory(),
-                        fcp.relativePath.segments[3..-1] as String[])
-            }
+        def zipPath = project.configurations.goJavaLauncherBinaries.find {
+            it.name.startsWith("go-java-launcher")
         }
+
+        def zipFile = project.file(zipPath)
+
+        copyLauncherBinaries.from project.tarTree(zipFile)
+        copyLauncherBinaries.into "${project.buildDir}/scripts"
+        copyLauncherBinaries.includeEmptyDirs = false
+
+        // remove first three levels of directory structure from Tar container
+        copyLauncherBinaries.eachFile { FileCopyDetails fcp ->
+            fcp.relativePath = new RelativePath(
+                    !fcp.file.isDirectory(),
+                    fcp.relativePath.segments[3..-1] as String[])
+        }
+        return copyLauncherBinaries
     }
 }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateCheckScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateCheckScriptTask.groovy
@@ -19,10 +19,11 @@ package com.palantir.gradle.javadist.tasks
 import com.palantir.gradle.javadist.util.EmitFiles
 import com.palantir.gradle.javadist.JavaDistributionPlugin
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.DefaultTask
 
 import java.nio.file.Paths
 
-class CreateCheckScriptTask extends BaseTask {
+class CreateCheckScriptTask extends DefaultTask {
     CreateCheckScriptTask() {
         group = JavaDistributionPlugin.GROUP_NAME
         description = "Generates healthcheck (service/monitoring/bin/check.sh) script."
@@ -30,12 +31,12 @@ class CreateCheckScriptTask extends BaseTask {
 
     @TaskAction
     void createInitScript() {
-        if (!distributionExtension().checkArgs.empty) {
+        if (!project.distributionExtension().checkArgs.empty) {
             EmitFiles.replaceVars(
                     JavaDistributionPlugin.class.getResourceAsStream('/check.sh'),
                     Paths.get("${project.buildDir}/monitoring/check.sh"),
-                    ['@serviceName@': distributionExtension().serviceName,
-                     '@checkArgs@': distributionExtension().checkArgs.iterator().join(' ')])
+                    ['@serviceName@': project.distributionExtension().serviceName,
+                     '@checkArgs@': project.distributionExtension().checkArgs.iterator().join(' ')])
                     .toFile()
                     .setExecutable(true)
         }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateInitScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateInitScriptTask.groovy
@@ -18,11 +18,12 @@ package com.palantir.gradle.javadist.tasks
 
 import com.palantir.gradle.javadist.util.EmitFiles
 import com.palantir.gradle.javadist.JavaDistributionPlugin
+import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
 import java.nio.file.Paths
 
-class CreateInitScriptTask extends BaseTask {
+class CreateInitScriptTask extends DefaultTask {
     CreateInitScriptTask() {
         group = JavaDistributionPlugin.GROUP_NAME
         description = "Generates daemonizing init.sh script."
@@ -33,7 +34,7 @@ class CreateInitScriptTask extends BaseTask {
         EmitFiles.replaceVars(
                 JavaDistributionPlugin.class.getResourceAsStream('/init.sh'),
                 Paths.get("${project.buildDir}/scripts/init.sh"),
-                ['@serviceName@': distributionExtension().serviceName])
+                ['@serviceName@': project.distributionExtension().serviceName])
                 .toFile()
                 .setExecutable(true)
     }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateManifestTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateManifestTask.groovy
@@ -18,11 +18,12 @@ package com.palantir.gradle.javadist.tasks
 
 import com.palantir.gradle.javadist.util.EmitFiles
 import com.palantir.gradle.javadist.JavaDistributionPlugin
+import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
 import java.nio.file.Paths
 
-class CreateManifestTask extends BaseTask {
+class CreateManifestTask extends DefaultTask {
     CreateManifestTask() {
         group = JavaDistributionPlugin.GROUP_NAME
         description = "Generates a simple yaml file describing the package content."
@@ -33,7 +34,7 @@ class CreateManifestTask extends BaseTask {
         EmitFiles.replaceVars(
                 CreateManifestTask.class.getResourceAsStream('/manifest.yml'),
                 Paths.get("${project.buildDir}/deployment/manifest.yml"),
-                ['@serviceName@'   : distributionExtension().serviceName,
+                ['@serviceName@'   : project.distributionExtension().serviceName,
                  '@serviceVersion@': String.valueOf(project.version)])
     }
 }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateStartScriptsTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateStartScriptsTask.groovy
@@ -15,7 +15,6 @@
  */
 package com.palantir.gradle.javadist.tasks
 
-import com.palantir.gradle.javadist.DistributionExtension
 import com.palantir.gradle.javadist.JavaDistributionPlugin
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
@@ -23,6 +22,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.jvm.application.tasks.CreateStartScripts
+import org.gradle.api.tasks.bundling.Jar
 
 class CreateStartScriptsTask extends CreateStartScripts {
 
@@ -31,13 +31,13 @@ class CreateStartScriptsTask extends CreateStartScripts {
         description = "Generates standard Java start scripts."
 
         doLast {
-            ManifestClasspathJarTask manifestClasspathJarTask =
-                    (ManifestClasspathJarTask) project.tasks.getByName('manifestClasspathJar')
+            Jar manifestClasspathJarTask =
+                    project.tasks.getByName('manifestClasspathJar')
             if (!manifestClasspathJarTask) {
                 throw new GradleException("Required task not found: manifestClasspathJar")
             }
 
-            if (distributionExtension().isEnableManifestClasspath()) {
+            if (project.distributionExtension().isEnableManifestClasspath()) {
                 // Replace standard classpath with pathing jar in order to circumnavigate length limits:
                 // https://issues.gradle.org/browse/GRADLE-2992
                 def winScriptFile = project.file getWindowsScript()
@@ -54,26 +54,22 @@ class CreateStartScriptsTask extends CreateStartScripts {
         }
     }
 
-    DistributionExtension distributionExtension() {
-        return project.extensions.findByType(DistributionExtension)
-    }
-
     @Input
     @Override
     public String getMainClassName() {
-        return distributionExtension().mainClass
+        return project.distributionExtension().mainClass
     }
 
     @Input
     @Override
     public String getApplicationName() {
-        return distributionExtension().serviceName
+        return project.distributionExtension().serviceName
     }
 
     @Input
     @Override
     public List<String> getDefaultJvmOpts() {
-        return distributionExtension().defaultJvmOpts
+        return project.distributionExtension().defaultJvmOpts
     }
 
     @OutputDirectory

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/LaunchConfigTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/LaunchConfigTask.groovy
@@ -20,13 +20,14 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.palantir.gradle.javadist.JavaDistributionPlugin
 import groovy.transform.EqualsAndHashCode
+import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.TaskAction
 
 import java.nio.file.Files
 
-class LaunchConfigTask extends BaseTask {
+class LaunchConfigTask extends DefaultTask {
 
     LaunchConfigTask() {
         group = JavaDistributionPlugin.GROUP_NAME
@@ -47,8 +48,8 @@ class LaunchConfigTask extends BaseTask {
 
     @TaskAction
     void createConfig() {
-        writeConfig(createConfig(distributionExtension().args), "scripts/launcher-static.yml")
-        writeConfig(createConfig(distributionExtension().checkArgs), "scripts/launcher-check.yml")
+        writeConfig(createConfig(project.distributionExtension().args), "scripts/launcher-static.yml")
+        writeConfig(createConfig(project.distributionExtension().checkArgs), "scripts/launcher-check.yml")
     }
 
     void writeConfig(StaticLaunchConfig config, String relativePath) {
@@ -62,12 +63,12 @@ class LaunchConfigTask extends BaseTask {
 
     StaticLaunchConfig createConfig(List<String> args) {
         StaticLaunchConfig config = new StaticLaunchConfig()
-        config.mainClass = distributionExtension().mainClass
-        config.javaHome = distributionExtension().javaHome ?: ""
+        config.mainClass = project.distributionExtension().mainClass
+        config.javaHome = project.distributionExtension().javaHome ?: ""
         config.args = args
         config.classpath = relativizeToServiceLibDirectory(
                 project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtime)
-        config.jvmOpts = distributionExtension().defaultJvmOpts
+        config.jvmOpts = project.distributionExtension().defaultJvmOpts
         return config
     }
 

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/ManifestClasspathJarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/ManifestClasspathJarTask.groovy
@@ -16,32 +16,31 @@
 
 package com.palantir.gradle.javadist.tasks
 
-import com.palantir.gradle.javadist.DistributionExtension
 import com.palantir.gradle.javadist.JavaDistributionPlugin
+import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Jar
 
 /**
  * Produces a JAR whose manifest's {@code Class-Path} entry lists exactly the JARs produced by the project's runtime
  * configuration.
  */
-class ManifestClasspathJarTask extends Jar {
+class ManifestClasspathJarTask {
 
-    public ManifestClasspathJarTask() {
-        group = JavaDistributionPlugin.GROUP_NAME
-        description = "Creates a jar containing a Class-Path manifest entry specifying the classpath using pathing " +
+    public static Jar createManifestClasspathJarTask(Project project, String taskName) {
+        def manifestClasspathJar = project.tasks.create(taskName, Jar.class)
+        manifestClasspathJar.group = JavaDistributionPlugin.GROUP_NAME
+        manifestClasspathJar.description = "Creates a jar containing a Class-Path manifest entry specifying the classpath using pathing " +
                 "jar rather than command line argument on Windows, since Windows path sizes are limited."
-        appendix = 'manifest-classpath'
+        manifestClasspathJar.appendix = 'manifest-classpath'
 
-        project.afterEvaluate {
+        manifestClasspathJar.doFirst {
             manifest.attributes("Class-Path": project.files(project.configurations.runtime)
                     .collect { it.getName() }
                     .join(' ') + ' ' + project.tasks.jar.archiveName
             )
-            onlyIf { distributionExtension().isEnableManifestClasspath() }
         }
-    }
+         manifestClasspathJar.onlyIf { project.distributionExtension().isEnableManifestClasspath() }
 
-    DistributionExtension distributionExtension() {
-        return project.extensions.findByType(DistributionExtension)
+        return manifestClasspathJar
     }
 }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/RunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/RunTask.groovy
@@ -17,25 +17,24 @@ package com.palantir.gradle.javadist.tasks
 
 import com.palantir.gradle.javadist.DistributionExtension
 import com.palantir.gradle.javadist.JavaDistributionPlugin
+import org.gradle.api.Project
 import org.gradle.api.tasks.JavaExec
 
-class RunTask extends JavaExec {
+class RunTask {
 
-    RunTask() {
-        group = JavaDistributionPlugin.GROUP_NAME
-        description = "Runs the specified project using configured mainClass and with default args."
+    public static JavaExec createRunTask(Project project, String taskName) {
+        def run = project.tasks.create(taskName, JavaExec.class)
+        run.group = JavaDistributionPlugin.GROUP_NAME
+        run.description = "Runs the specified project using configured mainClass and with default args."
 
-        project.afterEvaluate {
+        run.doFirst {
             setClasspath(project.sourceSets.main.runtimeClasspath)
-            setMain(distributionExtension().mainClass)
-            if (!distributionExtension().args.isEmpty()) {
+            setMain(project.distributionExtension().mainClass)
+            if (!project.distributionExtension().args.isEmpty()) {
                 setArgs(distributionExtension().args)
             }
-            setJvmArgs(distributionExtension().getDefaultJvmOpts())
+            setJvmArgs(project.distributionExtension().getDefaultJvmOpts())
         }
-    }
-
-    DistributionExtension distributionExtension() {
-        return project.extensions.findByType(DistributionExtension)
+        return run
     }
 }


### PR DESCRIPTION
For example, accessing project.configurations.runtime during
configuration phase (.../blob/0.9.0/.../ManifestClasspathJarTask.groovy#L36)
slows down all the other tasks in the project that uses this plugin.

Also, favour composition over inheritance by reusing Gradle's
Copy/Jar/Tar tasks instead of extending them when the new tasks
only reconfigure the tasks.

Lastly, tasks should not reach into the Gradle object model
(BaseTask.distributionExtenion()). Instead have the plugin supply
a method for tasks to use. This will probably need further
clean-up/refactoring.
