### PR TITLE
set sun.net.inetaddr.ttl to 20s by default

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
@@ -40,7 +40,8 @@ class LaunchConfigTask extends DefaultTask {
             '-XX:GCLogFileSize=10M',
             '-XX:NumberOfGCLogFiles=10',
             '-Xloggc:var/log/gc-%t-%p.log',
-            '-verbose:gc'
+            '-verbose:gc',
+            '-Dsun.net.inetaddr.ttl=20'
     ]
 
     static final List<String> dirs = ['var/data/tmp']

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
@@ -40,7 +40,10 @@ class LaunchConfigTask extends DefaultTask {
             '-XX:GCLogFileSize=10M',
             '-XX:NumberOfGCLogFiles=10',
             '-Xloggc:var/log/gc-%t-%p.log',
-            '-verbose:gc',
+            '-verbose:gc'
+    ]
+
+    static final List<String> dnsJvmOpts = [
             '-Dsun.net.inetaddr.ttl=20'
     ]
 
@@ -100,7 +103,7 @@ class LaunchConfigTask extends DefaultTask {
 
     @TaskAction
     void createConfig() {
-        writeConfig(createConfig(getArgs(), tmpdirJvmOpts + gcJvmOpts + defaultJvmOpts), getStaticLauncher())
+        writeConfig(createConfig(getArgs(), tmpdirJvmOpts + gcJvmOpts + dnsJvmOpts + defaultJvmOpts), getStaticLauncher())
         writeConfig(createConfig(getCheckArgs(), tmpdirJvmOpts + defaultJvmOpts), getCheckLauncher())
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -439,6 +439,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 '-XX:NumberOfGCLogFiles=10',
                 '-Xloggc:var/log/gc-%t-%p.log',
                 '-verbose:gc',
+                '-Dsun.net.inetaddr.ttl=20',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
         expectedStaticConfig.setEnv([


### PR DESCRIPTION
Tested RDS failover on an internal product with with 60s as per email with Dan and team and it took the product about 70s to re-establish valid connections (likely due to DNS timeout + connection pool timeouts), which I think may be a little too long given that these can happen somewhat frequently -- e.g. AWS maintenance. Setting to 20s here but open to recommendations if people have opinions on a more appropriate value.