### PR TITLE
Include timestamp and process ID in GC log file name

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/DistributionExtension.groovy
@@ -25,7 +25,7 @@ class DistributionExtension {
             '-XX:+UseGCLogFileRotation',
             '-XX:GCLogFileSize=10M',
             '-XX:NumberOfGCLogFiles=10',
-            '-Xloggc:var/log/gc.log',
+            '-Xloggc:var/log/gc-%t-%p.log',
             '-verbose:gc'
     ]
 

--- a/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
@@ -259,7 +259,7 @@ class JavaDistributionPluginTests extends GradleTestSpec {
 
         then:
         String startScript = file('dist/service-name-0.1/service/bin/service-name', projectDir).text
-        startScript.contains('DEFAULT_JVM_OPTS=\'"-Djava.io.tmpdir=var/data/tmp" "-XX:+PrintGCDateStamps" "-XX:+PrintGCDetails" "-XX:-TraceClassUnloading" "-XX:+UseGCLogFileRotation" "-XX:GCLogFileSize=10M" "-XX:NumberOfGCLogFiles=10" "-Xloggc:var/log/gc.log" "-verbose:gc" "-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
+        startScript.contains('DEFAULT_JVM_OPTS=\'"-Djava.io.tmpdir=var/data/tmp" "-XX:+PrintGCDateStamps" "-XX:+PrintGCDetails" "-XX:-TraceClassUnloading" "-XX:+UseGCLogFileRotation" "-XX:GCLogFileSize=10M" "-XX:NumberOfGCLogFiles=10" "-Xloggc:var/log/gc-%t-%p.log" "-verbose:gc" "-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
     }
 
     def 'produce distribution bundle that populates launcher-static.yml and launcher-check.yml'() {
@@ -294,7 +294,7 @@ class JavaDistributionPluginTests extends GradleTestSpec {
                 '-XX:+UseGCLogFileRotation',
                 '-XX:GCLogFileSize=10M',
                 '-XX:NumberOfGCLogFiles=10',
-                '-Xloggc:var/log/gc.log',
+                '-Xloggc:var/log/gc-%t-%p.log',
                 '-verbose:gc',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])


### PR DESCRIPTION
To avoid overwriting previous GC logs, the default GC log file name
includes the start timestamp and process ID.

See https://bugs.openjdk.java.net/browse/JDK-7164841 for more
information about the `%t` and `%p` `-Xloggc` template placeholders.

For example, the current log file may be of the form:
  `var/log/gc-2016-10-21_11-22-39-pid30532.log.0.current`
