### PR TITLE
Change sleep value to 5 seconds in init.sh

### DIFF
--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -65,7 +65,7 @@ start)
     PID=$($LAUNCHER_CMD $STATIC_LAUNCHER_CONFIG $CUSTOM_LAUNCHER_CONFIG > var/log/$SERVICE-startup.log 2>&1 & echo $!)
     # always write $PIDFILE so that `init.sh status` for a service that crashed when starting will return 1, not 3
     echo $PID > $PIDFILE
-    sleep 1
+    sleep 5
     if is_process_service $PID $SERVICE; then
         printf "%s\n" "Started ($PID)"
         exit 0


### PR DESCRIPTION
If a server has a particularly long startup sequence (or the JVM just takes a while to start), this script will spuriously report sucess for `init.sh start`. Our infrastructure will then asyncronously call this later and realize that the service is in fact down. This results in the service flipping on and off instead of failing fast. Bumping this value to 5 seconds does not solve the problem, but  does give services a longer window in which to fail on startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/256)
<!-- Reviewable:end -->
