### PR TITLE
Disable optimization which can lead to empty stacktraces

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
@@ -43,6 +43,10 @@ class LaunchConfigTask extends DefaultTask {
             '-verbose:gc'
     ]
 
+    static final List<String> optimizationsToDisableJvmOpts = [
+            '-XX:-OmitStackTraceInFastThrow'
+    ]
+
     static final List<String> dirs = ['var/data/tmp']
 
     @Input
@@ -99,7 +103,7 @@ class LaunchConfigTask extends DefaultTask {
 
     @TaskAction
     void createConfig() {
-        writeConfig(createConfig(getArgs(), tmpdirJvmOpts + gcJvmOpts + defaultJvmOpts), getStaticLauncher())
+        writeConfig(createConfig(getArgs(), tmpdirJvmOpts + gcJvmOpts + optimizationsToDisableJvmOpts + defaultJvmOpts), getStaticLauncher())
         writeConfig(createConfig(getCheckArgs(), tmpdirJvmOpts + defaultJvmOpts), getCheckLauncher())
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -439,6 +439,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 '-XX:NumberOfGCLogFiles=10',
                 '-Xloggc:var/log/gc-%t-%p.log',
                 '-verbose:gc',
+                '-XX:-OmitStackTraceInFastThrow',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
         expectedStaticConfig.setEnv([


### PR DESCRIPTION
We recently had this issue where a `ClassCastException` was occuring repeatedly without a stacktrace. Turns out that it was because of this JVM optimization. I don't think we gain much value and given the pain it can cause in debugging, I think we should disable it. This optimization seems useful if you're using exceptions as control flow, but that is anyway an anti-pattern. 

@rfink, @schlosna thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/sls-packaging/264)
<!-- Reviewable:end -->
