### PR TITLE
Use go-init in init.sh

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.groovy
@@ -46,7 +46,8 @@ class JavaServiceDistributionPlugin implements Plugin<Project> {
 
         project.configurations.create('goJavaLauncherBinaries')
         project.dependencies {
-            goJavaLauncherBinaries 'com.palantir.launching:go-java-launcher:1.2.0'
+            goJavaLauncherBinaries 'com.palantir.launching:go-java-launcher:1.4.2'
+            goJavaLauncherBinaries 'com.palantir.launching:go-init:1.4.2'
         }
 
         def distributionExtension = project.extensions.findByType(JavaServiceDistributionExtension)
@@ -67,8 +68,9 @@ class JavaServiceDistributionPlugin implements Plugin<Project> {
 
         LaunchConfigTask launchConfig = project.tasks.create('createLaunchConfig', LaunchConfigTask)
         project.afterEvaluate {
-            launchConfig.configure(distributionExtension.mainClass, distributionExtension.args, distributionExtension.checkArgs,
-                    distributionExtension.defaultJvmOpts, distributionExtension.javaHome, distributionExtension.env,
+            launchConfig.configure(distributionExtension.mainClass, distributionExtension.serviceName,
+                    distributionExtension.args, distributionExtension.checkArgs, distributionExtension.defaultJvmOpts,
+                    distributionExtension.javaHome, distributionExtension.env,
                     project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtimeClasspath)
         }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
@@ -26,21 +26,23 @@ class CopyLauncherBinariesTask extends DefaultTask {
         group = JavaServiceDistributionPlugin.GROUP_NAME
         description = "Creates go-java-launcher binaries."
         doLast {
-            project.copy { copySpec ->
-                def zipPath = project.configurations.goJavaLauncherBinaries.find {
-                    it.name.startsWith("go-java-launcher")
-                }
-                def zipFile = project.file(zipPath)
+            ['go-java-launcher', 'go-init'].each { binary ->
+                project.copy { copySpec ->
+                    def zipPath = project.configurations.goJavaLauncherBinaries.find {
+                        it.name.startsWith(binary)
+                    }
+                    def zipFile = project.file(zipPath)
 
-                copySpec.from project.tarTree(zipFile)
-                copySpec.into "${project.buildDir}/scripts"
-                copySpec.includeEmptyDirs = false
+                    copySpec.from project.tarTree(zipFile)
+                    copySpec.into "${project.buildDir}/scripts"
+                    copySpec.includeEmptyDirs = false
 
-                // remove first three levels of directory structure from Tar container
-                copySpec.eachFile { FileCopyDetails fcp ->
-                    fcp.relativePath = new RelativePath(
-                            !fcp.file.isDirectory(),
-                            fcp.relativePath.segments[3..-1] as String[])
+                    // remove first three levels of directory structure from Tar container
+                    copySpec.eachFile { FileCopyDetails fcp ->
+                        fcp.relativePath = new RelativePath(
+                                !fcp.file.isDirectory(),
+                                fcp.relativePath.segments[3..-1] as String[])
+                    }
                 }
             }
         }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.groovy
@@ -60,6 +60,9 @@ class LaunchConfigTask extends DefaultTask {
     String mainClass
 
     @Input
+    String serviceName
+
+    @Input
     List<String> args
 
     @Input
@@ -90,6 +93,7 @@ class LaunchConfigTask extends DefaultTask {
         String configType = "java"
         int configVersion = 1
         String mainClass
+        String serviceName
         String javaHome
         List<String> classpath
         List<String> jvmOpts
@@ -129,6 +133,7 @@ class LaunchConfigTask extends DefaultTask {
     StaticLaunchConfig createConfig(List<String> args, List<String> jvmOpts, Map<String, String> defaultEnv) {
         StaticLaunchConfig config = new StaticLaunchConfig()
         config.mainClass = mainClass
+        config.serviceName = serviceName
         config.javaHome = javaHome ?: ""
         config.args = args
         config.classpath = relativizeToServiceLibDirectory(classpath)
@@ -144,8 +149,9 @@ class LaunchConfigTask extends DefaultTask {
         return output
     }
 
-    void configure(String mainClass, List<String> args, List<String> checkArgs, List<String> defaultJvmOpts, String javaHome, Map<String, String> env, FileCollection classpath) {
+    void configure(String mainClass, String serviceName, List<String> args, List<String> checkArgs, List<String> defaultJvmOpts, String javaHome, Map<String, String> env, FileCollection classpath) {
         this.mainClass = mainClass
+        this.serviceName = serviceName
         this.args = args
         this.checkArgs = checkArgs
         this.defaultJvmOpts = defaultJvmOpts

--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -15,20 +15,6 @@
 # limitations under the License.
 #
 
-is_process_active() {
-   local PID=$1
-   ps $PID > /dev/null;
-   return $?
-}
-
-is_process_service() {
-  local PID=$1
-  local SERVICE_NAME=$2
-  # trailing '=' prevents a header line
-  ps -ww -o command= $PID | grep -q "$SERVICE_NAME"
-  return $?
-}
-
 # Everything in this script is relative to the base directory of an SLSv2 distribution
 pushd "`dirname \"$0\"`/../.." > /dev/null
 
@@ -36,9 +22,11 @@ pushd "`dirname \"$0\"`/../.." > /dev/null
 case "`uname`" in
   Linux*)
     LAUNCHER_CMD=service/bin/linux-amd64/go-java-launcher
+    GO_INIT_CMD=service/bin/linux-amd64/go-init
     ;;
   Darwin*)
     LAUNCHER_CMD=service/bin/darwin-amd64/go-java-launcher
+    GO_INIT_CMD=service/bin/darwin-amd64/go-init
     ;;
   *)
     echo "Unsupported operating system: $(uname)"; exit 1
@@ -52,83 +40,20 @@ STATIC_LAUNCHER_CONFIG="service/bin/launcher-static.yml"
 CUSTOM_LAUNCHER_CONFIG="var/conf/launcher-custom.yml"
 STATIC_LAUNCHER_CHECK_CONFIG="service/bin/launcher-check.yml"
 
+DEPRECATION_MESSAGE="Command is deprecated: the next major release of sls-packaging will only support start/status/stop"
+
 case $ACTION in
 start)
-    if service/bin/init.sh status &> /dev/null; then
-        echo "Process is already running"
-        exit 0
-    fi
-    printf "%-50s" "Running '$SERVICE'..."
-
-    # ensure log and pid directories exist
-    mkdir -p "var/log" "var/run"
-    PID=$($LAUNCHER_CMD $STATIC_LAUNCHER_CONFIG $CUSTOM_LAUNCHER_CONFIG > var/log/$SERVICE-startup.log 2>&1 & echo $!)
-    # always write $PIDFILE so that `init.sh status` for a service that crashed when starting will return 1, not 3
-    echo $PID > $PIDFILE
-    sleep 5
-    if is_process_service $PID $SERVICE; then
-        printf "%s\n" "Started ($PID)"
-        exit 0
-    else
-        printf "%s\n" "Failed"
-        exit 1
-    fi
+    $GO_INIT_CMD start
 ;;
 status)
-    printf "%-50s" "Checking '$SERVICE'..."
-    if [ -f $PIDFILE ]; then
-        PID=$(cat $PIDFILE)
-        if is_process_service $PID $SERVICE; then
-          printf "%s\n" "Running ($PID)"
-          exit 0
-        elif is_process_active $PID; then
-          printf "%s\n" "Warning, Pid $PID appears to not correspond to service $SERVICE"
-          # fallthrough to generic 'process dead but pidfile exists'
-        fi
-
-        printf "%s\n" "Process dead but pidfile exists."
-        exit 1
-    else
-        printf "%s\n" "Service not running"
-        exit 3
-    fi
+    $GO_INIT_CMD status
 ;;
 stop)
-    printf "%-50s" "Stopping '$SERVICE'..."
-    if service/bin/init.sh status &> /dev/null; then
-        PID=$(cat $PIDFILE)
-        kill $PID
-        COUNTER=0
-        while is_process_service $PID $SERVICE && [ "$COUNTER" -lt "240" ]; do
-            sleep 1
-            let COUNTER=COUNTER+1
-            if [ $((COUNTER%5)) == 0 ]; then
-                if [ "$COUNTER" -eq "5" ]; then
-                    printf "\n" # first time get a new line to get off Stopping printf
-                fi
-                printf "%s\n" "Waiting for '$SERVICE' ($PID) to stop"
-            fi
-        done
-        if is_process_service $PID $SERVICE; then
-            # waited for entire timeout, now forcefully kill the service
-            printf "%s\n" "Executing kill -9 on '$SERVICE' ($PID)"
-            kill -9 $PID
-        fi
-        if is_process_service $PID $SERVICE; then
-            printf "%s\n" "Failed ($PID)"
-            exit 1
-        else
-            rm -f $PIDFILE
-            printf "%s\n" "Stopped ($PID)"
-            exit 0
-        fi
-    else
-        rm -f $PIDFILE
-        printf "%s\n" "Service not running"
-        exit 0
-    fi
+    $GO_INIT_CMD stop
 ;;
 console)
+    echo $DEPRECATION_MESSAGE
     if service/bin/init.sh status &> /dev/null; then
         echo "Process is already running"
         exit 1
@@ -141,10 +66,12 @@ console)
     wait
 ;;
 restart)
+    echo $DEPRECATION_MESSAGE
     service/bin/init.sh stop
     service/bin/init.sh start
 ;;
 check)
+    echo $DEPRECATION_MESSAGE
     printf "%-50s" "Checking health of '$SERVICE'..."
     $LAUNCHER_CMD $STATIC_LAUNCHER_CHECK_CONFIG > var/log/$SERVICE-check.log 2>&1
     RESULT=$?
@@ -159,6 +86,7 @@ check)
 *)
     # Support arbitrary additional actions; e.g. init-reload.sh will add a "reload" action
     if [[ -f "$SCRIPT_DIR/init-$ACTION.sh" ]]; then
