### PR TITLE
Jc/missed fix for java lib plugin

### DIFF
--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -33,7 +33,3 @@ pluginBundle {
 publishPlugins.onlyIf {
     project.version ==~ /[0-9]+(\.[0-9]+)+(-rc[0-9]+)?(-alpha[0-9]+)?/
 }
-
-test {
-    include '**/ServiceDistributionPluginTests.class'
-}

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -33,3 +33,7 @@ pluginBundle {
 publishPlugins.onlyIf {
     project.version ==~ /[0-9]+(\.[0-9]+)+(-rc[0-9]+)?(-alpha[0-9]+)?/
 }
+
+test {
+    include '**/ServiceDistributionPluginTests.class'
+}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
@@ -64,7 +64,7 @@ class JavaServiceDistributionPlugin implements Plugin<Project> {
         project.afterEvaluate {
             launchConfig.configure(distributionExtension.mainClass, distributionExtension.args, distributionExtension.checkArgs,
                     distributionExtension.defaultJvmOpts, distributionExtension.javaHome, distributionExtension.env,
-                    project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtime)
+                    project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtimeClasspath)
         }
 
         CreateInitScriptTask initScript = project.tasks.create('createInitScript', CreateInitScriptTask)

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
@@ -28,7 +28,7 @@ class CreateStartScriptsTask {
             p.group = JavaServiceDistributionPlugin.GROUP_NAME
             p.description = "Generates standard Java start scripts."
             p.setOutputDir(new File("${project.buildDir}/scripts"))
-            p.setClasspath(project.tasks['jar'].outputs.files + project.configurations.runtime)
+            p.setClasspath(project.tasks['jar'].outputs.files + project.configurations.runtimeClasspath)
         }
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -664,13 +664,33 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         !manifestContents.contains('main')
 
         // verify start scripts
-        def startScript = new File(projectDir,'parent/dist/service-name-0.0.1/service/bin/service-name').text
+        List<String> startScript = new File(projectDir,'parent/dist/service-name-0.0.1/service/bin/service-name')
+                .text
                 .find(/CLASSPATH=(.*)/) { match, classpath -> classpath }
                 .split(':')
 
         startScript.any { it.contains('/lib/annotations-3.0.1.jar') }
         startScript.any { it.contains('/lib/guava-19.0.jar') }
         startScript.any { it.contains('/lib/mockito-core-2.7.22.jar') }
+
+        // verify launcher YAML files
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+
+        LaunchConfigTask.StaticLaunchConfig launcherCheck = mapper.readValue(
+                new File(projectDir, 'parent/dist/service-name-0.0.1/service/bin/launcher-check.yml'),
+                LaunchConfigTask.StaticLaunchConfig.class)
+
+        launcherCheck.classpath.any { it.contains('/lib/annotations-3.0.1.jar') }
+        launcherCheck.classpath.any { it.contains('/lib/guava-19.0.jar') }
+        launcherCheck.classpath.any { it.contains('/lib/mockito-core-2.7.22.jar') }
+
+        LaunchConfigTask.StaticLaunchConfig launcherStatic = mapper.readValue(
+                new File(projectDir, 'parent/dist/service-name-0.0.1/service/bin/launcher-check.yml'),
+                LaunchConfigTask.StaticLaunchConfig.class)
+
+        launcherStatic.classpath.any { it.contains('/lib/annotations-3.0.1.jar') }
+        launcherStatic.classpath.any { it.contains('/lib/guava-19.0.jar') }
+        launcherStatic.classpath.any { it.contains('/lib/mockito-core-2.7.22.jar') }
     }
 
     def 'project class files do not appear in output lib directory'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -685,7 +685,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         launcherCheck.classpath.any { it.contains('/lib/mockito-core-2.7.22.jar') }
 
         LaunchConfigTask.StaticLaunchConfig launcherStatic = mapper.readValue(
-                new File(projectDir, 'parent/dist/service-name-0.0.1/service/bin/launcher-check.yml'),
+                new File(projectDir, 'parent/dist/service-name-0.0.1/service/bin/launcher-static.yml'),
                 LaunchConfigTask.StaticLaunchConfig.class)
 
         launcherStatic.classpath.any { it.contains('/lib/annotations-3.0.1.jar') }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -22,7 +22,6 @@ import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-import spock.lang.IgnoreRest
 
 import java.util.zip.ZipFile
 
@@ -601,7 +600,6 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         result.output.contains("The plugins 'com.palantir.sls-asset-distribution' and 'com.palantir.sls-java-service-distribution' cannot be used in the same Gradle project.")
     }
 
-    @IgnoreRest
     def 'uses the runtimeClasspath so api and implementation configurations work with java-library plugin'() {
         given:
         helper.addSubproject('parent', '''
@@ -658,6 +656,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 .readLines()
                 .collect { it.trim() }
                 .join('')
+
         manifestContents.contains('annotations-3.0.1.jar')
         manifestContents.contains('guava-19.0.jar')
         manifestContents.contains('mockito-core-2.7.22.jar')


### PR DESCRIPTION
fixes #201 

this should cover migrating all `.runtime` to `.runtimeClasspath`.

this PR covers:

* `<service-name>` script (BAT script has the classpath omitted)
* `launcher-static.yml`
* `launcher-check.yml`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/215)
<!-- Reviewable:end -->
