### PR TITLE
Refactor to accommodate different SLSv2 product types.

### DIFF
--- a/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
@@ -27,7 +27,7 @@ class BaseDistributionExtension {
     }
 
     public void setManifestExtensions(Map<String, Object> manifestExtensions) {
-        this.manifestExtensions = manifestExtensions;
+        this.manifestExtensions = manifestExtensions
     }
 
     public void manifestExtensions(Map<String, Object> manifestExtensions) {

--- a/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
@@ -1,0 +1,61 @@
+package com.palantir.gradle.dist
+
+import org.gradle.api.Project
+
+class BaseDistributionExtension {
+
+    private static final List<String> VALID_PRODUCT_TYPES = [
+            "service.v1",
+            "asset.v1",
+            "daemon.v1"
+    ]
+
+    private final Project project
+    private String serviceGroup
+    private String serviceName
+    private String productType = "service.v1"
+    private Map<String, Object> manifestExtensions = [:]
+
+    public BaseDistributionExtension(Project project) {
+        this.project = project;
+    }
+
+    public void serviceName(String serviceName) {
+        this.serviceName = serviceName
+    }
+
+    void serviceGroup(String serviceGroup) {
+        this.serviceGroup = serviceGroup
+    }
+
+    public void setManifestExtensions(Map<String, Object> manifestExtensions) {
+        this.manifestExtensions = manifestExtensions;
+    }
+
+    public void manifestExtensions(Map<String, Object> manifestExtensions) {
+        this.manifestExtensions.putAll(manifestExtensions)
+    }
+
+    public String getServiceName() {
+        return serviceName
+    }
+
+    public String getServiceGroup() {
+        return serviceGroup ?: project.group
+    }
+
+    public Map<String, Object> getManifestExtensions() {
+        return this.manifestExtensions;
+    }
+
+    public String getProductType() {
+        return productType
+    }
+
+    public void setProductType(String type) {
+        if (!VALID_PRODUCT_TYPES.contains(type)) {
+            throw new IllegalArgumentException("Invalid product type specified: " + type)
+        }
+        this.productType = type
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
@@ -4,27 +4,25 @@ import org.gradle.api.Project
 
 class BaseDistributionExtension {
 
-    private static final List<String> VALID_PRODUCT_TYPES = [
-            "service.v1",
-            "asset.v1",
-            "daemon.v1"
+    private static final Set<String> VALID_PRODUCT_TYPES = [
+            "service.v1"
     ]
 
     private final Project project
     private String serviceGroup
     private String serviceName
-    private String productType = "service.v1"
+    private String productType
     private Map<String, Object> manifestExtensions = [:]
 
     public BaseDistributionExtension(Project project) {
-        this.project = project;
+        this.project = project
     }
 
     public void serviceName(String serviceName) {
         this.serviceName = serviceName
     }
 
-    void serviceGroup(String serviceGroup) {
+    public void serviceGroup(String serviceGroup) {
         this.serviceGroup = serviceGroup
     }
 
@@ -34,6 +32,13 @@ class BaseDistributionExtension {
 
     public void manifestExtensions(Map<String, Object> manifestExtensions) {
         this.manifestExtensions.putAll(manifestExtensions)
+    }
+
+    public void productType(String type) {
+        if (!VALID_PRODUCT_TYPES.contains(type)) {
+            throw new IllegalArgumentException("Invalid product type '${type}' specified; supported types: ${VALID_PRODUCT_TYPES}.")
+        }
+        this.productType = type
     }
 
     public String getServiceName() {
@@ -50,12 +55,5 @@ class BaseDistributionExtension {
 
     public String getProductType() {
         return productType
-    }
-
-    public void setProductType(String type) {
-        if (!VALID_PRODUCT_TYPES.contains(type)) {
-            throw new IllegalArgumentException("Invalid product type specified: " + type)
-        }
-        this.productType = type
     }
 }

--- a/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
@@ -13,9 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
-import com.palantir.gradle.javadist.tasks.*
+import com.palantir.gradle.dist.service.tasks.CopyLauncherBinariesTask
+import com.palantir.gradle.dist.service.tasks.CreateCheckScriptTask
+import com.palantir.gradle.dist.service.tasks.CreateInitScriptTask
+import com.palantir.gradle.dist.service.tasks.CreateManifestTask
+import com.palantir.gradle.dist.service.tasks.CreateStartScriptsTask
+import com.palantir.gradle.dist.service.tasks.DistTarTask
+import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
+import com.palantir.gradle.dist.service.tasks.ManifestClasspathJarTask
+import com.palantir.gradle.dist.service.tasks.RunTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -25,17 +33,18 @@ class JavaDistributionPlugin implements Plugin<Project> {
 
     static final String GROUP_NAME = "Distribution"
     static final String SLS_CONFIGURATION_NAME = "sls"
+    static final String SERVICE_PRODUCT_TYPE = "service.v1"
 
     void apply(Project project) {
         project.plugins.apply('java')
-        project.extensions.create('distribution', DistributionExtension, project)
+        project.extensions.create('distribution', ServiceDistributionExtension, project)
 
         project.configurations.create('goJavaLauncherBinaries')
         project.dependencies {
             goJavaLauncherBinaries 'com.palantir.launching:go-java-launcher:1.1.1'
         }
 
-        def distributionExtension = project.extensions.findByType(DistributionExtension)
+        def distributionExtension = project.extensions.findByType(ServiceDistributionExtension)
 
         // Create tasks
         Task manifestClasspathJar = ManifestClasspathJarTask.createManifestClasspathJarTask(project, "manifestClasspathJar")
@@ -73,6 +82,7 @@ class JavaDistributionPlugin implements Plugin<Project> {
             manifest.configure(
                     distributionExtension.serviceName,
                     distributionExtension.serviceGroup,
+                    SERVICE_PRODUCT_TYPE,
                     distributionExtension.manifestExtensions,
             )
         }

--- a/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
@@ -33,7 +33,6 @@ class JavaDistributionPlugin implements Plugin<Project> {
 
     static final String GROUP_NAME = "Distribution"
     static final String SLS_CONFIGURATION_NAME = "sls"
-    static final String SERVICE_PRODUCT_TYPE = "service.v1"
 
     void apply(Project project) {
         project.plugins.apply('java')
@@ -82,7 +81,7 @@ class JavaDistributionPlugin implements Plugin<Project> {
             manifest.configure(
                     distributionExtension.serviceName,
                     distributionExtension.serviceGroup,
-                    SERVICE_PRODUCT_TYPE,
+                    distributionExtension.productType,
                     distributionExtension.manifestExtensions,
             )
         }

--- a/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
@@ -31,7 +31,7 @@ class ServiceDistributionExtension extends BaseDistributionExtension {
 
     ServiceDistributionExtension(Project project) {
         super(project)
-        setProductType("service.v1")
+        productType("service.v1")
     }
 
     public void mainClass(String mainClass) {

--- a/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
@@ -20,8 +20,6 @@ import org.gradle.api.Project;
 
 class ServiceDistributionExtension extends BaseDistributionExtension {
 
-    private final Project project
-
     private String mainClass
     private List<String> args = []
     private List<String> checkArgs = []
@@ -33,7 +31,6 @@ class ServiceDistributionExtension extends BaseDistributionExtension {
 
     ServiceDistributionExtension(Project project) {
         super(project)
-        this.project = project
         setProductType("service.v1")
     }
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtension.groovy
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
+import com.palantir.gradle.dist.BaseDistributionExtension
 import org.gradle.api.Project;
 
-class DistributionExtension {
+class ServiceDistributionExtension extends BaseDistributionExtension {
 
     private final Project project
 
-    private String serviceGroup
-    private String serviceName
     private String mainClass
     private List<String> args = []
     private List<String> checkArgs = []
@@ -31,18 +30,11 @@ class DistributionExtension {
     private boolean enableManifestClasspath = false
     private String javaHome = null
     private List<String> excludeFromVar = ['log', 'run']
-    private Map<String, Object> manifestExtensions = [:]
 
-    DistributionExtension(Project project) {
+    ServiceDistributionExtension(Project project) {
+        super(project)
         this.project = project
-    }
-
-    public void serviceName(String serviceName) {
-        this.serviceName = serviceName
-    }
-
-    void serviceGroup(String serviceGroup) {
-        this.serviceGroup = serviceGroup
+        setProductType("service.v1")
     }
 
     public void mainClass(String mainClass) {
@@ -95,26 +87,6 @@ class DistributionExtension {
 
     public void setExcludeFromVar(Iterable<String> excludeFromVar) {
         this.excludeFromVar = excludeFromVar.toList()
-    }
-
-    public Map<String, Object> getManifestExtensions() {
-        return this.manifestExtensions;
-    }
-
-    public void setManifestExtensions(Map<String, Object> manifestExtensions) {
-        this.manifestExtensions = manifestExtensions;
-    }
-
-    public void manifestExtensions(Map<String, Object> manifestExtensions) {
-        this.manifestExtensions.putAll(manifestExtensions)
-    }
-
-    public String getServiceName() {
-        return serviceName
-    }
-
-    public String getServiceGroup() {
-        return serviceGroup ?: project.group
     }
 
     public String getMainClass() {

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
 import org.gradle.api.DefaultTask

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateCheckScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateCheckScriptTask.groovy
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
-import com.palantir.gradle.javadist.util.EmitFiles
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.util.EmitFiles
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.nio.file.Paths
 
 class CreateCheckScriptTask extends DefaultTask {
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateInitScriptTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateInitScriptTask.groovy
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
-import com.palantir.gradle.javadist.util.EmitFiles
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.util.EmitFiles
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.nio.file.Paths
 
 class CreateInitScriptTask extends DefaultTask {
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateManifestTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateManifestTask.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import groovy.json.JsonOutput
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -30,6 +30,9 @@ class CreateManifestTask extends DefaultTask {
 
     @Input
     String serviceGroup
+
+    @Input
+    String productType
 
     @Input
     Map<String, Object> manifestExtensions
@@ -53,7 +56,7 @@ class CreateManifestTask extends DefaultTask {
     void createManifest() {
         getManifestFile().setText(JsonOutput.prettyPrint(JsonOutput.toJson([
                 'manifest-version': '1.0',
-                'product-type': 'service.v1',
+                'product-type': productType,
                 'product-group': serviceGroup,
                 'product-name': serviceName,
                 'product-version': projectVersion,
@@ -61,9 +64,11 @@ class CreateManifestTask extends DefaultTask {
         ])))
     }
 
-    public void configure(String serviceName, String serviceGroup, Map<String, Object> manifestExtensions) {
+    public void configure(
+            String serviceName, String serviceGroup, String productType, Map<String, Object> manifestExtensions) {
         this.serviceName = serviceName
         this.serviceGroup = serviceGroup
+        this.productType = productType
         this.manifestExtensions = manifestExtensions
     }
 }

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Jar

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/DistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/DistTarTask.groovy
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import org.gradle.api.DefaultTask

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/ManifestClasspathJarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/ManifestClasspathJarTask.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Jar
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.tasks
+package com.palantir.gradle.dist.service.tasks
 
-import com.palantir.gradle.javadist.JavaDistributionPlugin
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.JavaExec
 

--- a/src/main/groovy/com/palantir/gradle/dist/service/util/EmitFiles.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/util/EmitFiles.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist.util
+package com.palantir.gradle.dist.service.util
 
 import java.nio.charset.Charset
 import java.nio.file.Files

--- a/src/main/resources/META-INF/gradle-plugins/com.palantir.java-distribution.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.palantir.java-distribution.properties
@@ -1,1 +1,1 @@
-implementation-class=com.palantir.gradle.javadist.JavaDistributionPlugin
+implementation-class=com.palantir.gradle.dist.service.JavaDistributionPlugin

--- a/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
@@ -1,0 +1,56 @@
+package com.palantir.gradle.dist
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class BaseDistributionExtensionTest extends Specification {
+
+    def 'serviceGroup uses project group as default'() {
+        when:
+        Project project = ProjectBuilder.builder().build()
+        project.group = "foo"
+
+        then:
+        new BaseDistributionExtension(project).serviceGroup == "foo"
+    }
+
+    def 'serviceGroup can be overwritten'() {
+        when:
+        Project project = ProjectBuilder.builder().build()
+        project.group = "foo"
+
+        then:
+        def ext = new BaseDistributionExtension(project)
+        ext.serviceGroup("bar")
+        ext.serviceGroup == "bar"
+    }
+
+    def 'productType uses service as default'() {
+        when:
+        def ext = new BaseDistributionExtension(null)
+
+        then:
+        ext.productType == "service.v1"
+    }
+
+    def 'productType can be overwritten'() {
+        when:
+        def ext = new BaseDistributionExtension(null)
+        ext.productType = "asset.v1"
+
+        then:
+        ext.productType == "asset.v1"
+    }
+
+    def 'productType only accepts valid values'() {
+        when:
+        def ext = new BaseDistributionExtension(null)
+        ext.productType = "foobar"
+
+        then:
+        def ex = thrown IllegalArgumentException
+        ex.message == "Invalid product type specified: foobar"
+
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
@@ -26,31 +26,13 @@ class BaseDistributionExtensionTest extends Specification {
         ext.serviceGroup == "bar"
     }
 
-    def 'productType uses service as default'() {
-        when:
-        def ext = new BaseDistributionExtension(null)
-
-        then:
-        ext.productType == "service.v1"
-    }
-
-    def 'productType can be overwritten'() {
-        when:
-        def ext = new BaseDistributionExtension(null)
-        ext.productType = "asset.v1"
-
-        then:
-        ext.productType == "asset.v1"
-    }
-
     def 'productType only accepts valid values'() {
         when:
         def ext = new BaseDistributionExtension(null)
-        ext.productType = "foobar"
+        ext.productType "foobar"
 
         then:
         def ex = thrown IllegalArgumentException
-        ex.message == "Invalid product type specified: foobar"
-
+        ex.message == "Invalid product type 'foobar' specified; supported types: [service.v1]."
     }
 }

--- a/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist
 
 import com.energizedwork.spock.extensions.TempDirectory
 import groovy.transform.CompileStatic

--- a/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.palantir.gradle.javadist.tasks.LaunchConfigTask
+import com.palantir.gradle.dist.GradleTestSpec
+import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 

--- a/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionExtensionTest.groovy
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.javadist
+package com.palantir.gradle.dist.service
 
-import org.gradle.api.Project
-import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
-class DistributionExtensionTest extends Specification {
+class ServiceDistributionExtensionTest extends Specification {
     def 'collection modifiers are cumulative when varargs are given'() {
         given:
-        def ext = new DistributionExtension(null)
+        def ext = new ServiceDistributionExtension(null)
 
         when:
         ext.with {
@@ -57,7 +55,7 @@ class DistributionExtensionTest extends Specification {
 
     def 'collection setters replace existing data'() {
         given:
-        def ext = new DistributionExtension(null)
+        def ext = new ServiceDistributionExtension(null)
 
         when:
         ext.with {
@@ -83,23 +81,4 @@ class DistributionExtensionTest extends Specification {
         ext.env == ['foo': 'bar']
     }
 
-    def 'serviceGroup uses project group as default'() {
-        when:
-        Project project = ProjectBuilder.builder().build()
-        project.group = "foo"
-
-        then:
-        new DistributionExtension(project).serviceGroup == "foo"
-    }
-
-    def 'serviceGroup can be overwritten'() {
-        when:
-        Project project = ProjectBuilder.builder().build()
-        project.group = "foo"
-
-        then:
-        def ext = new DistributionExtension(project)
-        ext.serviceGroup("bar")
-        ext.serviceGroup == "bar"
-    }
 }


### PR DESCRIPTION
- Moves packages; com.palantir.gradle.javadist -> com.palantir.gradle.dist.service
- Moves properties common to all SLSv2 distributions to a `BaseDistributionExtension`
- Functionality change: you can now set `productType` on the extension (vs a hard-coded `service.v1` in the `CreateManifestTask`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/158)
<!-- Reviewable:end -->
