### PR TITLE
Mention Gradle 4.3 on the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,8 @@ requirements about shared resources, such as shared disk.
 
 ## Usage
 
+_This plugin requires at least Gradle 4.3._
+
 ### Java Service Distribution plugin
 
 Apply the plugin using standard Gradle convention:


### PR DESCRIPTION
Trivial README update so we can tag a real 2.22.0 without CircleCI getting confused.