### PR TITLE
Add JVM Default GC configuration

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.groovy
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap
 import com.palantir.gradle.dist.BaseDistributionExtension
 import com.palantir.gradle.dist.service.gc.GcProfile
 import com.palantir.gradle.dist.service.gc.Hybrid
+import com.palantir.gradle.dist.service.gc.JvmDefault
 import com.palantir.gradle.dist.service.gc.ResponseTime
 import com.palantir.gradle.dist.service.gc.Throughput
 import javax.annotation.Nullable
@@ -32,7 +33,8 @@ class JavaServiceDistributionExtension extends BaseDistributionExtension {
     private static final Map<String, Class<? extends GcProfile>> profileNames = ImmutableMap.of(
             "throughput", Throughput.class,
             "response-time", ResponseTime.class,
-            "hybrid", Hybrid.class)
+            "hybrid", Hybrid.class,
+            "jvm-default", JvmDefault.class)
 
     private final ObjectFactory objects
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/JvmDefault.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/JvmDefault.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.service.gc;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+public class JvmDefault implements GcProfile {
+    @Override
+    public final List<String> gcProfileJvmOpts() {
+        return ImmutableList.of();
+    }
+}


### PR DESCRIPTION
Enable the usage of the JVM default GC (or set GC using java options).

Follow-up to https://github.com/palantir/sls-packaging/pull/312 as it breaks back-compat for distributions that override GC methods as part of their own configuration. Should this be made the default GC setting?