### PR TITLE
Clean up stale PID files in init.sh and exit 1

### DIFF
--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -53,7 +53,7 @@ STATIC_LAUNCHER_CHECK_CONFIG="service/bin/launcher-check.yml"
 
 case $ACTION in
 start)
-    if service/bin/init.sh status > /dev/null 2>&1; then
+    if service/bin/init.sh status &> /dev/null; then
         echo "Process is already running"
         exit 0
     fi
@@ -95,7 +95,7 @@ status)
 ;;
 stop)
     printf "%-50s" "Stopping '$SERVICE'..."
-    if service/bin/init.sh status > /dev/null 2>&1; then
+    if service/bin/init.sh status &> /dev/null; then
         PID=$(cat $PIDFILE)
         kill $PID
         COUNTER=0
@@ -124,7 +124,7 @@ stop)
     fi
 ;;
 console)
-    if service/bin/init.sh status > /dev/null 2>&1; then
+    if service/bin/init.sh status &> /dev/null; then
         echo "Process is already running"
         exit 1
     fi

--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -18,7 +18,15 @@
 is_process_active() {
    local PID=$1
    ps $PID > /dev/null;
-   echo $?
+   return $?
+}
+
+is_process_service() {
+  local PID=$1
+  local SERVICE_NAME=$2
+  # trailing '=' prevents a header line
+  ps -o command= $PID | grep -q "$SERVICE"
+  return $?
 }
 
 # Everything in this script is relative to the base directory of an SLSv2 distribution
@@ -45,8 +53,7 @@ STATIC_LAUNCHER_CHECK_CONFIG="service/bin/launcher-check.yml"
 
 case $ACTION in
 start)
-    service/bin/init.sh status > /dev/null 2>&1
-    if [[ $? == 0 ]]; then
+    if service/bin/init.sh status > /dev/null 2>&1; then
         echo "Process is already running"
         exit 0
     fi
@@ -56,9 +63,10 @@ start)
     mkdir -p "var/log"
     mkdir -p "var/run"
     PID=$($LAUNCHER_CMD $STATIC_LAUNCHER_CONFIG $CUSTOM_LAUNCHER_CONFIG > var/log/$SERVICE-startup.log 2>&1 & echo $!)
+    # always write $PIDFILE so that `init.sh status` for a service that crashed when starting will return 1, not 3
+    echo $PID > $PIDFILE
     sleep 1
-    if [ $(is_process_active $PID) -eq 0 ]; then
-        echo $PID > $PIDFILE
+    if is_process_service $PID $SERVICE; then
         printf "%s\n" "Started ($PID)"
         exit 0
     else
@@ -70,15 +78,14 @@ status)
     printf "%-50s" "Checking '$SERVICE'..."
     if [ -f $PIDFILE ]; then
         PID=$(cat $PIDFILE)
-        if [[ $(is_process_active $PID) -eq 0 ]]; then
-            ps -o command $PID | grep -q "$SERVICE"
-            if [[ $? == 0 ]]; then
-                printf "%s\n" "Running ($PID)"
-                exit 0
-            else
-                printf "%s\n" "Warning, Pid $PID appears to not correspond to service $SERVICE"
-            fi
+        if is_process_service $PID $SERVICE; then
+          printf "%s\n" "Running ($PID)"
+          exit 0
+        elif is_process_active $PID; then
+          printf "%s\n" "Warning, Pid $PID appears to not correspond to service $SERVICE"
+          # fallthrough to generic 'process dead but pidfile exists'
         fi
+
         printf "%s\n" "Process dead but pidfile exists."
         exit 1
     else
@@ -88,12 +95,11 @@ status)
 ;;
 stop)
     printf "%-50s" "Stopping '$SERVICE'..."
-    service/bin/init.sh status > /dev/null 2>&1
-    if [[ $? == 0 ]]; then
+    if service/bin/init.sh status > /dev/null 2>&1; then
         PID=$(cat $PIDFILE)
         kill $PID
         COUNTER=0
-        while [ $(is_process_active $PID) -eq "0" -a "$COUNTER" -lt "240" ]; do
+        while is_process_service $PID $SERVICE && [ "$COUNTER" -lt "240" ]; do
             sleep 1
             let COUNTER=COUNTER+1
             if [ $((COUNTER%5)) == 0 ]; then
