### PR TITLE
Do not force dependency resolution during configuration phase

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CopyLauncherBinariesTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CopyLauncherBinariesTask.groovy
@@ -19,28 +19,29 @@ package com.palantir.gradle.javadist.tasks
 import com.palantir.gradle.javadist.JavaDistributionPlugin
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
-import org.gradle.api.tasks.Copy
+import org.gradle.api.DefaultTask
 
-class CopyLauncherBinariesTask extends Copy {
+class CopyLauncherBinariesTask extends DefaultTask {
     CopyLauncherBinariesTask() {
         group = JavaDistributionPlugin.GROUP_NAME
         description = "Creates go-java-launcher binaries."
+        doLast{
+            project.copy {
+                def zipPath = project.configurations.goJavaLauncherBinaries.find {
+                    it.name.startsWith("go-java-launcher")
+                }
+                def zipFile = project.file(zipPath)
 
-        project.afterEvaluate {
-            def zipPath = project.configurations.goJavaLauncherBinaries.find {
-                it.name.startsWith("go-java-launcher")
-            }
-            def zipFile = project.file(zipPath)
+                from project.tarTree(zipFile)
+                into "${project.buildDir}/scripts"
+                includeEmptyDirs = false
 
-            from project.tarTree(zipFile)
-            into "${project.buildDir}/scripts"
-            includeEmptyDirs = false
-
-            // remove first three levels of directory structure from Tar container
-            eachFile { FileCopyDetails fcp ->
-                fcp.relativePath = new RelativePath(
-                        !fcp.file.isDirectory(),
-                        fcp.relativePath.segments[3..-1] as String[])
+                // remove first three levels of directory structure from Tar container
+                eachFile { FileCopyDetails fcp ->
+                    fcp.relativePath = new RelativePath(
+                            !fcp.file.isDirectory(),
+                            fcp.relativePath.segments[3..-1] as String[])
+                }
             }
         }
     }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/DistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/DistTarTask.groovy
@@ -29,6 +29,9 @@ class DistTarTask extends Tar {
         compression = Compression.GZIP
         extension = 'sls.tgz'
 
+        // Do not access runtime configurations in this closure as it will force dependency
+        // resolution during configuration time and it will slow down all the other tasks
+        // in the project that uses this plugin.
         project.afterEvaluate {
             String archiveRootDir = distributionExtension().serviceName + '-' + String.valueOf(project.version)
 

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/ManifestClasspathJarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/ManifestClasspathJarTask.groovy
@@ -32,13 +32,13 @@ class ManifestClasspathJarTask extends Jar {
                 "jar rather than command line argument on Windows, since Windows path sizes are limited."
         appendix = 'manifest-classpath'
 
-        project.afterEvaluate {
+        doFirst {
             manifest.attributes("Class-Path": project.files(project.configurations.runtime)
                     .collect { it.getName() }
                     .join(' ') + ' ' + project.tasks.jar.archiveName
             )
-            onlyIf { distributionExtension().isEnableManifestClasspath() }
         }
+        onlyIf { distributionExtension().isEnableManifestClasspath() }
     }
 
     DistributionExtension distributionExtension() {

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/RunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/RunTask.groovy
@@ -25,6 +25,9 @@ class RunTask extends JavaExec {
         group = JavaDistributionPlugin.GROUP_NAME
         description = "Runs the specified project using configured mainClass and with default args."
 
+        // Do not access runtime configurations in this closure as it will force dependency
+        // resolution during configuration time and it will slow down all the other tasks
+        // in the project that uses this plugin.
         project.afterEvaluate {
             setClasspath(project.sourceSets.main.runtimeClasspath)
             setMain(distributionExtension().mainClass)


### PR DESCRIPTION
For example, accessing project.configurations.runtime during
configuration phase (.../blob/0.9.0/.../ManifestClasspathJarTask.groovy#L36)
slows down all the other tasks in the project that uses this plugin.
