### PR TITLE
(WIP) Refactor existing code and add support for asset bundle generation.

### DIFF
--- a/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
@@ -1,0 +1,61 @@
+package com.palantir.gradle.dist
+
+import org.gradle.api.Project
+
+class BaseDistributionExtension {
+
+        private static final List<String> VALID_PRODUCT_TYPES = [
+                "service.v1",
+                "asset.v1",
+                "daemon.v1"
+        ]
+
+        private final Project project
+        private String serviceGroup
+        private String serviceName
+        private String productType = "service.v1"
+        private Map<String, Object> manifestExtensions = [:]
+
+        public BaseDistributionExtension(Project project) {
+                this.project = project;
+        }
+
+        public void serviceName(String serviceName) {
+                this.serviceName = serviceName
+        }
+
+        void serviceGroup(String serviceGroup) {
+                this.serviceGroup = serviceGroup
+        }
+
+        public void setManifestExtensions(Map<String, Object> manifestExtensions) {
+                this.manifestExtensions = manifestExtensions;
+        }
+
+        public void manifestExtensions(Map<String, Object> manifestExtensions) {
+                this.manifestExtensions.putAll(manifestExtensions)
+        }
+
+        public String getServiceName() {
+                return serviceName
+        }
+
+        public String getServiceGroup() {
+                return serviceGroup ?: project.group
+        }
+
+        public Map<String, Object> getManifestExtensions() {
+                return this.manifestExtensions;
+        }
+
+        public String getProductType() {
+                return productType
+        }
+
+        public void setProductType(String type) {
+                if (!VALID_PRODUCT_TYPES.contains(type)) {
+                        throw new IllegalArgumentException("Invalid product type specified: " + type)
+                }
+                this.productType = type
+        }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistTarTask.groovy
@@ -1,0 +1,44 @@
+package com.palantir.gradle.dist.asset
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.bundling.Compression
+import org.gradle.api.tasks.bundling.Tar
+
+class AssetDistTarTask {
+
+    public static Tar createAssetDistTarTask(Project project, String taskName) {
+        Tar tarTask = project.tasks.create(taskName, Tar) {
+            group = AssetDistributionPlugin.GROUP_NAME
+            description = "Creates a compressed, gzipped tar file that contains required static assets."
+            // Set compression in constructor so that task output has the right name from the start.
+            compression = Compression.GZIP
+            extension = 'sls.tgz'
+        }
+        return tarTask
+    }
+
+    public static void configure(Tar distTar, String serviceName, Map<String, String> assetDirs) {
+        distTar.configure {
+            setBaseName(serviceName)
+            // do the things that the java plugin would otherwise do for us
+            def version = String.valueOf(project.version)
+            setVersion(version)
+            setDestinationDir(new File("${project.buildDir}/distributions"))
+            String archiveRootDir = serviceName + '-' + version
+
+            from("${project.projectDir}/deployment") {
+                into "${archiveRootDir}/deployment"
+            }
+
+            into("${archiveRootDir}/deployment") {
+                from("${project.buildDir}/deployment")
+            }
+
+            assetDirs.entrySet().each { entry ->
+                from("${project.projectDir}/${entry.getKey()}") {
+                    into("${archiveRootDir}/asset/${entry.getValue()}")
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
@@ -1,0 +1,26 @@
+package com.palantir.gradle.dist.asset
+
+import com.palantir.gradle.dist.BaseDistributionExtension
+import org.gradle.api.Project
+
+class AssetDistributionExtension extends BaseDistributionExtension {
+
+    private Map<String, String> assetDirs = [:]
+
+    AssetDistributionExtension(Project project) {
+        super(project)
+        setProductType("asset.v1")
+    }
+
+    public Map<String, String> getAssetDirs() {
+        return assetDirs
+    }
+
+    public void assetDir(String relativeSourcePath, String relativeDestinationPath) {
+        this.assetDirs.put(relativeSourcePath, relativeDestinationPath)
+    }
+
+    public void setAssetDirs(Map<String, String> assets) {
+        this.assetDirs = assets
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
@@ -1,0 +1,42 @@
+package com.palantir.gradle.dist.asset
+
+import com.palantir.gradle.dist.service.tasks.CreateManifestTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.bundling.Tar
+
+class AssetDistributionPlugin implements Plugin<Project> {
+
+    static final String GROUP_NAME = "Distribution"
+    static final String SLS_CONFIGURATION_NAME = "sls"
+
+    @Override
+    void apply(Project project) {
+        project.extensions.create("distribution", AssetDistributionExtension, project)
+
+        def distributionExtension = project.extensions.findByType(AssetDistributionExtension)
+
+        Task manifest = project.tasks.create('createManifest', CreateManifestTask)
+        project.afterEvaluate {
+            manifest.configure(
+                    distributionExtension.serviceName,
+                    distributionExtension.serviceGroup,
+                    distributionExtension.productType,
+                    distributionExtension.manifestExtensions,
+            )
+        }
+
+        Tar distTar = AssetDistTarTask.createAssetDistTarTask(project, 'distTar')
+
+        project.afterEvaluate {
+            AssetDistTarTask.configure(distTar, distributionExtension.serviceName, distributionExtension.assetDirs)
+        }
+
+        project.configurations.create(SLS_CONFIGURATION_NAME)
+        project.artifacts.add(SLS_CONFIGURATION_NAME, distTar)
+
+        // Configure tasks
+        distTar.dependsOn manifest
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
@@ -13,9 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
-import com.palantir.gradle.javadist.tasks.*
+import com.palantir.gradle.dist.service.tasks.CopyLauncherBinariesTask
+import com.palantir.gradle.dist.service.tasks.CreateCheckScriptTask
+import com.palantir.gradle.dist.service.tasks.CreateInitScriptTask
+import com.palantir.gradle.dist.service.tasks.CreateManifestTask
+import com.palantir.gradle.dist.service.tasks.CreateStartScriptsTask
+import com.palantir.gradle.dist.service.tasks.DistTarTask
+import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
+import com.palantir.gradle.dist.service.tasks.ManifestClasspathJarTask
+import com.palantir.gradle.dist.service.tasks.RunTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -25,17 +33,18 @@ class JavaDistributionPlugin implements Plugin<Project> {
 
     static final String GROUP_NAME = "Distribution"
     static final String SLS_CONFIGURATION_NAME = "sls"
+    static final String SERVICE_PRODUCT_TYPE = "service.v1"
 
     void apply(Project project) {
         project.plugins.apply('java')
-        project.extensions.create('distribution', DistributionExtension, project)
+        project.extensions.create('distribution', ServiceDistributionExtension, project)
 
         project.configurations.create('goJavaLauncherBinaries')
         project.dependencies {
             goJavaLauncherBinaries 'com.palantir.launching:go-java-launcher:1.1.1'
         }
 
-        def distributionExtension = project.extensions.findByType(DistributionExtension)
+        def distributionExtension = project.extensions.findByType(ServiceDistributionExtension)
 
         // Create tasks
         Task manifestClasspathJar = ManifestClasspathJarTask.createManifestClasspathJarTask(project, "manifestClasspathJar")
@@ -73,6 +82,7 @@ class JavaDistributionPlugin implements Plugin<Project> {
             manifest.configure(
                     distributionExtension.serviceName,
                     distributionExtension.serviceGroup,
+                    SERVICE_PRODUCT_TYPE,
                     distributionExtension.manifestExtensions,
             )
         }

--- a/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
+import com.palantir.gradle.dist.BaseDistributionExtension
 import org.gradle.api.Project;
 
-class DistributionExtension {
+class ServiceDistributionExtension extends BaseDistributionExtension {
 
     private final Project project
 
-    private String serviceGroup
-    private String serviceName
     private String mainClass
     private List<String> args = []
     private List<String> checkArgs = []
@@ -31,18 +30,11 @@ class DistributionExtension {
     private boolean enableManifestClasspath = false
     private String javaHome = null
     private List<String> excludeFromVar = ['log', 'run']
-    private Map<String, Object> manifestExtensions = [:]
 
-    DistributionExtension(Project project) {
+    ServiceDistributionExtension(Project project) {
+        super(project)
         this.project = project
-    }
-
-    public void serviceName(String serviceName) {
-        this.serviceName = serviceName
-    }
-
-    void serviceGroup(String serviceGroup) {
-        this.serviceGroup = serviceGroup
+        setProductType("service.v1")
     }
 
     public void mainClass(String mainClass) {
@@ -95,26 +87,6 @@ class DistributionExtension {
 
     public void setExcludeFromVar(Iterable<String> excludeFromVar) {
         this.excludeFromVar = excludeFromVar.toList()
-    }
-
-    public Map<String, Object> getManifestExtensions() {
-        return this.manifestExtensions;
-    }
-
-    public void setManifestExtensions(Map<String, Object> manifestExtensions) {
-        this.manifestExtensions = manifestExtensions;
-    }
-
-    public void manifestExtensions(Map<String, Object> manifestExtensions) {
-        this.manifestExtensions.putAll(manifestExtensions)
-    }
-
-    public String getServiceName() {
-        return serviceName
-    }
-
-    public String getServiceGroup() {
-        return serviceGroup ?: project.group
     }
 
     public String getMainClass() {

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
 import org.gradle.api.DefaultTask

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateCheckScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateCheckScriptTask.groovy
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
-import com.palantir.gradle.javadist.util.EmitFiles
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.util.EmitFiles
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.nio.file.Paths
 
 class CreateCheckScriptTask extends DefaultTask {
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateInitScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateInitScriptTask.groovy
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
-import com.palantir.gradle.javadist.util.EmitFiles
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.util.EmitFiles
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.nio.file.Paths
 
 class CreateInitScriptTask extends DefaultTask {
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateManifestTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateManifestTask.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import groovy.json.JsonOutput
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -30,6 +30,9 @@ class CreateManifestTask extends DefaultTask {
 
     @Input
     String serviceGroup
+
+    @Input
+    String productType
 
     @Input
     Map<String, Object> manifestExtensions
@@ -53,7 +56,7 @@ class CreateManifestTask extends DefaultTask {
     void createManifest() {
         getManifestFile().setText(JsonOutput.prettyPrint(JsonOutput.toJson([
                 'manifest-version': '1.0',
-                'product-type': 'service.v1',
+                'product-type': productType,
                 'product-group': serviceGroup,
                 'product-name': serviceName,
                 'product-version': projectVersion,
@@ -61,9 +64,11 @@ class CreateManifestTask extends DefaultTask {
         ])))
     }
 
-    public void configure(String serviceName, String serviceGroup, Map<String, Object> manifestExtensions) {
+    public void configure(
+            String serviceName, String serviceGroup, String productType, Map<String, Object> manifestExtensions) {
         this.serviceName = serviceName
         this.serviceGroup = serviceGroup
+        this.productType = productType
         this.manifestExtensions = manifestExtensions
     }
 }

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Jar

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/DistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/DistTarTask.groovy
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import org.gradle.api.DefaultTask

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/ManifestClasspathJarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/ManifestClasspathJarTask.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Jar
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.JavaExec
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/util/EmitFiles.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/util/EmitFiles.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.util
+package com.palantir.gradle.dist.service.util
 
 import java.nio.charset.Charset
 import java.nio.file.Files

--- a/src/main/resources/META-INF/gradle-plugins/com.palantir.asset-distribution.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.palantir.asset-distribution.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.gradle.dist.asset.AssetDistributionPlugin

--- a/src/main/resources/META-INF/gradle-plugins/com.palantir.java-distribution.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.palantir.java-distribution.properties
@@ -1,1 +1,1 @@
-implementation-class=com.palantir.gradle.javadist.JavaDistributionPlugin
+implementation-class=com.palantir.gradle.dist.service.JavaDistributionPlugin

--- a/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
@@ -1,0 +1,56 @@
+package com.palantir.gradle.dist
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class BaseDistributionExtensionTest extends Specification {
+
+    def 'serviceGroup uses project group as default'() {
+        when:
+        Project project = ProjectBuilder.builder().build()
+        project.group = "foo"
+
+        then:
+        new BaseDistributionExtension(project).serviceGroup == "foo"
+    }
+
+    def 'serviceGroup can be overwritten'() {
+        when:
+        Project project = ProjectBuilder.builder().build()
+        project.group = "foo"
+
+        then:
+        def ext = new BaseDistributionExtension(project)
+        ext.serviceGroup("bar")
+        ext.serviceGroup == "bar"
+    }
+
+    def 'productType uses service as default'() {
+        when:
+        def ext = new BaseDistributionExtension(null)
+
+        then:
+        ext.productType == "service.v1"
+    }
+
+    def 'productType can be overwritten'() {
+        when:
+        def ext = new BaseDistributionExtension(null)
+        ext.productType = "asset.v1"
+
+        then:
+        ext.productType == "asset.v1"
+    }
+
+    def 'productType only accepts valid values'() {
+        when:
+        def ext = new BaseDistributionExtension(null)
+        ext.productType = "foobar"
+
+        then:
+        def ex = thrown IllegalArgumentException
+        ex.message == "Invalid product type specified: foobar"
+
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist
 
 import com.energizedwork.spock.extensions.TempDirectory
 import groovy.transform.CompileStatic

--- a/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * <http://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.asset
+
+import spock.lang.Specification
+
+class AssetDistributionExtensionTest extends Specification {
+    def 'collection modifiers are cumulative'() {
+        given:
+        def ext = new AssetDistributionExtension(null)
+
+        when:
+        ext.with {
+            assetDir "path/to/src", "relocated/dest"
+            assetDir "path/to/src2", "relocated/dest2"
+        }
+
+        then:
+        ext.assetDirs == ["path/to/src": "relocated/dest", "path/to/src2": "relocated/dest2"]
+    }
+
+    def 'collection setters replace existing data'() {
+        given:
+        def ext = new AssetDistributionExtension(null)
+
+        when:
+        ext.with {
+            assetDir "path/to/src", "relocated/dest"
+            setAssetDirs(["path/to/src2": "relocated/dest2"])
+        }
+
+        then:
+        ext.assetDirs == ["path/to/src2": "relocated/dest2"]
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
@@ -1,0 +1,76 @@
+package com.palantir.gradle.dist.asset
+
+import com.palantir.gradle.dist.GradleTestSpec
+
+class AssetDistributionPluginTest extends GradleTestSpec {
+
+    def 'manifest file contains expected fields'() {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.asset-distribution'
+            }
+
+            project.group = 'service-group'
+
+            version '0.1'
+
+            distribution {
+                serviceName 'asset-name'
+            }
+
+            // most convenient way to untar the dist is to use gradle
+            task untar (type: Copy) {
+                from tarTree(resources.gzip("${buildDir}/distributions/asset-name-0.1.sls.tgz"))
+                into "${projectDir}/dist"
+                dependsOn distTar
+            }
+        '''.stripIndent()
+
+        when:
+        runSuccessfully(':distTar', ':untar')
+
+        then:
+        String manifest = file('dist/asset-name-0.1/deployment/manifest.yml', projectDir).text
+        manifest.contains('"manifest-version": "1.0"')
+        manifest.contains('"product-group": "service-group"')
+        manifest.contains('"product-name": "asset-name"')
+        manifest.contains('"product-version": "0.1"')
+        manifest.contains('"product-type": "asset.v1"')
+    }
+
+    def 'asset dirs are copied correctly'() {
+        given:
+        [file("static/foo/bar"), file("static/baz/abc")].each { it.write(".") }
+        buildFile << '''
+            plugins {
+                id 'com.palantir.asset-distribution'
+            }
+
+            project.group = 'service-group'
+            version '0.2'
+
+            distribution {
+                serviceName 'asset-name'
+                assetDir "static/foo", "maven"
+                assetDir "static/baz", "maven"
+            }
+
+            // most convenient way to untar the dist is to use gradle
+            task untar (type: Copy) {
+                from tarTree(resources.gzip("${buildDir}/distributions/asset-name-0.2.sls.tgz"))
+                into "${projectDir}/dist"
+                dependsOn distTar
+            }
+        '''.stripIndent()
+
+        when:
+        runSuccessfully(':distTar', ':untar')
+
+        then:
+        file("dist/asset-name-0.2/asset/maven/abc").exists()
+        file("dist/asset-name-0.2/asset/maven/bar").exists()
+    }
+
+
+}

--- a/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.palantir.gradle.javadist.tasks.LaunchConfigTask
+import com.palantir.gradle.dist.GradleTestSpec
+import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 

--- a/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtensionTest.groovy
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
-import org.gradle.api.Project
-import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
-class DistributionExtensionTest extends Specification {
+class ServiceDistributionExtensionTest extends Specification {
     def 'collection modifiers are cumulative when varargs are given'() {
         given:
-        def ext = new DistributionExtension(null)
+        def ext = new ServiceDistributionExtension(null)
 
         when:
         ext.with {
@@ -57,7 +55,7 @@ class DistributionExtensionTest extends Specification {
 
     def 'collection setters replace existing data'() {
         given:
-        def ext = new DistributionExtension(null)
+        def ext = new ServiceDistributionExtension(null)
 
         when:
         ext.with {
@@ -83,23 +81,4 @@ class DistributionExtensionTest extends Specification {
         ext.env == ['foo': 'bar']
     }
 
-    def 'serviceGroup uses project group as default'() {
-        when:
-        Project project = ProjectBuilder.builder().build()
-        project.group = "foo"
-
-        then:
-        new DistributionExtension(project).serviceGroup == "foo"
-    }
-
-    def 'serviceGroup can be overwritten'() {
-        when:
-        Project project = ProjectBuilder.builder().build()
-        project.group = "foo"
-
-        then:
-        def ext = new DistributionExtension(project)
-        ext.serviceGroup("bar")
-        ext.serviceGroup == "bar"
-    }
 }


### PR DESCRIPTION
Rough draft; need to look it over again. Does the following things--

- Refactors out a `BaseDistributionExtension` with properties common to all slsv2 product types. This is inherited by an `AssetDistr...` and an `ServiceDistr...`, the latter being the existing class
- Moves packages; `com.palantir.gradle.javadist` -> `com.palantir.gradle.dist.(service|asset)`
- Lastly, adds a `asset-distribution` plugin which accepts mappings of `sourceDir, relocatedDir` that will be used to copy static content into the final asset bundle. As with the java dist plugin, the final tarball is created at `${project.buildDir}/build/distributions/${serviceName}-${versionName}.sls.tgz`.

Note that I'm not renaming properties on the extension e.g. `serviceName` to be the more consistent `productName` (per slsv2) in the interest of not breaking existing users of the plugin. There is also an assumption here that we're not going to produce multiple slsv2 product type dists from the same gradle subproject (I re-use the `distTar` and `distribution` names), which should be ok as by convention we only have one `configuration.yml` per subproject anyway.

Happy to break it up as appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/157)
<!-- Reviewable:end -->
