### PR TITLE
Fix init.sh variable reference and output truncation

### DIFF
--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -25,7 +25,7 @@ is_process_service() {
   local PID=$1
   local SERVICE_NAME=$2
   # trailing '=' prevents a header line
-  ps -o command= $PID | grep -q "$SERVICE"
+  ps ewww -o command= $PID | grep -q "$SERVICE_NAME"
   return $?
 }
 


### PR DESCRIPTION
It appears that the is_process_service function defined in init.sh is improperly using the globally defined `$SERVICE` variable when identifying whether a given PID corresponds to a service, instead of the local `$SERVICE_NAME` variable as intended.

Additionally, running the `ps | grep` command failed for me because the output from `ps` was being truncated on my operating system (I'm adapting this script to run on IBM AIX). Adding the `ewww` flag prevents output truncation, so the `grep` can correctly find the name of the service in the `ps` output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/220)
<!-- Reviewable:end -->
