### PR TITLE
Add support for asset distributions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,21 @@
-Java Distribution Gradle Plugin
-================================
+# SLSv2 Distribution Gradle Plugins
+
 [![Build Status](https://circleci.com/gh/palantir/gradle-java-distribution.svg?style=shield)](https://circleci.com/gh/palantir/gradle-java-distribution)
 [![Coverage Status](https://coveralls.io/repos/github/palantir/gradle-java-distribution/badge.svg?branch=develop)](https://coveralls.io/github/palantir/gradle-java-distribution?branch=develop)
 [![Gradle Plugins Release](https://api.bintray.com/packages/palantir/releases/gradle-java-distribution/images/download.svg)](https://plugins.gradle.org/plugin/com.palantir.java-distribution)
 
-Similar to the standard application plugin, this plugin facilitates packaging
-Gradle projects for easy distribution and execution. This distribution chooses
-different packaging conventions that attempt to split immutable files from
-mutable state and configuration.
+A set of gradle plugins that facilitate packaging projects for distributions
+conforming to the [Service Layout Specification](https://github.com/palantir/sls-spec).
+
+The Java Service and Asset plugins cannot both be applied to the same gradle project, and
+distributions from both are produced as a gzipped tar named `[service-name]-[project-version].sls.tgz`.
+
+## Java Service Distribution Gradle Plugin
+
+Similar to the standard application plugin, this plugin helps package Java
+Gradle projects for easy distribution and execution. This distribution conforms with the
+[SLS service layout conventions](https://github.com/palantir/sls-spec/blob/master/layout.md#services-and-daemons)
+ that attempt to split immutable files from mutable state and configuration.
 
 In particular, this plugin packages a project into a common deployment structure
 with a simple start script, daemonizing script, and, a manifest describing the
@@ -35,18 +43,47 @@ content of the package. The package will follow this structure:
 The `service/bin/` directory contains both Gradle-generated launcher scripts (`[service-name]` and `[service-name].bat`)
 and [go-java-launcher](https://github.com/palantir/go-java-launcher) launcher binaries.
 
-Packages are produced as gzipped tar named `[service-name]-[project-version].sls.tgz`.
+## Asset Distribution Gradle Plugin
 
-Usage
------
-Apply the plugin using standard Gradle convention:
+This plugin helps package static files and directories into a distribution that conforms with the
+[SLS asset layout conventions](https://github.com/palantir/sls-spec/blob/master/layout.md#assets).
+Asset distributions differ from service distributions in that they do not have a top-level `service`
+or `var` directory, and instead utilize a top-level `asset` directory that can contain arbitrary files.
+
+## Usage
+
+Apply the plugins using standard Gradle convention:
 
     plugins {
         id 'com.palantir.java-distribution'
     }
 
-Set the service name, main class, and optionally the arguments to pass to the
-program for a default run configuration:
+Or similarly for the asset dist plugin:
+
+    plugins {
+        id 'com.palantir.asset-distribution'
+    }
+
+Both the plugins allow you to configure some shared properties, e.g. the service name:
+
+    distribution {
+        serviceName 'my-service'
+        serviceGroup 'my.service.group'
+    }
+
+The complete list of shared options:
+
+ * `serviceName` the name of this service, used to construct the final artifact's file name.
+ * (optional) `serviceGroup` the group of the service, used in the final artifact's manifest.
+   Defaults to the group for the gradle project.
+ * (optional) `manifestExtensions` a map of extended manifest attributes, as specified in
+   [SLS 1.0](https://github.com/palantir/sls-spec/blob/master/manifest.md).
+
+Additionally, each plugin allows you to configure properties pertinent to the type of distribution it creates.
+
+### Java Service plugin configuration
+
+A sample configuration block for the Java Service plugin:
 
     distribution {
         serviceName 'my-service'
@@ -56,9 +93,8 @@ program for a default run configuration:
         manifestExtensions 'KEY3': 'value2'
     }
 
-The `distribution` block offers the following options:
+And the complete list of available options:
 
- * `serviceName` the name of this service, used to construct the final artifact's file name.
  * `mainClass` class containing the entry point to start the program.
  * (optional) `args` a list of arguments to supply when running `start`.
  * (optional) `checkArgs` a list of arguments to supply to the monitoring script, if omitted,
@@ -77,10 +113,9 @@ The `distribution` block offers the following options:
    nothing in `${projectDir}/var/data` is copied.
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
    be applied when `init.sh` is run.
- * (optional) `manifestExtensions` a map of extended manifest attributes, as specified in
-   [SLS 1.0](https://github.com/palantir/sls-spec/blob/master/manifest.md).
 
 #### JVM Options
+
 The list of JVM options passed to the Java processes launched through a package's start-up scripts is obtained by
 concatenating the following list of hard-coded *required options* and the list of options specified in
 `distribution.defaultJvmOpts`:
@@ -95,15 +130,55 @@ options typically override earlier options (although this behavior is undefined 
 users to override the hard-coded options.
 
 #### Runtime environment variables
+
 Environment variables can be configured through the `env` blocks of `launcher-static.yml` and `launcher-custom.yml` as
 described in [configuration file](https://github.com/palantir/go-java-launcher). They are set by the launcher process
 before the Java process is executed.
 
-Packaging
----------
+### Asset plugin configuration
+
+A sample configuration for the Asset plugin:
+
+    distribution {
+        serviceName 'my-assets'
+        assetDir 'relative/path/to/assets', 'relocated/path/in/dist'
+        assetDir 'another/path, 'another/relocated/path'
+    }
+
+The complete list of available options:
+
+ * (optional) `assetsDir` accepts the path to a directory or file, relative from the root of the gradle project it is applied to,
+   and a path that the resource must be shipped under, relative to the top-level `asset` directory in the created dist.
+ * (optional) `setAssetsDirs` resets the plugin's internal state to a provided map of (source dir -> destination dir).
+
+The example above, when applied to a project rooted at `~/project`, would create a distribution with the following structure:
+
+    [service-name]-[service-version]/
+        deployment/
+            manifest.yml                      # simple package manifest
+        asset/
+            relocated/path/in/dist			  # contents from `~/project/relative/path/to/assets/`
+            another/relocated/path            # contents from `~/project/another/path`
+
+Note that repeated calls to `assetsDir` are processed in-order, and as such, it is possible to overwrite resources
+by specifying that a later invocation be relocated to a previously used destination's ancestor directory.
+
+### Packaging
+
 To create a compressed, gzipped tar file, run the `distTar` task.
 
-As part of package creation, this plugin will create three shell scripts:
+The plugins expose the tar file as an artifact in the `sls` configuration, making it easy to
+share the artifact between sibling Gradle projects. For example:
+
+```groovy
+configurations { tarballs }
+
+dependencies {
+    tarballs project(path: ':other-project', configuration: 'sls')
+}
+```
+
+As part of package creation, the Java Service plugin will additionally create three shell scripts:
 
  * `service/bin/[service-name]`: a Gradle default start script for running
    the defined `mainClass`. This script is considered deprecated due to security issues with
@@ -126,32 +201,20 @@ As part of package creation, this plugin will create three shell scripts:
    `<mainClass> [checkArgs]` to obtain health status.
 
 
-In addition to creating these scripts, this plugin will merge the entire
-contents of `${projectDir}/service` and `${projectDir}/var` into the package.
+Furthermore, the Java Service plugin will merge the entire contents of
+`${projectDir}/service` and `${projectDir}/var` into the package.
 
-The plugin also exposes the tar file as an artifact in the `sls` configuration, making it easy to
-share the artifact between sibling Gradle projects. For example:
+### Tasks
 
-```groovy
-configurations { tarballs }
-
-dependencies {
-    tarballs project(path: ':other-project', configuration: 'sls')
-}
-```
-
-Running with Gradle
--------------------
-To run the main class using Gradle, run the `run` task.
-
-Tasks
------
  * `distTar`: creates the gzipped tar package
+ * `createManifest`: generates a simple yaml file describing the package content
+
+Specific to the Java Service plugin:
+
  * `createStartScripts`: generates standard Java start scripts
  * `createInitScript`: generates daemonizing init.sh script
- * `createManifest`: generates a simple yaml file describing the package content
  * `run`: runs the specified `mainClass` with default `args`
 
-License
--------
+## License
+
 This plugin is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/readme.md
+++ b/readme.md
@@ -130,8 +130,8 @@ A sample configuration for the Asset plugin:
 
     distribution {
         serviceName 'my-assets'
-        asset 'relative/path/to/assets', 'relocated/path/in/dist'
-        asset 'another/path, 'another/relocated/path'
+        assets 'relative/path/to/assets', 'relocated/path/in/dist'
+        assets 'another/path, 'another/relocated/path'
     }
 
 The complete list of configurable properties:
@@ -158,7 +158,7 @@ The example above, when applied to a project rooted at `~/project`, would create
             relocated/path/in/dist            # contents from `~/project/relative/path/to/assets/`
             another/relocated/path            # contents from `~/project/another/path`
 
-Note that repeated calls to `assetsDir` are processed in-order, and as such, it is possible to overwrite resources
+Note that repeated calls to `assets` are processed in-order, and as such, it is possible to overwrite resources
 by specifying that a later invocation be relocated to a previously used destination's ancestor directory.
 
 ### Packaging

--- a/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.groovy
@@ -5,7 +5,8 @@ import org.gradle.api.Project
 class BaseDistributionExtension {
 
     private static final Set<String> VALID_PRODUCT_TYPES = [
-            "service.v1"
+            "service.v1",
+            "asset.v1"
     ]
 
     private final Project project

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistTarTask.groovy
@@ -1,0 +1,44 @@
+package com.palantir.gradle.dist.asset
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.bundling.Compression
+import org.gradle.api.tasks.bundling.Tar
+
+class AssetDistTarTask {
+
+    public static Tar createAssetDistTarTask(Project project, String taskName) {
+        Tar tarTask = project.tasks.create(taskName, Tar) {
+            group = AssetDistributionPlugin.GROUP_NAME
+            description = "Creates a compressed, gzipped tar file that contains required static assets."
+            // Set compression in constructor so that task output has the right name from the start.
+            compression = Compression.GZIP
+            extension = 'sls.tgz'
+        }
+        return tarTask
+    }
+
+    public static void configure(Tar distTar, String serviceName, Map<String, String> assetDirs) {
+        distTar.configure {
+            setBaseName(serviceName)
+            // do the things that the java plugin would otherwise do for us
+            def version = String.valueOf(project.version)
+            setVersion(version)
+            setDestinationDir(new File("${project.buildDir}/distributions"))
+            String archiveRootDir = serviceName + '-' + version
+
+            from("${project.projectDir}/deployment") {
+                into "${archiveRootDir}/deployment"
+            }
+
+            into("${archiveRootDir}/deployment") {
+                from("${project.buildDir}/deployment")
+            }
+
+            assetDirs.entrySet().each { entry ->
+                from("${project.projectDir}/${entry.getKey()}") {
+                    into("${archiveRootDir}/asset/${entry.getValue()}")
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
@@ -1,0 +1,26 @@
+package com.palantir.gradle.dist.asset
+
+import com.palantir.gradle.dist.BaseDistributionExtension
+import org.gradle.api.Project
+
+class AssetDistributionExtension extends BaseDistributionExtension {
+
+    private Map<String, String> assetsDirs = [:]
+
+    AssetDistributionExtension(Project project) {
+        super(project)
+        setProductType("asset.v1")
+    }
+
+    public Map<String, String> getAssetsDirs() {
+        return assetsDirs
+    }
+
+    public void assetsDir(String relativeSourcePath, String relativeDestinationPath) {
+        this.assetsDirs.put(relativeSourcePath, relativeDestinationPath)
+    }
+
+    public void setAssetsDirs(Map<String, String> assets) {
+        this.assetsDirs = assets
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
@@ -5,22 +5,26 @@ import org.gradle.api.Project
 
 class AssetDistributionExtension extends BaseDistributionExtension {
 
-    private Map<String, String> assetsDirs = [:]
+    private Map<String, String> assets = [:]
 
     AssetDistributionExtension(Project project) {
         super(project)
         productType("asset.v1")
     }
 
-    public Map<String, String> getAssetsDirs() {
-        return assetsDirs
+    public Map<String, String> getAssets() {
+        return assets
     }
 
-    public void assetsDir(String relativeSourcePath, String relativeDestinationPath) {
-        this.assetsDirs.put(relativeSourcePath, relativeDestinationPath)
+    public void assets(String relativeSourcePath) {
+        this.assets.put(relativeSourcePath, relativeSourcePath)
     }
 
-    public void setAssetsDirs(Map<String, String> assets) {
-        this.assetsDirs = assets
+    public void assets(String relativeSourcePath, String relativeDestinationPath) {
+        this.assets.put(relativeSourcePath, relativeDestinationPath)
+    }
+
+    public void setAssets(Map<String, String> assets) {
+        this.assets = assets
     }
 }

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.groovy
@@ -9,7 +9,7 @@ class AssetDistributionExtension extends BaseDistributionExtension {
 
     AssetDistributionExtension(Project project) {
         super(project)
-        setProductType("asset.v1")
+        productType("asset.v1")
     }
 
     public Map<String, String> getAssetsDirs() {

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
@@ -17,7 +17,7 @@ class AssetDistributionPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         if (project.getPlugins().hasPlugin(JavaDistributionPlugin)) {
-            throw new InvalidUserCodeException("The Asset distribution and the Java Service distribution plugins cannot be used in the same Gradle project.")
+            throw new InvalidUserCodeException("The plugins 'com.palantir.asset-distribution' and 'com.palantir.java-distribution' cannot be used in the same Gradle project.")
         }
         project.extensions.create("distribution", AssetDistributionExtension, project)
 

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
@@ -1,0 +1,42 @@
+package com.palantir.gradle.dist.asset
+
+import com.palantir.gradle.dist.service.tasks.CreateManifestTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.bundling.Tar
+
+class AssetDistributionPlugin implements Plugin<Project> {
+
+    static final String GROUP_NAME = "Distribution"
+    static final String SLS_CONFIGURATION_NAME = "sls"
+
+    @Override
+    void apply(Project project) {
+        project.extensions.create("distribution", AssetDistributionExtension, project)
+
+        def distributionExtension = project.extensions.findByType(AssetDistributionExtension)
+
+        Task manifest = project.tasks.create('createManifest', CreateManifestTask)
+        project.afterEvaluate {
+            manifest.configure(
+                    distributionExtension.serviceName,
+                    distributionExtension.serviceGroup,
+                    distributionExtension.productType,
+                    distributionExtension.manifestExtensions,
+            )
+        }
+
+        Tar distTar = AssetDistTarTask.createAssetDistTarTask(project, 'distTar')
+
+        project.afterEvaluate {
+            AssetDistTarTask.configure(distTar, distributionExtension.serviceName, distributionExtension.assetsDirs)
+        }
+
+        project.configurations.create(SLS_CONFIGURATION_NAME)
+        project.artifacts.add(SLS_CONFIGURATION_NAME, distTar)
+
+        // Configure tasks
+        distTar.dependsOn manifest
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
@@ -1,7 +1,9 @@
 package com.palantir.gradle.dist.asset
 
 import com.palantir.gradle.dist.asset.tasks.AssetDistTarTask
+import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import com.palantir.gradle.dist.tasks.CreateManifestTask
+import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -14,6 +16,9 @@ class AssetDistributionPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        if (project.getPlugins().hasPlugin(JavaDistributionPlugin)) {
+            throw new InvalidUserCodeException("The Asset distribution and the Java Service distribution plugins cannot be used in the same Gradle project.")
+        }
         project.extensions.create("distribution", AssetDistributionExtension, project)
 
         def distributionExtension = project.extensions.findByType(AssetDistributionExtension)
@@ -31,7 +36,7 @@ class AssetDistributionPlugin implements Plugin<Project> {
         Tar distTar = AssetDistTarTask.createAssetDistTarTask(project, 'distTar')
 
         project.afterEvaluate {
-            AssetDistTarTask.configure(distTar, distributionExtension.serviceName, distributionExtension.assetsDirs)
+            AssetDistTarTask.configure(distTar, distributionExtension.serviceName, distributionExtension.assets)
         }
 
         project.configurations.create(SLS_CONFIGURATION_NAME)

--- a/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.groovy
@@ -1,6 +1,7 @@
 package com.palantir.gradle.dist.asset
 
-import com.palantir.gradle.dist.service.tasks.CreateManifestTask
+import com.palantir.gradle.dist.asset.tasks.AssetDistTarTask
+import com.palantir.gradle.dist.tasks.CreateManifestTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/src/main/groovy/com/palantir/gradle/dist/asset/tasks/AssetDistTarTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/asset/tasks/AssetDistTarTask.groovy
@@ -1,5 +1,6 @@
-package com.palantir.gradle.dist.asset
+package com.palantir.gradle.dist.asset.tasks
 
+import com.palantir.gradle.dist.asset.AssetDistributionPlugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar

--- a/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
@@ -18,7 +18,7 @@ package com.palantir.gradle.dist.service
 import com.palantir.gradle.dist.service.tasks.CopyLauncherBinariesTask
 import com.palantir.gradle.dist.service.tasks.CreateCheckScriptTask
 import com.palantir.gradle.dist.service.tasks.CreateInitScriptTask
-import com.palantir.gradle.dist.service.tasks.CreateManifestTask
+import com.palantir.gradle.dist.tasks.CreateManifestTask
 import com.palantir.gradle.dist.service.tasks.CreateStartScriptsTask
 import com.palantir.gradle.dist.service.tasks.DistTarTask
 import com.palantir.gradle.dist.service.tasks.LaunchConfigTask

--- a/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
@@ -38,7 +38,7 @@ class JavaDistributionPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         if (project.getPlugins().hasPlugin(AssetDistributionPlugin)) {
-            throw new InvalidUserCodeException("The Asset distribution and the Java Service distribution plugins cannot be used in the same Gradle project.")
+            throw new InvalidUserCodeException("The plugins 'com.palantir.asset-distribution' and 'com.palantir.java-distribution' cannot be used in the same Gradle project.")
         }
         project.plugins.apply('java')
         project.extensions.create('distribution', ServiceDistributionExtension, project)

--- a/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/service/JavaDistributionPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package com.palantir.gradle.dist.service
 
+import com.palantir.gradle.dist.asset.AssetDistributionPlugin
 import com.palantir.gradle.dist.service.tasks.CopyLauncherBinariesTask
 import com.palantir.gradle.dist.service.tasks.CreateCheckScriptTask
 import com.palantir.gradle.dist.service.tasks.CreateInitScriptTask
@@ -24,6 +25,7 @@ import com.palantir.gradle.dist.service.tasks.DistTarTask
 import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
 import com.palantir.gradle.dist.service.tasks.ManifestClasspathJarTask
 import com.palantir.gradle.dist.service.tasks.RunTask
+import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -35,6 +37,9 @@ class JavaDistributionPlugin implements Plugin<Project> {
     static final String SLS_CONFIGURATION_NAME = "sls"
 
     void apply(Project project) {
+        if (project.getPlugins().hasPlugin(AssetDistributionPlugin)) {
+            throw new InvalidUserCodeException("The Asset distribution and the Java Service distribution plugins cannot be used in the same Gradle project.")
+        }
         project.plugins.apply('java')
         project.extensions.create('distribution', ServiceDistributionExtension, project)
 

--- a/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.dist.service.tasks
+package com.palantir.gradle.dist.tasks
 
 import com.palantir.gradle.dist.service.JavaDistributionPlugin
 import groovy.json.JsonOutput

--- a/src/main/resources/META-INF/gradle-plugins/com.palantir.asset-distribution.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.palantir.asset-distribution.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.gradle.dist.asset.AssetDistributionPlugin

--- a/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
@@ -33,6 +33,6 @@ class BaseDistributionExtensionTest extends Specification {
 
         then:
         def ex = thrown IllegalArgumentException
-        ex.message == "Invalid product type 'foobar' specified; supported types: [service.v1]."
+        ex.message == "Invalid product type 'foobar' specified; supported types: [service.v1, asset.v1]."
     }
 }

--- a/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
@@ -46,11 +46,10 @@ public class GradleTestSpec extends Specification {
                 .withArguments(tasks)
                 .withPluginClasspath()
                 .withDebug(true)
-                .build()
     }
 
     protected def runSuccessfully(String... tasks) {
-        BuildResult buildResult = run(tasks)
+        BuildResult buildResult = run(tasks).build()
         tasks.each { buildResult.task(it).outcome == TaskOutcome.SUCCESS }
         return buildResult
     }

--- a/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
@@ -25,12 +25,17 @@ class AssetDistributionExtensionTest extends Specification {
 
         when:
         ext.with {
-            assetsDir "path/to/src", "relocated/dest"
-            assetsDir "path/to/src2", "relocated/dest2"
+            assets "path/to/foo"
+            assets "path/to/src", "relocated/dest"
+            assets "path/to/src2", "relocated/dest2"
         }
 
         then:
-        ext.assetsDirs == ["path/to/src": "relocated/dest", "path/to/src2": "relocated/dest2"]
+        ext.assets == [
+                "path/to/src" : "relocated/dest",
+                "path/to/src2": "relocated/dest2",
+                "path/to/foo" : "path/to/foo"
+        ]
     }
 
     def 'collection setters replace existing data'() {
@@ -39,11 +44,11 @@ class AssetDistributionExtensionTest extends Specification {
 
         when:
         ext.with {
-            assetsDir "path/to/src", "relocated/dest"
-            setAssetsDirs(["path/to/src2": "relocated/dest2"])
+            assets "path/to/src", "relocated/dest"
+            setAssets(["path/to/src2": "relocated/dest2"])
         }
 
         then:
-        ext.assetsDirs == ["path/to/src2": "relocated/dest2"]
+        ext.assets == ["path/to/src2": "relocated/dest2"]
     }
 }

--- a/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * <http://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.asset
+
+import spock.lang.Specification
+
+class AssetDistributionExtensionTest extends Specification {
+    def 'collection modifiers are cumulative'() {
+        given:
+        def ext = new AssetDistributionExtension(null)
+
+        when:
+        ext.with {
+            assetsDir "path/to/src", "relocated/dest"
+            assetsDir "path/to/src2", "relocated/dest2"
+        }
+
+        then:
+        ext.assetsDirs == ["path/to/src": "relocated/dest", "path/to/src2": "relocated/dest2"]
+    }
+
+    def 'collection setters replace existing data'() {
+        given:
+        def ext = new AssetDistributionExtension(null)
+
+        when:
+        ext.with {
+            assetsDir "path/to/src", "relocated/dest"
+            setAssetsDirs(["path/to/src2": "relocated/dest2"])
+        }
+
+        then:
+        ext.assetsDirs == ["path/to/src2": "relocated/dest2"]
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
@@ -64,7 +64,7 @@ class AssetDistributionPluginTest extends GradleTestSpec {
         def result = run(":tasks").buildAndFail()
 
         then:
-        result.output.contains("The Asset distribution and the Java Service distribution plugins cannot be used in the same Gradle project.")
+        result.output.contains("The plugins 'com.palantir.asset-distribution' and 'com.palantir.java-distribution' cannot be used in the same Gradle project.")
     }
 
     private static def createUntarBuildFile(buildFile) {

--- a/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
@@ -42,6 +42,7 @@ class AssetDistributionPluginTest extends GradleTestSpec {
     def 'asset dirs are copied correctly'() {
         given:
         [file("static/foo/bar"), file("static/baz/abc")].each { it.write(".") }
+        file("static/abc").write("overwritten")
         buildFile << '''
             plugins {
                 id 'com.palantir.asset-distribution'
@@ -54,6 +55,7 @@ class AssetDistributionPluginTest extends GradleTestSpec {
                 serviceName 'asset-name'
                 assetsDir "static/foo", "maven"
                 assetsDir "static/baz", "maven"
+                assetsDir "static/abc", "maven"
             }
 
             // most convenient way to untar the dist is to use gradle
@@ -70,7 +72,9 @@ class AssetDistributionPluginTest extends GradleTestSpec {
         then:
         file("dist/asset-name-0.2/asset/maven/abc").exists()
         file("dist/asset-name-0.2/asset/maven/bar").exists()
+        def lines = file("dist/asset-name-0.2/asset/maven/abc").readLines()
+        lines.size() == 1
+        lines.get(0) == "overwritten"
     }
-
 
 }

--- a/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
@@ -1,0 +1,76 @@
+package com.palantir.gradle.dist.asset
+
+import com.palantir.gradle.dist.GradleTestSpec
+
+class AssetDistributionPluginTest extends GradleTestSpec {
+
+    def 'manifest file contains expected fields'() {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.asset-distribution'
+            }
+
+            project.group = 'service-group'
+
+            version '0.1'
+
+            distribution {
+                serviceName 'asset-name'
+            }
+
+            // most convenient way to untar the dist is to use gradle
+            task untar (type: Copy) {
+                from tarTree(resources.gzip("${buildDir}/distributions/asset-name-0.1.sls.tgz"))
+                into "${projectDir}/dist"
+                dependsOn distTar
+            }
+        '''.stripIndent()
+
+        when:
+        runSuccessfully(':distTar', ':untar')
+
+        then:
+        String manifest = file('dist/asset-name-0.1/deployment/manifest.yml', projectDir).text
+        manifest.contains('"manifest-version": "1.0"')
+        manifest.contains('"product-group": "service-group"')
+        manifest.contains('"product-name": "asset-name"')
+        manifest.contains('"product-version": "0.1"')
+        manifest.contains('"product-type": "asset.v1"')
+    }
+
+    def 'asset dirs are copied correctly'() {
+        given:
+        [file("static/foo/bar"), file("static/baz/abc")].each { it.write(".") }
+        buildFile << '''
+            plugins {
+                id 'com.palantir.asset-distribution'
+            }
+
+            project.group = 'service-group'
+            version '0.2'
+
+            distribution {
+                serviceName 'asset-name'
+                assetsDir "static/foo", "maven"
+                assetsDir "static/baz", "maven"
+            }
+
+            // most convenient way to untar the dist is to use gradle
+            task untar (type: Copy) {
+                from tarTree(resources.gzip("${buildDir}/distributions/asset-name-0.2.sls.tgz"))
+                into "${projectDir}/dist"
+                dependsOn distTar
+            }
+        '''.stripIndent()
+
+        when:
+        runSuccessfully(':distTar', ':untar')
+
+        then:
+        file("dist/asset-name-0.2/asset/maven/abc").exists()
+        file("dist/asset-name-0.2/asset/maven/bar").exists()
+    }
+
+
+}

--- a/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
@@ -501,7 +501,7 @@ class JavaDistributionPluginTests extends GradleTestSpec {
         def result = run(":tasks").buildAndFail()
 
         then:
-        result.output.contains("The Asset distribution and the Java Service distribution plugins cannot be used in the same Gradle project.")
+        result.output.contains("The plugins 'com.palantir.asset-distribution' and 'com.palantir.java-distribution' cannot be used in the same Gradle project.")
     }
 
     private static def createUntarBuildFile(buildFile) {

--- a/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/dist/service/JavaDistributionPluginTests.groovy
@@ -488,6 +488,22 @@ class JavaDistributionPluginTests extends GradleTestSpec {
         file('child/build/exploded/my-service-0.1/deployment/manifest.yml')
     }
 
+    def 'fails when asset and service plugins are both applied'() {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.asset-distribution'
+                id 'com.palantir.java-distribution'
+            }
+        '''.stripIndent()
+
+        when:
+        def result = run(":tasks").buildAndFail()
+
+        then:
+        result.output.contains("The Asset distribution and the Java Service distribution plugins cannot be used in the same Gradle project.")
+    }
+
     private static def createUntarBuildFile(buildFile) {
         buildFile << '''
             plugins {


### PR DESCRIPTION
This is a FLUP to the earlier refactor in #158 

- Add a plugin for creating SLS asset distributions
- The `CreateManifestTask` class, which is shared between both plugins now, is moved up a level to a shared tasks package
- Refactor readme

@uschi2000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/160)
<!-- Reviewable:end -->
