### PR TITLE
Change VersionMatcher format

### DIFF
--- a/sls-versions/src/main/java/com/palantir/slspackaging/versions/SlsProductVersions.java
+++ b/sls-versions/src/main/java/com/palantir/slspackaging/versions/SlsProductVersions.java
@@ -13,7 +13,8 @@ public class SlsProductVersions {
             Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"),
             Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+-[0-9]+-g[a-f0-9]+$")
     };
-    private static final Pattern VERSION_MATCHER = Pattern.compile("^((x\.x\.x)|([0-9]+\.x\.x)|([0-9]+\.[0-9]+\.x)|([0-9]+\.[0-9]+\.[0-9]+))$")
+    private static final Pattern VERSION_MATCHER =
+            Pattern.compile("^((x\\.x\\.x)|([0-9]+\\.x\\.x)|([0-9]+\\.[0-9]+\\.x)|([0-9]+\\.[0-9]+\\.[0-9]+))$");
 
     /**
      * Returns true iff the given string is a valid "orderable" SLS version.

--- a/sls-versions/src/main/java/com/palantir/slspackaging/versions/SlsProductVersions.java
+++ b/sls-versions/src/main/java/com/palantir/slspackaging/versions/SlsProductVersions.java
@@ -13,11 +13,7 @@ public class SlsProductVersions {
             Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"),
             Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+-[0-9]+-g[a-f0-9]+$")
     };
-    private static final Pattern[] VERSION_MATCHER = new Pattern[]{
-            Pattern.compile("^[0-9]+\\.[0-9]+\\.x$"),
-            Pattern.compile("^[0-9]+\\.x\\.x$"),
-            Pattern.compile("^x\\.x\\.x$")
-    };
+    private static final Pattern VERSION_MATCHER = Pattern.compile("^((x\.x\.x)|([0-9]+\.x\.x)|([0-9]+\.[0-9]+\.x)|([0-9]+\.[0-9]+\.[0-9]+))$")
 
     /**
      * Returns true iff the given string is a valid "orderable" SLS version.
@@ -39,12 +35,7 @@ public class SlsProductVersions {
     }
 
     public static boolean isMatcher(String matcher) {
-        for (Pattern p : VERSION_MATCHER) {
-            if (p.matcher(matcher).matches()) {
-                return true;
-            }
-        }
-        return false;
+        return VERSION_MATCHER.matcher(matcher).matches();
     }
 
     /**

--- a/sls-versions/src/main/java/com/palantir/slspackaging/versions/SlsProductVersions.java
+++ b/sls-versions/src/main/java/com/palantir/slspackaging/versions/SlsProductVersions.java
@@ -13,7 +13,11 @@ public class SlsProductVersions {
             Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"),
             Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$")
     };
-    private static final Pattern VERSION_MATCHER = Pattern.compile("^([0-9]+|x)\\.([0-9]+|x)\\.([0-9]+|x)$");
+    private static final Pattern[] VERSION_MATCHER = new Pattern[]{
+            Pattern.compile("^[0-9]+\\.[0-9]+\\.x$"),
+            Pattern.compile("^[0-9]+\\.x\\.x$"),
+            Pattern.compile("^x\\.x\\.x$")
+    };
 
     /**
      * Returns true iff the given string is a valid "orderable" SLS version.
@@ -35,7 +39,12 @@ public class SlsProductVersions {
     }
 
     public static boolean isMatcher(String matcher) {
-        return VERSION_MATCHER.matcher(matcher).matches() && matcher.contains("x");
+        for (Pattern p : VERSION_MATCHER) {
+            if (p.matcher(matcher).matches()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/sls-versions/src/test/java/com/palantir/slspackaging/versions/SlsProductVersionsTest.java
+++ b/sls-versions/src/test/java/com/palantir/slspackaging/versions/SlsProductVersionsTest.java
@@ -48,7 +48,7 @@ public final class SlsProductVersionsTest {
         assertThat(SlsProductVersions.isMatcher("2.x.x")).isTrue();
         assertThat(SlsProductVersions.isMatcher("x.x.x")).isTrue();
 
-        assertThat(SlsProductVersions.isMatcher("2.0.0")).isFalse();
+        assertThat(SlsProductVersions.isMatcher("2.0.0")).isTrue();
         assertThat(SlsProductVersions.isMatcher("1.x.x.x")).isFalse();
         assertThat(SlsProductVersions.isMatcher("x.y.z")).isFalse();
         assertThat(SlsProductVersions.isMatcher("x.x.x-rc1")).isFalse();

--- a/sls-versions/src/test/java/com/palantir/slspackaging/versions/SlsProductVersionsTest.java
+++ b/sls-versions/src/test/java/com/palantir/slspackaging/versions/SlsProductVersionsTest.java
@@ -49,6 +49,10 @@ public final class SlsProductVersionsTest {
         assertThat(SlsProductVersions.isMatcher("x.x.x-beta1")).isFalse();
         assertThat(SlsProductVersions.isMatcher("x.x.x-1-gaaaaaa")).isFalse();
         assertThat(SlsProductVersions.isMatcher("x.x.x-foo")).isFalse();
+        assertThat(SlsProductVersions.isMatcher("x.x.3")).isFalse();
+        assertThat(SlsProductVersions.isMatcher("x.2.3")).isFalse();
+        assertThat(SlsProductVersions.isMatcher("x.2.x")).isFalse();
+        assertThat(SlsProductVersions.isMatcher("1.x.3")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Version matcher must:
 1. Contain at least one wildcard (x).
 2. Must not contain a wildcard in a larger position than a
    a non-wildcard version (e.g. x.1.2 is not valid)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/191)
<!-- Reviewable:end -->