@@ -103,7 +109,7 @@ stop)
                 printf "%s\n" "Waiting for '$SERVICE' ($PID) to stop"
             fi
         done
-        if [[ $(is_process_active $PID) -eq "0" ]]; then
+        if is_process_service $PID $SERVICE; then
             printf "%s\n" "Failed"
             exit 1
         else
@@ -118,8 +124,7 @@ stop)
     fi
 ;;
 console)
-    service/bin/init.sh status > /dev/null 2>&1
-    if [[ $? == 0 ]]; then
+    if service/bin/init.sh status > /dev/null 2>&1; then
         echo "Process is already running"
         exit 1
     fi

--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -77,11 +77,11 @@ status)
                 exit 0
             else
                 printf "%s\n" "Warning, Pid $PID appears to not correspond to service $SERVICE"
-                exit 0
             fi
         fi
-        printf "%s\n" "Process dead but pidfile exists"
-        exit 1
+        printf "%s\n" "Process dead but pidfile exists. Cleaning up."
+        rm -f $PIDFILE
+        exit 3
     else
         printf "%s\n" "Service not running"
         exit 3

--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -79,9 +79,8 @@ status)
                 printf "%s\n" "Warning, Pid $PID appears to not correspond to service $SERVICE"
             fi
         fi
-        printf "%s\n" "Process dead but pidfile exists. Cleaning up."
-        rm -f $PIDFILE
-        exit 3
+        printf "%s\n" "Process dead but pidfile exists."
+        exit 1
     else
         printf "%s\n" "Service not running"
         exit 3

--- a/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
@@ -55,11 +55,15 @@ public class GradleTestSpec extends Specification {
     }
 
     protected String exec(String... tasks) {
+        return execWithResult(0, tasks)
+    }
+
+    protected String execWithResult(int expected, String... tasks) {
         StringBuffer sout = new StringBuffer(), serr = new StringBuffer()
         Process proc = new ProcessBuilder().command(tasks).directory(projectDir).start()
         proc.consumeProcessOutput(sout, serr)
         int result = proc.waitFor()
-        Assert.assertEquals(sprintf("Expected command '%s' to be successful", tasks.join(' ')), result, 0)
+        Assert.assertEquals(sprintf("Expected command '%s' to exit with '%d'", tasks.join(' '), expected), expected, result)
         sleep 1000 // wait for the Java process to actually run
         return sout.toString()
     }

--- a/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
@@ -127,12 +127,15 @@ class JavaDistributionPluginTests extends GradleTestSpec {
 
         when:
         runSuccessfully(':build', ':distTar', ':untar')
-        Files.move(file('dist/service-name-0.0.1').toPath(), file('dist/foo').toPath())
+        createFile('dist/service-name-0.0.1/var/run/service-name.pid')
+        exec('/bin/bash', '-c', 'sleep 30 & echo $! > dist/service-name-0.0.1/var/run/service-name.pid')
 
         then:
-        exec('dist/foo/service/bin/init.sh', 'start') ==~ /(?m)Running 'service-name'\.\.\.\s+Started \(\d+\)\n/
-        exec('dist/foo/service/bin/init.sh', 'status').contains('appears to not correspond to service service-name')
-        exec('dist/foo/service/bin/init.sh', 'stop') ==~ /(?m)Stopping 'service-name'\.\.\.\s+Stopped \(\d+\)\n/
+        execWithResult(1, 'dist/service-name-0.0.1/service/bin/init.sh', 'status').contains('appears to not correspond to service service-name')
+        // 'dead with pidfile' persist across status calls
+        execWithResult(1, 'dist/service-name-0.0.1/service/bin/init.sh', 'status').contains('Process dead but pidfile exists')
+        exec('dist/service-name-0.0.1/service/bin/init.sh', 'stop').contains('Service not running')
+        execWithResult(3, 'dist/service-name-0.0.1/service/bin/init.sh', 'status').contains('Service not running')
     }
 
     def 'produce distribution bundle and check var/log and var/run are excluded'() {


### PR DESCRIPTION
If the process identified by the pid file is dead, or was replaced by another process, we should consistently report the service as not running (1), and clean up the stale PID file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/159)
<!-- Reviewable:end -->
