### PR TITLE
[fix] Restore old setter methods (without set*) and add lazy setters

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -27,6 +27,7 @@ import com.palantir.gradle.dist.service.gc.ResponseTime;
 import com.palantir.gradle.dist.service.gc.ResponseTime11;
 import com.palantir.gradle.dist.service.gc.Throughput;
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -66,7 +67,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     public JavaServiceDistributionExtension(Project project) {
         super(project);
 
-        this.objectFactory = project.getObjects();
+        objectFactory = project.getObjects();
         mainClass = objectFactory.property(String.class);
         javaHome = objectFactory.property(String.class);
         addJava8GcLogging = objectFactory.property(Boolean.class);
@@ -89,7 +90,11 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         return mainClass;
     }
 
-    public final void setMainClass(String mainClass) {
+    public final void mainClass(String newMainClass) {
+        this.mainClass.set(newMainClass);
+    }
+
+    public final void setMainClass(Provider<String> mainClass) {
         this.mainClass.set(mainClass);
     }
 
@@ -97,7 +102,11 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         return javaHome;
     }
 
-    public final void setJavaHome(String javaHome) {
+    public final void javaHome(String newJavaHome) {
+        this.javaHome.set(newJavaHome);
+    }
+
+    public final void setJavaHome(Provider<String> javaHome) {
         this.javaHome.set(javaHome);
     }
 
@@ -109,11 +118,19 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.addJava8GcLogging.set(addJava8GcLogging);
     }
 
+    public final void addJava8GcLogging(boolean newAddJava8GcLogging) {
+        this.addJava8GcLogging.set(newAddJava8GcLogging);
+    }
+
     public final Provider<Boolean> getEnableManifestClasspath() {
         return enableManifestClasspath;
     }
 
-    public final void setEnableManifestClasspath(boolean enableManifestClasspath) {
+    public final void enableManifestClasspath(boolean newEnableManifestClasspath) {
+        this.enableManifestClasspath.set(newEnableManifestClasspath);
+    }
+
+    public final void setEnableManifestClasspath(Provider<Boolean> enableManifestClasspath) {
         this.enableManifestClasspath.set(enableManifestClasspath);
     }
 
@@ -125,7 +142,15 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.args.addAll(newArgs);
     }
 
+    public final void args(Provider<Iterable<String>> newArgs) {
+        this.args.addAll(newArgs);
+    }
+
     public final void setArgs(Iterable<String> args) {
+        this.args.set(args);
+    }
+
+    public final void setArgs(Provider<Iterable<String>> args) {
         this.args.set(args);
     }
 
@@ -137,7 +162,15 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.checkArgs.addAll(newCheckArgs);
     }
 
+    public final void checkArgs(Provider<Iterable<String>> newCheckArgs) {
+        this.checkArgs.addAll(newCheckArgs);
+    }
+
     public final void setCheckArgs(Iterable<String> checkArgs) {
+        this.checkArgs.set(checkArgs);
+    }
+
+    public final void setCheckArgs(Provider<Iterable<String>> checkArgs) {
         this.checkArgs.set(checkArgs);
     }
 
@@ -149,7 +182,15 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.defaultJvmOpts.addAll(opts);
     }
 
+    public final void defaultJvmOpts(Provider<Iterable<String>> opts) {
+        this.defaultJvmOpts.addAll(opts);
+    }
+
     public final void setDefaultJvmOpts(Iterable<String> defaultJvmOpts) {
+        this.defaultJvmOpts.set(defaultJvmOpts);
+    }
+
+    public final void setDefaultJvmOpts(Provider<Iterable<String>> defaultJvmOpts) {
         this.defaultJvmOpts.set(defaultJvmOpts);
     }
 
@@ -161,7 +202,15 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.excludeFromVar.addAll(fromVar);
     }
 
+    public final void excludeFromVar(Provider<Iterable<String>> fromVar) {
+        this.excludeFromVar.addAll(fromVar);
+    }
+
     public final void setExcludeFromVar(Iterable<String> excludeFromVar) {
+        this.excludeFromVar.set(excludeFromVar);
+    }
+
+    public final void setExcludeFromVar(Provider<Iterable<String>> excludeFromVar) {
         this.excludeFromVar.set(excludeFromVar);
     }
 
@@ -181,7 +230,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         return gc;
     }
 
-    public final void gc(String type, @Nullable Closure configuration) {
+    public final void gc(String type, @Nullable @DelegatesTo(GcProfile.class) Closure configuration) {
         GcProfile newGc = objectFactory.newInstance(profileNames.get(type));
         if (configuration != null) {
             ConfigureUtil.configure(configuration, newGc);

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -94,20 +94,12 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.mainClass.set(newMainClass);
     }
 
-    public final void setMainClass(Provider<String> mainClass) {
-        this.mainClass.set(mainClass);
-    }
-
     public final Provider<String> getJavaHome() {
         return javaHome;
     }
 
     public final void javaHome(String newJavaHome) {
         this.javaHome.set(newJavaHome);
-    }
-
-    public final void setJavaHome(Provider<String> javaHome) {
-        this.javaHome.set(javaHome);
     }
 
     public final Provider<Boolean> getAddJava8GcLogging() {
@@ -130,10 +122,6 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.enableManifestClasspath.set(newEnableManifestClasspath);
     }
 
-    public final void setEnableManifestClasspath(Provider<Boolean> enableManifestClasspath) {
-        this.enableManifestClasspath.set(enableManifestClasspath);
-    }
-
     public final Provider<List<String>> getArgs() {
         return args;
     }
@@ -147,10 +135,6 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     }
 
     public final void setArgs(Iterable<String> args) {
-        this.args.set(args);
-    }
-
-    public final void setArgs(Provider<Iterable<String>> args) {
         this.args.set(args);
     }
 
@@ -170,10 +154,6 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.checkArgs.set(checkArgs);
     }
 
-    public final void setCheckArgs(Provider<Iterable<String>> checkArgs) {
-        this.checkArgs.set(checkArgs);
-    }
-
     public final Provider<List<String>> getDefaultJvmOpts() {
         return defaultJvmOpts;
     }
@@ -190,10 +170,6 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.defaultJvmOpts.set(defaultJvmOpts);
     }
 
-    public final void setDefaultJvmOpts(Provider<Iterable<String>> defaultJvmOpts) {
-        this.defaultJvmOpts.set(defaultJvmOpts);
-    }
-
     public final Provider<List<String>> getExcludeFromVar() {
         return excludeFromVar;
     }
@@ -207,10 +183,6 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     }
 
     public final void setExcludeFromVar(Iterable<String> excludeFromVar) {
-        this.excludeFromVar.set(excludeFromVar);
-    }
-
-    public final void setExcludeFromVar(Provider<Iterable<String>> excludeFromVar) {
         this.excludeFromVar.set(excludeFromVar);
     }
 


### PR DESCRIPTION
## Before this PR

Rewrite in #385 removed some setter methods e.g. `JavaServiceDistributionExtension#mainClass(String)`.

## After this PR

Re-add old setter methods.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
