### PR TITLE
[fix] Ensure `gc: response-time` works on Java11

### DIFF
--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     testCompile gradleTestKit()
     testCompile 'com.netflix.nebula:nebula-test'
+    testCompile 'org.awaitility:awaitility'
 }
 
 pluginBundle {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist.service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.gradle.dist.BaseDistributionExtension;
@@ -40,7 +41,8 @@ import org.gradle.util.ConfigureUtil;
 
 public class JavaServiceDistributionExtension extends BaseDistributionExtension {
 
-    private static final Map<String, Class<? extends GcProfile>> profileNames = ImmutableMap.of(
+    @VisibleForTesting
+    static final Map<String, Class<? extends GcProfile>> profileNames = ImmutableMap.of(
             "throughput", Throughput.class,
             "response-time", ResponseTime.class,
             "hybrid", Hybrid.class,

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/ResponseTime.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/ResponseTime.java
@@ -34,7 +34,9 @@ public class ResponseTime implements GcProfile {
                 "-XX:+CMSClassUnloadingEnabled",
                 "-XX:+ExplicitGCInvokesConcurrent",
                 "-XX:+ClassUnloadingWithConcurrentMark",
-                "-XX:+CMSScavengeBeforeRemark");
+                "-XX:+CMSScavengeBeforeRemark",
+                // 'UseParNewGC' was removed in Java10: https://bugs.openjdk.java.net/browse/JDK-8173421
+                "-XX:+IgnoreUnrecognizedVMOptions");
     }
 
     public final void initiatingOccupancyFraction(int occupancyFraction) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ExampleTouchService.java
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ExampleTouchService.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public final class ExampleTouchService {
+
+    /** A tiny service which we run as part of integration tests */
+    public static void main(String[] args) throws IOException {
+        Files.createFile(Paths.get(args[0]));
+    }
+
+    private ExampleTouchService() {}
+}

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.service.tasks
+
+import com.palantir.gradle.dist.GradleIntegrationSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class GcProfileIntegrationSpec extends GradleIntegrationSpec {
+
+    static Path touchService = Paths.get("src/test/groovy/com/palantir/gradle/dist/service/ExampleTouchService.java")
+
+    def setup() {
+        File signalFile = new File(getProjectDir(), "example-touch-service-started")
+        buildFile << """
+            plugins {
+                id 'com.palantir.sls-java-service-distribution'
+            }
+            
+            repositories {
+                maven { url "http://palantir.bintray.com/releases" }
+            }
+
+            project.version = '1.0.0'
+            
+            distribution {
+                serviceName 'touch-service'
+                serviceGroup 'com.palantir.test'
+                mainClass 'com.palantir.gradle.dist.service.ExampleTouchService'
+                args '${signalFile.getAbsolutePath()}'
+            }
+        """.stripIndent()
+        Path path = projectDir.toPath().resolve("src/main/java/com/palantir/gradle/dist/service/ExampleTouchService.java")
+        Files.createDirectories(path.getParent())
+        Files.copy(touchService, path)
+        assert signalFile.exists() == false
+    }
+
+    def 'successfully create a distribution'() {
+        setup:
+        buildFile << """
+        distribution {
+            gc 'throughput'
+        }
+        """.stripIndent()
+
+        when:
+        def buildResult = runTasks(':distTar')
+
+        then:
+        println buildResult.output
+    }
+}

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
@@ -23,6 +23,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import org.awaitility.Awaitility
 import spock.lang.Unroll
+import spock.util.environment.Jvm
 
 class GcProfileIntegrationSpec extends GradleIntegrationSpec {
 
@@ -74,8 +75,12 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
         runTasks(':unpackTgz')
 
         then:
-        assert "touch-service-1.0.0/service/bin/init.sh start".execute(null, getProjectDir()).waitFor() == 0
-        Awaitility.await("file exists").until({signalFile.exists()})
+        if (!gc.toString().endsWith("-11") || Jvm.getCurrent().isJava9Compatible()) {
+            assert "touch-service-1.0.0/service/bin/init.sh start".execute(null, getProjectDir()).waitFor() == 0
+            Awaitility.await("file exists").until({signalFile.exists()})
+        } else {
+            println "Intentionally skipping test for ${gc} on ${Jvm.getCurrent().getJavaVersion()}"
+        }
 
         where:
         gc << JavaServiceDistributionExtension.profileNames.keySet().toArray()

--- a/versions.props
+++ b/versions.props
@@ -5,7 +5,9 @@ org.immutables:value = 2.7.5
 
 com.netflix.nebula:nebula-test = 7.1.7
 junit:junit = 4.12
+org.awaitility:awaitility = 3.1.5
 
 # conflict resolution
 com.google.errorprone:error_prone_annotations = 2.3.2
 com.google.code.findbugs:jsr305 = 3.0.2
+org.objenesis:objenesis = 2.6


### PR DESCRIPTION
## Before this PR

If you configured a service to use the 'response-time' GC options, the service won't start up on OpenJdk11 as [UseParNewGC was removed in Java 10](https://bugs.openjdk.java.net/browse/JDK-8173421).

```gradle
distribution {
    serviceName 'your-service'
    mainClass 'com.palantir.service.Main'
    gc 'response-time'
}
```

```
Unrecognized VM option 'UseParNewGC'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

cc @robert3005 

## After this PR

The service should start up.