### PR TITLE
[fix] Don't include self dependencies

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -146,6 +146,10 @@ public class CreateManifestTask extends DefaultTask {
         Map<ProductId, ProductDependency> allProductDependencies = Maps.newHashMap();
         getProductDependencies().get().forEach(declaredDep -> {
             ProductId productId = new ProductId(declaredDep.getProductGroup(), declaredDep.getProductName());
+            Preconditions.checkArgument(!serviceGroup.get().equals(productId.getProductGroup())
+                    || !serviceName.get().equals(productId.getProductName()),
+                    "Invalid for product to declare an explicit dependency on itself, please remove: %s",
+                    declaredDep);
             if (getIgnoredProductIds().get().contains(productId)) {
                 throw new IllegalArgumentException(String.format(
                         "Encountered product dependency declaration that was also ignored for '%s', either remove the "

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -215,8 +215,8 @@ public class CreateManifestTask extends DefaultTask {
             }
 
             try {
-                RecommendedProductDependencies recommendedDeps = jsonMapper.readValue(pdeps.get(),
-                        RecommendedProductDependencies.class);
+                RecommendedProductDependencies recommendedDeps =
+                        jsonMapper.readValue(pdeps.get(), RecommendedProductDependencies.class);
                 return recommendedDeps.recommendedProductDependencies().stream()
                         .map(recommendedDep -> new ProductDependency(
                                 recommendedDep.getProductGroup(),

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -228,11 +228,18 @@ public class CreateManifestTask extends DefaultTask {
                 log.debug("Failed to load product dependency for artifact '{}', file '{}', '{}'", coord, artifact, e);
                 return Stream.empty();
             }
-        }).forEach(productDependency -> discoveredProductDependencies.merge(
-                new ProductId(productDependency.getProductGroup(), productDependency.getProductName()),
-                productDependency,
-                (key, oldValue) -> ProductDependencyMerger.merge(oldValue, productDependency)));
+        })
+                .filter(this::isNotSelfProductDependency)
+                .forEach(productDependency -> discoveredProductDependencies.merge(
+                        new ProductId(productDependency.getProductGroup(), productDependency.getProductName()),
+                        productDependency,
+                        (key, oldValue) -> ProductDependencyMerger.merge(oldValue, productDependency)));
         return discoveredProductDependencies;
+    }
+
+    private boolean isNotSelfProductDependency(ProductDependency dependency) {
+        return !serviceGroup.get().equals(dependency.getProductGroup())
+                || !serviceName.get().equals(dependency.getProductName());
     }
 
     private void validateProjectVersion() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskTest.groovy
@@ -16,7 +16,7 @@
 
 package com.palantir.gradle.dist.tasks
 
-
+import com.palantir.gradle.dist.ProductDependency
 import nebula.test.ProjectSpec
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -44,5 +44,23 @@ class CreateManifestTaskTest extends ProjectSpec {
         then:
         Exception exception = thrown()
         exception.message.contains("Project version must be a valid SLS version: 1.0.0foo")
+    }
+
+    def "Fails if user declares dependency on the same product"() {
+        project.version = "1.0.0"
+        CreateManifestTask task = project.tasks.create("m", CreateManifestTask)
+        task.serviceGroup = "serviceGroup"
+        task.serviceName = "serviceName"
+        task.productDependencies = [
+                new ProductDependency("serviceGroup", "serviceName", "1.1.0", "1.x.x", "1.2.0"),
+        ]
+
+        when:
+        task.createManifest()
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains 'Invalid for product to declare an explicit dependency on itself'
+
     }
 }


### PR DESCRIPTION
## Before this PR

A regression introduced in #402 meant that products which have an API that recommends _that product_ will see a product dependency on _that same product_ written to their manifest.

## After this PR

Dependencies on the same product are no longer included in the generated `manifest.yml`
