### PR TITLE
Support 0755 perms for custom scripts

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/DistTarTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/DistTarTask.groovy
@@ -51,7 +51,13 @@ class DistTarTask {
 
             from("${project.projectDir}/service") {
                 into "${archiveRootDir}/service"
+                exclude("**/bin/*")
             }
+            
+            from("${project.projectDir}/service/bin") {
+        		into("${archiveRootDir}/service/bin")
+        		fileMode = 0755
+        	}
 
             into("${archiveRootDir}/service/lib") {
                 from(project.tasks.jar.outputs.files)


### PR DESCRIPTION
Hey, guys. I'm looking for a way to have custom scripts shipped with an sls package have executable perms. Feel free to suggest something else if this implementation isn't what you're after.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/240)
<!-- Reviewable:end -->
