### PR TITLE
Timeout at 90 seconds

### DIFF
--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -99,7 +99,7 @@ stop)
         PID=$(cat $PIDFILE)
         kill $PID
         COUNTER=0
-        while is_process_service $PID $SERVICE && [ "$COUNTER" -lt "240" ]; do
+        while is_process_service $PID $SERVICE && [ "$COUNTER" -lt "90" ]; do
             sleep 1
             let COUNTER=COUNTER+1
             if [ $((COUNTER%5)) == 0 ]; then


### PR DESCRIPTION
Our internal infrastructure times out before 240 seconds and this confused at least one dev internally. 90 matches the init script for our internal go services.