### PR TITLE
Make minimumVersion required in ProductDependency

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
@@ -6,7 +6,6 @@ import org.gradle.api.Nullable
 class ProductDependency {
     String productGroup
     String productName
-    @Nullable
     String minimumVersion
     @Nullable
     String maximumVersion
@@ -15,7 +14,7 @@ class ProductDependency {
 
     ProductDependency() {}
 
-    ProductDependency(String productGroup, String productName, @Nullable String minimumVersion,
+    ProductDependency(String productGroup, String productName, String minimumVersion,
                       @Nullable String maximumVersion, @Nullable String recommendedVersion) {
         this.productGroup = productGroup
         this.productName = productName
@@ -29,14 +28,15 @@ class ProductDependency {
         if (maximumVersion) {
             return maximumVersion
         }
-        if (!maximumVersion && minimumVersion == null) {
-            return null
-        }
         def minimumVersionMajorRev = minimumVersion.tokenize('.')[0].toInteger()
         return "${minimumVersionMajorRev}.x.x"
     }
 
     def isValid() {
+        if (minimumVersion == null) {
+            throw new IllegalArgumentException("minimum version must be specified");
+        }
+
         [maximumVersion].each {
             if (it && !SlsProductVersions.isValidVersionOrMatcher(it)) {
                 throw new IllegalArgumentException(

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyTest.groovy
@@ -19,6 +19,14 @@ class ProductDependencyTest extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'min version must not be null'() {
+        when:
+        new ProductDependency("", "", null, "1.2.x", "1.2.3").isValid()
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
     def 'recommended version must not be matcher'() {
         when:
         new ProductDependency("", "", "1.2.3", "1.2.x", "1.2.x").isValid()
@@ -43,4 +51,11 @@ class ProductDependencyTest extends Specification {
         dep.maximumVersion == "2.x.x"
     }
 
+    def 'infer maximum version from min version'() {
+        when:
+        def dep = new ProductDependency("", "", "1.2.3", null, "1.2.4")
+
+        then:
+        dep.maximumVersion == "1.x.x"
+    }
 }


### PR DESCRIPTION
As a result of this, I cleaned up and tested the code which infers
maximum versions.  There are some added tests for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/237)
<!-- Reviewable:end -->
