### PR TITLE
orderable recommended versions are used only during manifest creation instead of task creation

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/RecommendedProductDependency.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/RecommendedProductDependency.groovy
@@ -61,7 +61,7 @@ class RecommendedProductDependency {
             }
         }
         [minimumVersion, recommendedVersion].each {
-            if (it && !SlsProductVersions.isOrderableVersion(it)) {
+            if (it && !SlsProductVersions.isValidVersion(it)) {
                 throw new IllegalArgumentException(
                         "minimumVersion and recommendedVersions must be valid SLS versions: " + it)
             }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.groovy
@@ -91,7 +91,6 @@ class CreateManifestTask extends DefaultTask {
 
     @TaskAction
     void createManifest() {
-        Set<RecommendedProductDependency> allRecommendedProductDeps = []
         Map<String, Set<RecommendedProductDependency>> allRecommendedDepsByCoord = [:]
         Map<String, String> mavenCoordsByProductIds = [:]
         Map<String, RecommendedProductDependency> recommendedDepsByProductId = [:]
@@ -126,7 +125,6 @@ class CreateManifestTask extends DefaultTask {
                 allRecommendedDepsByCoord.put(coord, new HashSet<RecommendedProductDependency>())
             }
 
-            allRecommendedProductDeps.addAll(recommendedDeps.recommendedProductDependencies())
             allRecommendedDepsByCoord.get(coord).addAll(recommendedDeps.recommendedProductDependencies())
 
             recommendedDeps.recommendedProductDependencies().each { recommendedDep ->
@@ -144,8 +142,7 @@ class CreateManifestTask extends DefaultTask {
                             othercoord,
                             recommendedDep,
                             existingDep)
-                    dep = RecommendedProductDependencyMerger
-                            .mergeRecommendedProductDependencies(recommendedDep, existingDep)
+                    dep = RecommendedProductDependencyMerger.merge(recommendedDep, existingDep)
                 } else {
                     dep = recommendedDep
                 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependencyMergerTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependencyMergerTest.groovy
@@ -30,12 +30,32 @@ class RecommendedProductDependencyMergerTest extends Specification {
         def dep2 = newRecommendation("2.1.0", "2.x.x", "2.2.0")
 
         when:
-        def merged = RecommendedProductDependencyMerger.mergeRecommendedProductDependencies(dep1, dep2)
+        def merged = RecommendedProductDependencyMerger.merge(dep1, dep2)
 
         then:
         merged.minimumVersion == "2.1.0"
         merged.maximumVersion == "2.6.x"
         merged.recommendedVersion == "2.2.0"
+    }
+
+    def "non-orderable versions will not be picked"() {
+        given:
+        def dep1 = newRecommendation("2.1.0", "2.6.x", "2.3.0.dirty")
+        def dep2 = newRecommendation("2.2.0.dirty", "2.x.x", "2.2.0")
+        def dep3 = newRecommendation("2.2.0", "2.x.x", null)
+
+        when:
+        def merged1 = RecommendedProductDependencyMerger.merge(dep1, dep2)
+        def merged2 = RecommendedProductDependencyMerger.merge(dep1, dep3)
+
+        then:
+        merged1.minimumVersion == "2.1.0"
+        merged1.maximumVersion == "2.6.x"
+        merged1.recommendedVersion == "2.2.0"
+
+        merged2.minimumVersion == "2.2.0"
+        merged2.maximumVersion == "2.6.x"
+        merged2.recommendedVersion == null
     }
 
     def "fails if new min is greater than new max"() {
@@ -44,11 +64,24 @@ class RecommendedProductDependencyMergerTest extends Specification {
         def dep2 = newRecommendation("2.7.0", "2.x.x", "2.8.0")
 
         when:
-        def merged = RecommendedProductDependencyMerger.mergeRecommendedProductDependencies(dep1, dep2)
+        def merged = RecommendedProductDependencyMerger.merge(dep1, dep2)
 
         then:
         def e = thrown(IllegalArgumentException)
         e.message.contains("Could not merge recommended product dependencies as their version ranges do not overlap")
+    }
+
+    def "fails if no orderable minimum version could be found"() {
+        given:
+        def dep1 = newRecommendation("2.0.0.dirty", "2.6.x", "2.2.0")
+        def dep2 = newRecommendation("2.7.0.dirty", "2.x.x", "2.8.0")
+
+        when:
+        RecommendedProductDependencyMerger.merge(dep1, dep2)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("Unable to determine minimum version")
     }
 
     def "fails if min == max"() {
@@ -57,7 +90,7 @@ class RecommendedProductDependencyMergerTest extends Specification {
         def dep2 = newRecommendation("2.1.0", "2.5.0", null)
 
         when:
-        def merged = RecommendedProductDependencyMerger.mergeRecommendedProductDependencies(dep1, dep2)
+        def merged = RecommendedProductDependencyMerger.merge(dep1, dep2)
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -66,11 +99,25 @@ class RecommendedProductDependencyMergerTest extends Specification {
 
     def "max and recommended can be optional"() {
         given:
-        def dep1 = newRecommendation("2.1.0", null, "2.6.0")
-        def dep2 = newRecommendation("2.1.0", "2.8.x", null)
+        def dep1 = newRecommendation("2.1.0", null, null)
+        def dep2 = newRecommendation("2.1.0", null, null)
 
         when:
-        def merged = RecommendedProductDependencyMerger.mergeRecommendedProductDependencies(dep1, dep2)
+        def merged = RecommendedProductDependencyMerger.merge(dep1, dep2)
+
+        then:
+        merged.minimumVersion == "2.1.0"
+        merged.maximumVersion == null
+        merged.recommendedVersion == null
+    }
+
+    def "orderable version gets picked over non-orderable version"() {
+        given:
+        def dep1 = newRecommendation("2.1.0", null, "2.6.0")
+        def dep2 = newRecommendation("2.2.0.dirty", "2.8.x", null)
+
+        when:
+        def merged = RecommendedProductDependencyMerger.merge(dep1, dep2)
 
         then:
         merged.minimumVersion == "2.1.0"

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependencyMergerTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependencyMergerTest.groovy
@@ -99,20 +99,6 @@ class RecommendedProductDependencyMergerTest extends Specification {
 
     def "max and recommended can be optional"() {
         given:
-        def dep1 = newRecommendation("2.1.0", null, null)
-        def dep2 = newRecommendation("2.1.0", null, null)
-
-        when:
-        def merged = RecommendedProductDependencyMerger.merge(dep1, dep2)
-
-        then:
-        merged.minimumVersion == "2.1.0"
-        merged.maximumVersion == null
-        merged.recommendedVersion == null
-    }
-
-    def "orderable version gets picked over non-orderable version"() {
-        given:
         def dep1 = newRecommendation("2.1.0", null, "2.6.0")
         def dep2 = newRecommendation("2.2.0.dirty", "2.8.x", null)
 


### PR DESCRIPTION
Fixes https://github.com/palantir/sls-packaging/issues/322 by making RecommendedProductDependency take both orderable and non-orderable versions and only use orderable versions when merging recommended versions.