### PR TITLE
[fix] revert copy task changes

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitAgentTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitAgentTask.java
@@ -19,11 +19,12 @@ package com.palantir.gradle.dist.service.tasks;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.util.GFileUtils;
 
 public class CopyYourkitAgentTask extends DefaultTask {
     public CopyYourkitAgentTask() {
@@ -33,13 +34,15 @@ public class CopyYourkitAgentTask extends DefaultTask {
 
     @OutputFile
     public final File getOutputFile() {
-        return new File(getProject().getBuildDir(), "/libs/linux-x86-64/libyjpagent.so");
+        return new File(getProject().getBuildDir() + "/libs/linux-x86-64/libyjpagent.so");
     }
 
     @TaskAction
-    public final void copyYourkitAgent() throws IOException, URISyntaxException {
-        File src = new File(JavaServiceDistributionPlugin.class.getResource("/linux-x86-64/libyjpagent.so").toURI());
-        GFileUtils.copyFile(src, getOutputFile());
+    public final void copyYourkitAgent() throws IOException {
+        InputStream src = JavaServiceDistributionPlugin.class.getResourceAsStream("/linux-x86-64/libyjpagent.so");
+        Path dest = getOutputFile().toPath();
+        dest.getParent().toFile().mkdirs();
+        Files.copy(src, dest);
     }
 
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitAgentTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitAgentTask.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -34,7 +35,7 @@ public class CopyYourkitAgentTask extends DefaultTask {
 
     @OutputFile
     public final File getOutputFile() {
-        return new File(getProject().getBuildDir() + "/libs/linux-x86-64/libyjpagent.so");
+        return new File(getProject().getBuildDir(), "libs/linux-x86-64/libyjpagent.so");
     }
 
     @TaskAction
@@ -42,7 +43,7 @@ public class CopyYourkitAgentTask extends DefaultTask {
         InputStream src = JavaServiceDistributionPlugin.class.getResourceAsStream("/linux-x86-64/libyjpagent.so");
         Path dest = getOutputFile().toPath();
         dest.getParent().toFile().mkdirs();
-        Files.copy(src, dest);
+        Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING);
     }
 
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitLicenseTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitLicenseTask.java
@@ -18,11 +18,13 @@ package com.palantir.gradle.dist.service.tasks;
 
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import java.io.File;
-import java.net.URISyntaxException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.util.GFileUtils;
 
 public class CopyYourkitLicenseTask extends DefaultTask {
     public CopyYourkitLicenseTask() {
@@ -32,13 +34,15 @@ public class CopyYourkitLicenseTask extends DefaultTask {
 
     @OutputFile
     public final File getOutputFile() {
-        return new File(getProject().getBuildDir(), "/libs/linux-x86-64/yourkit-license-redist.txt");
+        return new File(getProject().getBuildDir() + "/libs/linux-x86-64/yourkit-license-redist.txt");
     }
 
     @TaskAction
-    public final void copyYourkitLicense() throws URISyntaxException {
-        File src = new File(JavaServiceDistributionPlugin.class.getResource("/yourkit-license-redist.txt").toURI());
-        GFileUtils.copyFile(src, getOutputFile());
+    public final void copyYourkitLicense() throws IOException {
+        InputStream src = JavaServiceDistributionPlugin.class.getResourceAsStream("/yourkit-license-redist.txt");
+        Path dest = getOutputFile().toPath();
+        dest.getParent().toFile().mkdirs();
+        Files.copy(src, dest);
     }
 
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitLicenseTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CopyYourkitLicenseTask.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -34,7 +35,7 @@ public class CopyYourkitLicenseTask extends DefaultTask {
 
     @OutputFile
     public final File getOutputFile() {
-        return new File(getProject().getBuildDir() + "/libs/linux-x86-64/yourkit-license-redist.txt");
+        return new File(getProject().getBuildDir(), "libs/linux-x86-64/yourkit-license-redist.txt");
     }
 
     @TaskAction
@@ -42,7 +43,7 @@ public class CopyYourkitLicenseTask extends DefaultTask {
         InputStream src = JavaServiceDistributionPlugin.class.getResourceAsStream("/yourkit-license-redist.txt");
         Path dest = getOutputFile().toPath();
         dest.getParent().toFile().mkdirs();
-        Files.copy(src, dest);
+        Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING);
     }
 
 }


### PR DESCRIPTION
The fix push in #387 caused it to fail in production with the following error:
```
java.lang.IllegalArgumentException: URI is not hierarchical
	at java.io.File.<init>(File.java:418)
	at com.palantir.gradle.dist.service.tasks.CopyYourkitAgentTask.copyYourkitAgent(CopyYourkitAgentTask.java:41)
```