### PR TITLE
Resolve dependencies for publishPlugins

### DIFF
--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -40,10 +40,10 @@ pluginBundle {
 
     withDependencies {
         it.each { dep ->
-         if (!dep.version) {
-             dep.version = dependencyRecommendations.getRecommendedVersion(dep.groupId, dep.artifactId)
-         }
-       }
+            if (!dep.version) {
+                dep.version = dependencyRecommendations.getRecommendedVersion(dep.groupId, dep.artifactId)
+            }
+        }
     }
 }
 

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'java-gradle-plugin'
 apply plugin: 'groovy'
 apply plugin: 'org.inferred.processors'
 apply plugin: 'de.undercouch.download'
-apply plugin: 'nebula.maven-resolved-dependencies'
 
 dependencies {
     processor 'org.immutables:value'
@@ -37,6 +36,14 @@ pluginBundle {
             id = 'com.palantir.sls-pod-distribution'
             displayName = 'Creates SLS pod distributions'
         }
+    }
+
+    withDependencies {
+        it.each { dep ->
+         if (!dep.version) {
+             dep.version = dependencyRecommendations.getRecommendedVersion(dep.groupId, dep.artifactId)
+         }
+       }
     }
 }
 

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -38,6 +38,10 @@ pluginBundle {
         }
     }
 
+    // Fix for publishPlugins not working with dependency recommenders (nebula, in our case).
+    // Gradle suggests the 'withDependencies' approach in the following workaround:
+    // http://plugins.gradle.org/help/plugin/missing-dependency-version
+    // TODO(dsanduleac): this is bad and we want to remove it
     withDependencies {
         it.each { dep ->
             if (!dep.version) {


### PR DESCRIPTION
#298 wasn't the right thing to do.
Gradle recommends doing something like [this](https://discuss.gradle.org/t/plugin-publish-fails-with-npe-if-dependency-doesnt-have-version/19070/3), this is less extreme than that but suffices to source the un-set versions from nebula.