### PR TITLE
Make gcJvmOpts configurable on JavaServiceDistributionExtension

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.groovy
@@ -24,6 +24,17 @@ class JavaServiceDistributionExtension extends BaseDistributionExtension {
     private List<String> args = []
     private List<String> checkArgs = []
     private List<String> defaultJvmOpts = []
+    private List<String> gcJvmOpts = [
+            '-XX:+CrashOnOutOfMemoryError',  // requires JDK 8u92+
+            '-XX:+PrintGCDateStamps',
+            '-XX:+PrintGCDetails',
+            '-XX:-TraceClassUnloading',
+            '-XX:+UseGCLogFileRotation',
+            '-XX:GCLogFileSize=10M',
+            '-XX:NumberOfGCLogFiles=10',
+            '-Xloggc:var/log/gc-%t-%p.log',
+            '-verbose:gc'
+    ]
     private Map<String, String> env = [:]
     private boolean enableManifestClasspath = false
     private String javaHome = null
@@ -60,6 +71,14 @@ class JavaServiceDistributionExtension extends BaseDistributionExtension {
 
     void setDefaultJvmOpts(Iterable<String> defaultJvmOpts) {
         this.defaultJvmOpts = defaultJvmOpts.toList()
+    }
+
+    void gcJvmOpts(String... gcJvmOpts) {
+        this.gcJvmOpts = Arrays.asList(gcJvmOpts)
+    }
+
+    void setGcJvmOpts(Iterable<String> gcJvmOpts) {
+        this.gcJvmOpts = gcJvmOpts.toList()
     }
 
     void enableManifestClasspath(boolean enableManifestClasspath) {
@@ -100,6 +119,10 @@ class JavaServiceDistributionExtension extends BaseDistributionExtension {
 
     List<String> getDefaultJvmOpts() {
         return defaultJvmOpts
+    }
+
+    List<String> getGcJvmOpts() {
+        return gcJvmOpts
     }
 
     boolean isEnableManifestClasspath() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
@@ -62,8 +62,14 @@ class JavaServiceDistributionPlugin implements Plugin<Project> {
 
         LaunchConfigTask launchConfig = project.tasks.create('createLaunchConfig', LaunchConfigTask)
         project.afterEvaluate {
-            launchConfig.configure(distributionExtension.mainClass, distributionExtension.args, distributionExtension.checkArgs,
-                    distributionExtension.defaultJvmOpts, distributionExtension.javaHome, distributionExtension.env,
+            launchConfig.configure(
+                    distributionExtension.mainClass,
+                    distributionExtension.args,
+                    distributionExtension.checkArgs,
+                    distributionExtension.defaultJvmOpts,
+                    distributionExtension.gcJvmOpts,
+                    distributionExtension.javaHome,
+                    distributionExtension.env,
                     project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtime)
         }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
@@ -33,18 +33,6 @@ class LaunchConfigTask extends DefaultTask {
             '-Djava.io.tmpdir=var/data/tmp'
     ]
 
-    static final List<String> gcJvmOpts = [
-            '-XX:+CrashOnOutOfMemoryError',  // requires JDK 8u92+
-            '-XX:+PrintGCDateStamps',
-            '-XX:+PrintGCDetails',
-            '-XX:-TraceClassUnloading',
-            '-XX:+UseGCLogFileRotation',
-            '-XX:GCLogFileSize=10M',
-            '-XX:NumberOfGCLogFiles=10',
-            '-Xloggc:var/log/gc-%t-%p.log',
-            '-verbose:gc'
-    ]
-
     @Input
     String mainClass
 
@@ -56,6 +44,9 @@ class LaunchConfigTask extends DefaultTask {
 
     @Input
     List<String> defaultJvmOpts
+
+    @Input
+    List<String> gcJvmOpts
 
     @Input
     Map<String, String> env
@@ -128,11 +119,12 @@ class LaunchConfigTask extends DefaultTask {
         return output
     }
 
-    void configure(String mainClass, List<String> args, List<String> checkArgs, List<String> defaultJvmOpts, String javaHome, Map<String, String> env, FileCollection classpath) {
+    void configure(String mainClass, List<String> args, List<String> checkArgs, List<String> defaultJvmOpts, List<String> gcJvmOpts, String javaHome, Map<String, String> env, FileCollection classpath) {
         this.mainClass = mainClass
         this.args = args
         this.checkArgs = checkArgs
         this.defaultJvmOpts = defaultJvmOpts
+        this.gcJvmOpts = gcJvmOpts
         this.javaHome = javaHome
         this.env = env
         this.classpath = classpath


### PR DESCRIPTION
@uschi2000 I've hit some problems using sls-packaging 2.0.0 on circle:

```
Unrecognized VM option 'CrashOnOutOfMemoryError'
Did you mean 'OnOutOfMemoryError=<value>'?
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

This seems to arise because Circle's `oracklejdk8` is not new enough to support this option.  To enable a workaround, I've made these gc options configurable.  This PR doesn't change the defaults :)

cc @skedida

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/204)
<!-- Reviewable:end -->
