### PR TITLE
Declare inputs and outputs for every single task

### DIFF
--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateCheckScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateCheckScriptTask.groovy
@@ -16,11 +16,11 @@
 
 package com.palantir.gradle.javadist.tasks
 
-import com.palantir.gradle.javadist.util.EmitFiles
 import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.javadist.util.EmitFiles
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.nio.file.Paths
 
 class CreateCheckScriptTask extends BaseTask {
     CreateCheckScriptTask() {
@@ -28,14 +28,29 @@ class CreateCheckScriptTask extends BaseTask {
         description = "Generates healthcheck (service/monitoring/bin/check.sh) script."
     }
 
+    @Input
+    public String getServiceName() {
+        return distributionExtension().serviceName
+    }
+
+    @Input
+    public Iterable<String> getCheckArgs() {
+        return distributionExtension().checkArgs
+    }
+
+    @OutputFile
+    public File getOutputFile() {
+        return new File("${project.buildDir}/monitoring/check.sh")
+    }
+
     @TaskAction
     void createInitScript() {
         if (!distributionExtension().checkArgs.empty) {
             EmitFiles.replaceVars(
                     JavaDistributionPlugin.class.getResourceAsStream('/check.sh'),
-                    Paths.get("${project.buildDir}/monitoring/check.sh"),
-                    ['@serviceName@': distributionExtension().serviceName,
-                     '@checkArgs@': distributionExtension().checkArgs.iterator().join(' ')])
+                    getOutputFile().toPath(),
+                    ['@serviceName@': getServiceName(),
+                     '@checkArgs@': getCheckArgs().iterator().join(' ')])
                     .toFile()
                     .setExecutable(true)
         }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateInitScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateInitScriptTask.groovy
@@ -16,11 +16,11 @@
 
 package com.palantir.gradle.javadist.tasks
 
-import com.palantir.gradle.javadist.util.EmitFiles
 import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.javadist.util.EmitFiles
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.nio.file.Paths
 
 class CreateInitScriptTask extends BaseTask {
     CreateInitScriptTask() {
@@ -28,12 +28,23 @@ class CreateInitScriptTask extends BaseTask {
         description = "Generates daemonizing init.sh script."
     }
 
+
+    @Input
+    public String getServiceName() {
+        return distributionExtension().serviceName
+    }
+
+    @OutputFile
+    public File getOutputFile() {
+        return new File("${project.buildDir}/scripts/init.sh")
+    }
+
     @TaskAction
     void createInitScript() {
         EmitFiles.replaceVars(
                 JavaDistributionPlugin.class.getResourceAsStream('/init.sh'),
-                Paths.get("${project.buildDir}/scripts/init.sh"),
-                ['@serviceName@': distributionExtension().serviceName])
+                getOutputFile().toPath(),
+                ['@serviceName@': getServiceName()])
                 .toFile()
                 .setExecutable(true)
     }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateManifestTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/CreateManifestTask.groovy
@@ -18,9 +18,9 @@ package com.palantir.gradle.javadist.tasks
 
 import com.palantir.gradle.javadist.JavaDistributionPlugin
 import com.palantir.gradle.javadist.util.EmitFiles
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.nio.file.Paths
 
 class CreateManifestTask extends BaseTask {
     CreateManifestTask() {
@@ -28,13 +28,33 @@ class CreateManifestTask extends BaseTask {
         description = "Generates a simple yaml file describing the package content."
     }
 
+    @Input
+    public String getServiceGroup() {
+        return distributionExtension().serviceGroup
+    }
+
+    @Input
+    public String getServiceName() {
+        return distributionExtension().serviceName
+    }
+
+    @Input
+    public String getProjectVersion() {
+        return String.valueOf(project.version)
+    }
+
+    @OutputFile
+    File getManifestFile() {
+        return new File("${project.buildDir}/deployment/manifest.yml")
+    }
+
     @TaskAction
     void createManifest() {
         EmitFiles.replaceVars(
                 CreateManifestTask.class.getResourceAsStream('/manifest.yml'),
-                Paths.get("${project.buildDir}/deployment/manifest.yml"),
-                ['@serviceGroup@'  : distributionExtension().serviceGroup,
-                 '@serviceName@'   : distributionExtension().serviceName,
-                 '@serviceVersion@': String.valueOf(project.version)])
+                getManifestFile().toPath(),
+                ['@serviceGroup@'  : getServiceGroup(),
+                 '@serviceName@'   : getServiceName(),
+                 '@serviceVersion@': getProjectVersion()])
     }
 }

--- a/src/main/groovy/com/palantir/gradle/javadist/tasks/LaunchConfigTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/javadist/tasks/LaunchConfigTask.groovy
@@ -22,6 +22,8 @@ import com.palantir.gradle.javadist.JavaDistributionPlugin
 import groovy.transform.EqualsAndHashCode
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 import java.nio.file.Files
@@ -45,15 +47,35 @@ class LaunchConfigTask extends BaseTask {
         List<String> args
     }
 
-    @TaskAction
-    void createConfig() {
-        writeConfig(createConfig(distributionExtension().args), "scripts/launcher-static.yml")
-        writeConfig(createConfig(distributionExtension().checkArgs), "scripts/launcher-check.yml")
+    @Input
+    Iterable<String> getArgs() {
+        return distributionExtension().args
     }
 
-    void writeConfig(StaticLaunchConfig config, String relativePath) {
+    @Input
+    Iterable<String> getCheckArgs() {
+        return distributionExtension().checkArgs
+    }
+
+    @OutputFile
+    public File getStaticLauncher() {
+        return new File("scripts/launcher-static.yml")
+    }
+
+    @OutputFile
+    public File getCheckLauncher() {
+        return new File("scripts/launcher-check.yml")
+    }
+
+    @TaskAction
+    void createConfig() {
+        writeConfig(createConfig(getArgs()), getStaticLauncher())
+        writeConfig(createConfig(getCheckArgs()), getCheckLauncher())
+    }
+
+    void writeConfig(StaticLaunchConfig config, File scriptFile) {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
-        def outfile = project.buildDir.toPath().resolve(relativePath)
+        def outfile = project.buildDir.toPath().resolve(scriptFile.toPath())
         Files.createDirectories(outfile.parent)
         outfile.withWriter { it ->
             mapper.writeValue(it, config)


### PR DESCRIPTION
This ensures that cleanliness/dirtiness can be tracked properly
rather than not-running a task, or running a task unnecessarily
when all the dependencies are the same.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/138)

<!-- Reviewable:end -->
