### PR TITLE
gradle compatible pid status check

### DIFF
--- a/src/main/resources/init.sh
+++ b/src/main/resources/init.sh
@@ -17,7 +17,7 @@
 
 is_process_active() {
    local PID=$1
-   ps $PID > /dev/null;
+   ps -o pid | sed 's/ //g' | grep "^$PID$" > /dev/null;
    echo $?
 }
 


### PR DESCRIPTION
In our docker containers, `ps $PID` always returns successfully and just lists the same output as `ps`. This means that any docker based tests that check service status or restart services fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-java-distribution/165)
<!-- Reviewable:end -->
