### PR TITLE
Force unlimited width in ps output

### DIFF
--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -25,7 +25,7 @@ is_process_service() {
   local PID=$1
   local SERVICE_NAME=$2
   # trailing '=' prevents a header line
-  ps -o command= $PID | grep -q "$SERVICE_NAME"
+  ps -ww -o command= $PID | grep -q "$SERVICE_NAME"
   return $?
 }
 


### PR DESCRIPTION
`ps -o command` has an undefined maximum output line length if -w isn't specified as an argument (see https://github.com/mmalecki/procps/blob/fe4c4a7314f32907b9f558ad0d8b8d0ff1cc76be/ps/ps.1#L868). This means that although the process is correctly started `init.sh status` will incorrectly fail to find the process and conclude it failed to start correctly because the service name was truncated. Specifying -ww forces unlimited output line width which fixes this problem. Seen in the wild with an older version of ps on Centos 6.6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/250)
<!-- Reviewable:end -->
