### PR TITLE
[fix] don't print G1 gc stats

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/Hybrid.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/Hybrid.java
@@ -24,7 +24,6 @@ public class Hybrid implements GcProfile {
     public final List<String> gcJvmOpts() {
         return ImmutableList.of(
                 "-XX:+UseG1GC",
-                "-XX:+UseStringDeduplication",
-                "-XX:+PrintStringDeduplicationStatistics");
+                "-XX:+UseStringDeduplication");
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -847,7 +847,7 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         def actualStaticConfig = new ObjectMapper(new YAMLFactory()).readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.StaticLaunchConfig)
-        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseStringDeduplication', '-XX:+PrintStringDeduplicationStatistics'])
+        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseStringDeduplication'])
     }
 
     private static createUntarBuildFile(buildFile) {


### PR DESCRIPTION
It requires diagnostic vm options to be enabled, which this doesn't do and so won't actually start if you try it. Given we don't read the logs in this way, not worth having this.