### PR TITLE
Simplify CopyLauncherBinariesTask

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyLauncherBinariesTask.groovy
@@ -25,9 +25,7 @@ class CopyLauncherBinariesTask extends Sync {
     CopyLauncherBinariesTask() {
         group = JavaServiceDistributionPlugin.GROUP_NAME
         description = "Creates go-java-launcher binaries."
-        from { project.configurations.goJavaLauncherBinaries.collect {
-            project.tarTree(it)
-        } }
+        from { project.configurations.goJavaLauncherBinaries.collect { project.tarTree(it) } }
 
         into "${project.buildDir}/scripts"
         includeEmptyDirs = false


### PR DESCRIPTION
## Before this PR

CopyLauncherBinariesTask was doing two project.copy invocations, setting up inputs/outputs manually

## After this PR

It's now a Sync task, which sets up inputs/outputs automatically, copies both files in one go, and also deletes any extraneous files from the target dir.