+        echo $DEPRECATION_MESSAGE
         export LAUNCHER_CMD
         shift
         /bin/bash "$SCRIPT_DIR/init-$ACTION.sh" "$@"
@@ -166,6 +94,7 @@ check)
     else
         COMMANDS=$(ls $SCRIPT_DIR | sed -ne '/init-.*.sh/ { s/^init-\(.*\).sh$/|\1/g; p; }' | tr -d '\n')
         echo "Usage: $0 {status|start|stop|console|restart|check${COMMANDS}}"
+        echo "All commands but start/status/stop are deprecated: the next major release will only support these commands"
         exit 1
     fi
 esac

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleTestSpec.groovy
@@ -67,18 +67,20 @@ class GradleTestSpec extends Specification {
         return buildResult
     }
 
-    protected String exec(String... tasks) {
-        return execWithResult(0, tasks)
-    }
-
-    protected String execWithResult(int expected, String... tasks) {
+    protected String execWithOutput(String... tasks) {
         StringBuffer sout = new StringBuffer(), serr = new StringBuffer()
         Process proc = new ProcessBuilder().command(tasks).directory(projectDir).start()
         proc.consumeProcessOutput(sout, serr)
         int result = proc.waitFor()
+        int expected = 0
         Assert.assertEquals(sprintf("Expected command '%s' to exit with '%d'", tasks.join(' '), expected), expected, result)
-        sleep 1000 // wait for the Java process to actually run
         return sout.toString()
+    }
+
+    protected int execWithExitCode(String... tasks) {
+        Process proc = new ProcessBuilder().command(tasks).directory(projectDir).start()
+        int result = proc.waitFor()
+        return result
     }
 
     protected String execAllowFail(String... tasks) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -63,15 +63,16 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
 
         then:
         // try all of the service commands
-        exec('dist/service-name-0.0.1/service/bin/init.sh', 'start') ==~ /(?m)Running 'service-name'\.\.\.\s+Started \(\d+\)\n/
-        file('dist/service-name-0.0.1/var/log/service-name-startup.log', projectDir).text.contains('Test started\n')
-        exec('dist/service-name-0.0.1/service/bin/init.sh', 'start') ==~ /(?m)Process is already running\n/
-        exec('dist/service-name-0.0.1/service/bin/init.sh', 'status') ==~ /(?m)Checking 'service-name'\.\.\.\s+Running \(\d+\)\n/
-        exec('dist/service-name-0.0.1/service/bin/init.sh', 'restart') ==~
-                /(?m)Stopping 'service-name'\.\.\.\s+Stopped \(\d+\)\nRunning 'service-name'\.\.\.\s+Started \(\d+\)\n/
-        exec('dist/service-name-0.0.1/service/bin/init.sh', 'stop') ==~ /(?m)Stopping 'service-name'\.\.\.\s+Stopped \(\d+\)\n/
-        exec('dist/service-name-0.0.1/service/bin/init.sh', 'check') ==~ /(?m)Checking health of 'service-name'\.\.\.\s+Healthy.*\n/
-        exec('dist/service-name-0.0.1/service/monitoring/bin/check.sh') ==~ /(?m)Checking health of 'service-name'\.\.\.\s+Healthy.*\n/
+        execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'start') == 0
+        // wait for the Java process to start up and emit output
+        sleep 1000
+        file('dist/service-name-0.0.1/var/log/startup.log', projectDir).text.contains('Test started\n')
+        execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'start') == 0
+        execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'status') == 0
+        execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'restart') == 0
+        execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'stop') == 0
+        execWithOutput('dist/service-name-0.0.1/service/bin/init.sh', 'check') ==~ /.*\n*Checking health of 'service-name'\.\.\.\s+Healthy.*\n/
+        execWithOutput('dist/service-name-0.0.1/service/monitoring/bin/check.sh') ==~ /.*\n*Checking health of 'service-name'\.\.\.\s+Healthy.*\n/
     }
 
     def 'packaging tasks re-run after version change'() {
@@ -110,33 +111,8 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         version02BuildOutput ==~ /(?m)(?s).*:createManifest.*/
         version02BuildOutput ==~ /(?m)(?s).*:manifestClasspathJar.*/
         version02BuildOutput ==~ /(?m)(?s).*:distTar.*/
-        exec('dist/service-name-0.0.2/service/bin/init.sh', 'start') ==~ /(?m)Running 'service-name'\.\.\.\s+Started \(\d+\)\n/
-        exec('dist/service-name-0.0.2/service/bin/init.sh', 'stop') ==~ /(?m)Stopping 'service-name'\.\.\.\s+Stopped \(\d+\)\n/
-    }
-
-    def 'status reports when process name and id don"t match'() {
-        given:
-        createUntarBuildFile(buildFile)
-        file('src/main/java/test/Test.java') << '''
-        package test;
-        public class Test {
-            public static void main(String[] args) {
-                while(true);
-            }
-        }
-        '''.stripIndent()
-
-        when:
-        runSuccessfully(':build', ':distTar', ':untar')
-        createFile('dist/service-name-0.0.1/var/run/service-name.pid')
-        exec('/bin/bash', '-c', 'sleep 30 & echo $! > dist/service-name-0.0.1/var/run/service-name.pid')
-
-        then:
-        execWithResult(1, 'dist/service-name-0.0.1/service/bin/init.sh', 'status').contains('appears to not correspond to service service-name')
-        // 'dead with pidfile' persist across status calls
-        execWithResult(1, 'dist/service-name-0.0.1/service/bin/init.sh', 'status').contains('Process dead but pidfile exists')
-        exec('dist/service-name-0.0.1/service/bin/init.sh', 'stop').contains('Service not running')
-        execWithResult(3, 'dist/service-name-0.0.1/service/bin/init.sh', 'status').contains('Service not running')
+        execWithExitCode('dist/service-name-0.0.2/service/bin/init.sh', 'start') == 0
+        execWithExitCode('dist/service-name-0.0.2/service/bin/init.sh', 'stop') == 0
     }
 
     def 'produce distribution bundle and check var/log and var/run are excluded'() {
@@ -176,6 +152,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
 
         then:
         execAllowFail('dist/service-name-0.0.1/service/bin/init.sh', 'start')
+        sleep 1000
         file('dist/service-name-0.0.1/var/data/tmp').listFiles().length == 1
         file('dist/service-name-0.0.1/var/data/tmp').listFiles()[0].text == "temp content"
     }
