### PR TITLE
Add jar.archivePath to classpath

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
@@ -26,7 +26,7 @@ class RunTask {
             t.dependsOn(project.tasks.jar)
             t.group = JavaServiceDistributionPlugin.GROUP_NAME
             t.description = "Runs the specified project using configured mainClass and with default args."
-            classpath project.files(project.tasks.jar.archivePath, project.sourceSets.main.runtimeClasspath)
+            t.classpath project.files(project.tasks.jar.archivePath, project.sourceSets.main.runtimeClasspath)
         }
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/RunTask.groovy
@@ -23,9 +23,10 @@ class RunTask {
 
     static JavaExec createRunTask(Project project, String taskName) {
         return project.tasks.create(taskName, JavaExec) { t ->
+            t.dependsOn(project.tasks.jar)
             t.group = JavaServiceDistributionPlugin.GROUP_NAME
             t.description = "Runs the specified project using configured mainClass and with default args."
-            t.classpath project.sourceSets.main.runtimeClasspath
+            classpath project.files(project.tasks.jar.archivePath, project.sourceSets.main.runtimeClasspath)
         }
     }
 


### PR DESCRIPTION
This will create a run task which includes the application jar in the
classpath. This is important if the application reads informatino from
its own jar manifest like UserAgents.fromClass() in http-remoting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/207)
<!-- Reviewable:end -->
