### PR TITLE
Add 'product-type: service.v1' field to manifest.yml, fixes #107

### DIFF
--- a/src/main/resources/manifest.yml
+++ b/src/main/resources/manifest.yml
@@ -2,3 +2,4 @@ manifest-version: 1.0
 product-group: @serviceGroup@
 product-name: @serviceName@
 product-version: @serviceVersion@
+product-type: service.v1

--- a/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/javadist/JavaDistributionPluginTests.groovy
@@ -231,10 +231,11 @@ class JavaDistributionPluginTests extends GradleTestSpec {
 
         then:
         String manifest = file('dist/service-name-0.1/deployment/manifest.yml', projectDir).text
+        manifest.contains('manifest-version: 1.0\n')
         manifest.contains('product-group: service-group\n')
         manifest.contains('product-name: service-name\n')
         manifest.contains('product-version: 0.1\n')
-        manifest.contains('manifest-version: 1.0\n')
+        manifest.contains('product-type: service.v1\n')
     }
 
     def 'produce distribution bundle with files in deployment/'() {


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/135)

<!-- Reviewable:end -->
