### PR TITLE
Ensure that minimumVersion and maximumVersion are not equal

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
@@ -15,8 +15,8 @@ class ProductDependency {
 
     ProductDependency() {}
 
-    ProductDependency(String productGroup, String productName, String minimumVersion,
-                      String maximumVersion, @Nullable String recommendedVersion) {
+    ProductDependency(String productGroup, String productName, @Nullable String minimumVersion,
+                      @Nullable String maximumVersion, @Nullable String recommendedVersion) {
         this.productGroup = productGroup
         this.productName = productName
         this.minimumVersion = minimumVersion

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
@@ -50,5 +50,10 @@ class ProductDependency {
                         "minimumVersion and recommendedVersions must be valid SLS versions: " + it)
             }
         }
+
+        if (minimumVersion == maximumVersion) {
+            throw new IllegalArgumentException("minimumVersion and maximumVersion must be different "
+                + "in product dependency on " + this.productName)
+        }
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
@@ -15,8 +15,8 @@ class ProductDependency {
 
     ProductDependency() {}
 
-    ProductDependency(String productGroup, String productName, @Nullable String minimumVersion,
-                      @Nullable String maximumVersion, @Nullable String recommendedVersion) {
+    ProductDependency(String productGroup, String productName, String minimumVersion,
+                      String maximumVersion, @Nullable String recommendedVersion) {
         this.productGroup = productGroup
         this.productName = productName
         this.minimumVersion = minimumVersion

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyTest.groovy
@@ -43,4 +43,12 @@ class ProductDependencyTest extends Specification {
         dep.maximumVersion == "2.x.x"
     }
 
+    def 'minimumVersion and maximumVersion must not be equal' () {
+        when:
+        new ProductDependency("", "", "1.2.3", "1.2.3", null).isValid()
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
@@ -87,6 +87,8 @@ class AssetDistributionPluginTest extends GradleTestSpec {
                 productDependency {
                     productGroup = "group3"
                     productName = "name3"
+                    minimumVersion = "1.0.0"
+                    maximumVersion = "2.0.0"
                 }
             }
         """.stripIndent()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginTest.groovy
@@ -88,7 +88,6 @@ class AssetDistributionPluginTest extends GradleTestSpec {
                     productGroup = "group3"
                     productName = "name3"
                     minimumVersion = "1.0.0"
-                    maximumVersion = "2.0.0"
                 }
             }
         """.stripIndent()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -301,7 +301,6 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                     productGroup = "group3"
                     productName = "name3"
                     minimumVersion = "1.0.0"
-                    recommendedVersion = "2.0.0"
                 }
             }
         """.stripIndent()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -300,6 +300,8 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 productDependency {
                     productGroup = "group3"
                     productName = "name3"
+                    minimumVersion = "1.0.0"
+                    recommendedVersion = "2.0.0"
                 }
             }
         """.stripIndent()


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/230)
<!-- Reviewable:end -->

This prevents a known antipattern where services declare themselves to require a lockstep upgrade. 


For example:

Service A 1.5 depends service B with the range [2.0, 2.0]

Now B's version number cannot change to anything other than 2.0 without invalidating the dependency of service A.