### PR TITLE
Deprecate non-{start,status,stop} commands

### DIFF
--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -52,6 +52,8 @@ STATIC_LAUNCHER_CONFIG="service/bin/launcher-static.yml"
 CUSTOM_LAUNCHER_CONFIG="var/conf/launcher-custom.yml"
 STATIC_LAUNCHER_CHECK_CONFIG="service/bin/launcher-check.yml"
 
+DEPRECATION_MESSAGE="Command is deprecated: the next major release will only support start/status/stop"
+
 case $ACTION in
 start)
     if service/bin/init.sh status &> /dev/null; then
@@ -124,6 +126,7 @@ stop)
     fi
 ;;
 console)
+    echo $DEPRECATION_MESSAGE
     if service/bin/init.sh status &> /dev/null; then
         echo "Process is already running"
         exit 1
@@ -136,10 +139,12 @@ console)
     wait
 ;;
 restart)
+    echo $DEPRECATION_MESSAGE
     service/bin/init.sh stop
     service/bin/init.sh start
 ;;
 check)
+    echo $DEPRECATION_MESSAGE
     printf "%-50s" "Checking health of '$SERVICE'..."
     $LAUNCHER_CMD $STATIC_LAUNCHER_CHECK_CONFIG > var/log/$SERVICE-check.log 2>&1
     RESULT=$?
@@ -154,6 +159,7 @@ check)
 *)
     # Support arbitrary additional actions; e.g. init-reload.sh will add a "reload" action
     if [[ -f "$SCRIPT_DIR/init-$ACTION.sh" ]]; then
+        echo $DEPRECATION_MESSAGE
         export LAUNCHER_CMD
         shift
         /bin/bash "$SCRIPT_DIR/init-$ACTION.sh" "$@"
@@ -161,6 +167,7 @@ check)
     else
         COMMANDS=$(ls $SCRIPT_DIR | sed -ne '/init-.*.sh/ { s/^init-\(.*\).sh$/|\1/g; p; }' | tr -d '\n')
         echo "Usage: $0 {status|start|stop|console|restart|check${COMMANDS}}"
+        echo "All commands but start/status/stop are deprecated: the next major release will only support these commands"
         exit 1
     fi
 esac


### PR DESCRIPTION
cc @cbrockington @iamdanfox 

I want to see what the proper route is for deprecating these commands. I'm thinking:

- add these echos for due diligence (though in this day and age, humans should generally not be running these commands, though I don't know what the large internal product is doing in this regard)
- calling this out in changelog for release that includes this deprecation
- email
- search for usages of these and follow up individually with products using them to lessen impact of their removal

(Also, restart is potentially still includable, though I initially left it out from the perspective of ruthless spec-adherence, there's no concept of instantaneous restarts in the spec and status is easily replaceable on the client-side with `stop && start`, which, as a sidenote, is probably how the current command should be anyway, as it currently will still issue a start again even if stop fails, small edge case)