### PR TITLE
Configure JAVA_HOME for Windows startup script

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.groovy
@@ -27,6 +27,7 @@ class JavaServiceDistributionExtension extends BaseDistributionExtension {
     private Map<String, String> env = [:]
     private boolean enableManifestClasspath = false
     private String javaHome = null
+    private String javaHomeWin = null
     private List<String> excludeFromVar = ['log', 'run']
 
     JavaServiceDistributionExtension(Project project) {
@@ -68,6 +69,10 @@ class JavaServiceDistributionExtension extends BaseDistributionExtension {
 
     void javaHome(String javaHome) {
         this.javaHome = javaHome
+    }
+
+    void javaHomeWin(String javaHomeWin) {
+        this.javaHomeWin = javaHomeWin
     }
 
     void setEnv(Map<String, String> env) {
@@ -112,6 +117,10 @@ class JavaServiceDistributionExtension extends BaseDistributionExtension {
 
     String getJavaHome() {
         return javaHome
+    }
+
+    String getJavaHomeWin() {
+        return javaHomeWin
     }
 
     List<String> getExcludeFromVar() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
@@ -55,7 +55,7 @@ class JavaServiceDistributionPlugin implements Plugin<Project> {
         CreateStartScripts startScripts = CreateStartScriptsTask.createStartScriptsTask(project, 'createStartScripts')
         project.afterEvaluate {
             CreateStartScriptsTask.configure(startScripts, distributionExtension.mainClass, distributionExtension.serviceName,
-                    distributionExtension.javaHome, distributionExtension.defaultJvmOpts, distributionExtension.enableManifestClasspath)
+                    distributionExtension.javaHomeWin, distributionExtension.defaultJvmOpts, distributionExtension.enableManifestClasspath)
         }
 
         CopyLauncherBinariesTask copyLauncherBinaries = project.tasks.create('copyLauncherBinaries', CopyLauncherBinariesTask)

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
@@ -55,7 +55,7 @@ class JavaServiceDistributionPlugin implements Plugin<Project> {
         CreateStartScripts startScripts = CreateStartScriptsTask.createStartScriptsTask(project, 'createStartScripts')
         project.afterEvaluate {
             CreateStartScriptsTask.configure(startScripts, distributionExtension.mainClass, distributionExtension.serviceName,
-                    distributionExtension.defaultJvmOpts, distributionExtension.enableManifestClasspath)
+                    distributionExtension.javaHome, distributionExtension.defaultJvmOpts, distributionExtension.enableManifestClasspath)
         }
 
         CopyLauncherBinariesTask copyLauncherBinaries = project.tasks.create('copyLauncherBinaries', CopyLauncherBinariesTask)

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
@@ -46,8 +46,8 @@ class CreateStartScriptsTask {
 
                 if (javaHome != null) {
                     def setJavaHomeString = "@rem Set JAVA_HOME to configured path.\n"
-                    setJavaHomeString += 'set JAVA_HOME=' + javaHome + ' \n'
-                    winFileText =  winFileText.replaceAll('if defined JAVA_HOME', setJavaHomeString)
+                    setJavaHomeString += 'set JAVA_HOME=' + javaHome + '\n'
+                    winFileText =  winFileText.replaceAll('if defined JAVA_HOME ', setJavaHomeString)
                 }
 
                 Jar manifestClasspathJarTask = project.tasks.getByName('manifestClasspathJar')

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
@@ -32,7 +32,7 @@ class CreateStartScriptsTask {
         }
     }
 
-    static void configure(CreateStartScripts startScripts, String mainClass, String serviceName, String javaHome,
+    static void configure(CreateStartScripts startScripts, String mainClass, String serviceName, String javaHomeWin,
                           List<String> defaultJvmOpts, boolean isEnableManifestClasspath) {
         startScripts.configure {
             setMainClassName(mainClass)
@@ -44,9 +44,9 @@ class CreateStartScriptsTask {
                 def winScriptFile = project.file getWindowsScript()
                 def winFileText = winScriptFile.text
 
-                if (javaHome != null) {
+                if (javaHomeWin != null) {
                     def setJavaHomeString = "@rem Set JAVA_HOME to configured path.\n"
-                    setJavaHomeString += 'set JAVA_HOME=' + javaHome + '\n'
+                    setJavaHomeString += 'set JAVA_HOME=' + javaHomeWin + '\n'
                     winFileText =  winFileText.replaceAll('if defined JAVA_HOME ', setJavaHomeString)
                 }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
@@ -45,8 +45,9 @@ class CreateStartScriptsTask {
                 def winFileText = winScriptFile.text
 
                 if (javaHomeWin) {
-                    def setJavaHomeString = "@rem Set JAVA_HOME to configured path.\n"
-                    setJavaHomeString += 'set JAVA_HOME=' + javaHomeWin + '\n'
+                    winFileText = winFileText.replaceAll('Find java.exe',
+                            'Set JAVA_HOME to configured path.')
+                    def setJavaHomeString = 'set JAVA_HOME=' + javaHomeWin + '\n'
                     winFileText =  winFileText.replaceAll('if defined JAVA_HOME ', setJavaHomeString)
                 }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy
@@ -44,7 +44,7 @@ class CreateStartScriptsTask {
                 def winScriptFile = project.file getWindowsScript()
                 def winFileText = winScriptFile.text
 
-                if (javaHomeWin != null) {
+                if (javaHomeWin) {
                     def setJavaHomeString = "@rem Set JAVA_HOME to configured path.\n"
                     setJavaHomeString += 'set JAVA_HOME=' + javaHomeWin + '\n'
                     winFileText =  winFileText.replaceAll('if defined JAVA_HOME ', setJavaHomeString)

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -22,7 +22,6 @@ import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-import spock.lang.IgnoreRest
 
 import java.util.zip.ZipFile
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -508,7 +508,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         createUntarBuildFile(buildFile)
         buildFile << '''
             distribution {
-                javaHome 'java/path'
+                javaHomeWin 'java/path'
             }
             dependencies {
               compile "com.google.guava:guava:19.0"

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -519,6 +519,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
 
         then:
         String startScript = file('dist/service-name-0.0.1/service/bin/service-name.bat', projectDir).text
+        startScript.contains("@rem Set JAVA_HOME to configured path")
         startScript.contains("set JAVA_HOME=java/path")
     }
 
@@ -538,7 +539,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
 
         then:
         String startScript = file('dist/service-name-0.0.1/service/bin/service-name.bat', projectDir).text
-        !startScript.contains("set JAVA_HOME=")
+        !startScript.contains("@rem Set JAVA_HOME to configured path")
     }
 
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -22,6 +22,7 @@ import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
+import spock.lang.IgnoreRest
 
 import java.util.zip.ZipFile
 
@@ -476,12 +477,14 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         file('dist/service-name-0.0.1/service/monitoring/bin/check.sh').exists()
     }
 
+    @IgnoreRest
     def 'produces manifest-classpath jar and windows start script with no classpath length limitations'() {
         given:
         createUntarBuildFile(buildFile)
         buildFile << '''
             distribution {
                 enableManifestClasspath true
+                javaHome 'java/path'
             }
             dependencies {
               compile "com.google.guava:guava:19.0"
@@ -494,6 +497,8 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         then:
         String startScript = file('dist/service-name-0.0.1/service/bin/service-name.bat', projectDir).text
         startScript.contains("-manifest-classpath-0.0.1.jar")
+        // todo(jelena): move to a new test
+        startScript.contains("set JAVA_HOME=java/foo")
         !startScript.contains("-classpath \"%CLASSPATH%\"")
         def classpathJar = file('dist/service-name-0.0.1/service/lib/').listFiles()
                 .find({ it.name.endsWith("-manifest-classpath-0.0.1.jar") })

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -538,7 +538,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
 
         then:
         String startScript = file('dist/service-name-0.0.1/service/bin/service-name.bat', projectDir).text
-        !startScript.contains("set JAVA_HOME=java/path")
+        !startScript.contains("set JAVA_HOME=")
     }
 
 

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,8 @@ And the complete list of configurable properties:
    defaulting to `['log', 'run']`.
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
    be applied when `init.sh` is run.
+ * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
+   be applied when `serviceName.bat` Windows startup script is run.
 
 #### JVM Options
 


### PR DESCRIPTION
Add an option to configure java jre path for Windows startup script

Adresses #235 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/236)
<!-- Reviewable:end -->
