### PR TITLE
no longer match with full path, since mac os uses different path strings

### DIFF
--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -533,15 +533,19 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
             }
 
             afterEvaluate {
-                println "from test: ${distTar.outputs.files.singleFile} - distTar"
+                String actualTarballPath = distTar.outputs.files.singleFile.absolutePath
+                String expectedTarballPath = project.file('build/distributions/my-service.sls.tgz').absolutePath
+                
+                if (!actualTarballPath.equals(expectedTarballPath)) {
+                    throw new GradleException("tarball path didn't match.\\n" +
+                            "actual: ${actualTarballPath}\\n" +
+                            "expected: ${expectedTarballPath}")
+                }
             }
         '''.stripIndent()
 
-        when:
-        BuildResult buildResult = runSuccessfully(':tasks')
-
-        then:
-        buildResult.output =~ ("${projectDir}/build/distributions/my-service.sls.tgz - distTar")
+        expect:
+        runSuccessfully(':tasks')
     }
 
     def 'exposes an artifact through the sls configuration'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -533,7 +533,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
             }
 
             afterEvaluate {
-                println "distTar: ${distTar.outputs.files.singleFile}"
+                println "from test: ${distTar.outputs.files.singleFile} - distTar"
             }
         '''.stripIndent()
 
@@ -541,7 +541,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         BuildResult buildResult = runSuccessfully(':tasks')
 
         then:
-        buildResult.output =~ ("distTar: ${projectDir}/build/distributions/my-service.sls.tgz")
+        buildResult.output =~ ("${projectDir}/build/distributions/my-service.sls.tgz - distTar")
     }
 
     def 'exposes an artifact through the sls configuration'() {


### PR DESCRIPTION
when on a mac, we're searching for:

```
distTar: /var/folders/1n/lylm6fr54vn1mbhc_7rlgx95080n7q/T/junit3615108091981279385/junit2160697864594598480/build/distributions/my-service.sls.tgz
```

and the output contains:
```
distTar: /private/var/folders/1n/lylm6fr54vn1mbhc_7rlgx95080n7q/T/junit3615108091981279385/junit2160697864594598480/build/distributions/my-service.sls.tgz
```

so the leading `/private` is causing the `distTar: /var/...` string to not match. this change now looks for the trailing part of the folder AND a suffix of ` - distTar` this should be sufficiently equal for the project folder and avoid the private prefix issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/248)
<!-- Reviewable:end -->