@@ -187,7 +164,10 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 id 'com.palantir.sls-java-service-distribution'
                 id 'java'
             }
-            repositories { jcenter() }
+            repositories {
+                jcenter()
+                maven { url "http://palantir.bintray.com/releases" }
+            }
 
             version '0.0.1'
 
@@ -228,7 +208,10 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 id 'com.palantir.sls-java-service-distribution'
                 id 'java'
             }
-            repositories { jcenter() }
+            repositories {
+                jcenter()
+                maven { url "http://palantir.bintray.com/releases" }
+            }
 
             class MyVersion {
                 String version
@@ -425,6 +408,7 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
         expectedStaticConfig.setConfigVersion(1)
         expectedStaticConfig.setConfigType("java")
         expectedStaticConfig.setMainClass("test.Test")
+        expectedStaticConfig.setServiceName("service-name")
         expectedStaticConfig.setJavaHome("foo")
         expectedStaticConfig.setArgs(['myArg1', 'myArg2'])
         expectedStaticConfig.setClasspath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
@@ -559,7 +543,10 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 id 'com.palantir.sls-java-service-distribution'
                 id 'java'
             }
-            repositories { jcenter() }
+            repositories {
+                jcenter()
+                maven { url "http://palantir.bintray.com/releases" }
+            }
             version '0.0.1'
             distribution {
                 serviceName "my-service"
@@ -639,7 +626,10 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
                 args "hello"
                 enableManifestClasspath true
             }
