### PR TITLE
Avoid OOMs on CI

### DIFF
--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
@@ -40,6 +40,8 @@ class GradleTestSpec extends Specification {
 
     def setup() {
         projectDir = folder.newFolder()
+        File propertiesFile = file("gradle.properties")
+        propertiesFile << "org.gradle.daemon=false"
         buildFile = file("build.gradle")
         settingsFile = new File(projectDir, 'settings.gradle')
         helper = new MultiProjectIntegrationHelper(projectDir, settingsFile)


### PR DESCRIPTION
We are unable to iterate @andybradshaws PR (#265) because tests keep OOMing.  This change seems to drastically reduce memory requirements!