### PR TITLE
Set env MALLOC_ARENA_MAX=4 by default

### DIFF
--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -442,7 +442,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 '-Dsun.net.inetaddr.ttl=20',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
-        expectedStaticConfig.setEnv([
+        expectedStaticConfig.setEnv(LaunchConfigTask.defaultEnvironment + [
                 "key1": "val1",
                 "key2": "val2"
         ])
@@ -452,6 +452,9 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         expectedStaticConfig == actualStaticConfig
 
         def expectedCheckConfig = expectedStaticConfig
+
+        LaunchConfigTask.defaultEnvironment.keySet().forEach { key -> expectedCheckConfig.env.remove(key) }
+
         expectedCheckConfig.setJvmOpts([
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-Xmx4M',


### PR DESCRIPTION
Given some versions of glibc, this can provide a significant
reduction in virtual memory usage.

https://jkutner.github.io/2017/04/28/oh-the-places-your-java-memory-goes.html
https://github.com/prestodb/presto/issues/8993
https://issues.apache.org/jira/browse/HADOOP-7154