-            repositories { jcenter() }
+            repositories {
+                jcenter()
+                maven { url "http://palantir.bintray.com/releases" }
+            }
             dependencies {
                 implementation project(':child')
                 compile 'org.mockito:mockito-core:2.7.22'
@@ -745,7 +735,10 @@ class ServiceDistributionPluginTests extends GradleTestSpec {
 
             project.group = 'service-group'
 
-            repositories { jcenter() }
+            repositories {
+                jcenter()
+                maven { url "http://palantir.bintray.com/releases" }
+            }
 
             version '0.0.1'
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitAgentTaskTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitAgentTaskTest.groovy
@@ -69,7 +69,10 @@ class CopyYourkitAgentTaskTest extends GradleTestSpec {
 
             project.group = 'service-group'
 
-            repositories { jcenter() }
+            repositories {
+                jcenter()
+                maven { url "http://palantir.bintray.com/releases" }
+            }
 
             version '0.0.1'
 


### PR DESCRIPTION
This is a rehash of https://github.com/palantir/sls-packaging/pull/306. I had to have the tests also use the repository `maven { url "http://palantir.bintray.com/releases" }` since `go-init` isn't available in JCenter.

According to @bluekeyes this can likely be resolved by contacting JCenter support, if we so desire.

@dansanduleac 