### PR TITLE
Return 2 on check failure.

### DIFF
--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -138,7 +138,7 @@ restart)
 check)
     printf "%-50s" "Checking health of '$SERVICE'..."
     $LAUNCHER_CMD $STATIC_LAUNCHER_CHECK_CONFIG > var/log/$SERVICE-check.log 2>&1
-    if [ $RESULT -eq 0 ]; then
+    if [ $? -eq 0 ]; then
         printf "%s\n" "Healthy"
         exit 0
     else

--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -138,13 +138,12 @@ restart)
 check)
     printf "%-50s" "Checking health of '$SERVICE'..."
     $LAUNCHER_CMD $STATIC_LAUNCHER_CHECK_CONFIG > var/log/$SERVICE-check.log 2>&1
-    RESULT=$?
     if [ $RESULT -eq 0 ]; then
         printf "%s\n" "Healthy"
         exit 0
     else
         printf "%s\n" "Unhealthy"
-        exit $RESULT
+        exit 2
     fi
 ;;
 *)


### PR DESCRIPTION
Dropwizard doesn't allow for setting the return value and Nagios monitoring
expects a 2 for critical failure or 1 for a warning and healthcheck failures
shouldn't be warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/148)
<!-- Reviewable:end -->
