### PR TITLE
More conspicuous logging

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependency.groovy
@@ -137,4 +137,14 @@ class ProductDependency implements Serializable {
 
         return maximumOpt.get()
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s:%s(min: %s, recommended: %s, max: %s)",
+                productGroup,
+                productName,
+                minimumVersion,
+                recommendedVersion,
+                maximumVersion);
+    }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -196,6 +196,11 @@ public class CreateManifestTask extends DefaultTask {
             ModuleVersionIdentifier id = artifact.getModuleVersion().getId();
             String coord = String.format("%s:%s:%s", id.getGroup(), id.getName(), id.getVersion());
 
+            if (!artifact.getFile().exists()) {
+                log.debug("Artifact did not exist: {}", artifact.getFile());
+                return Stream.empty();
+            }
+
             Manifest manifest;
             try {
                 ZipFile zipFile = new ZipFile(artifact.getFile());

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -171,9 +171,9 @@ public class CreateManifestTask extends DefaultTask {
                     productId,
                     discoveredDependency,
                     (declaredDependency, newDependency) -> {
-                        log.warn("Encountered a declared product dependency for '{}' although there is a "
-                                + "discovered dependency, you should remove the declared dependency, discovered "
-                                + "'{}', declared '{}'", productId, discoveredDependency, declaredDependency);
+                        getLogger().error("Please remove your declared product dependency on '{}' because it is"
+                                + " already provided by a jar dependency:\n\n\tProvided: {}\n\tYou declared: {}",
+                                productId, discoveredDependency, declaredDependency);
                         return ProductDependencyMerger.merge(declaredDependency, discoveredDependency);
                     });
         });

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyTest.groovy
@@ -43,7 +43,7 @@ class ProductDependencyTest extends Specification {
         thrown(IllegalArgumentException)
     }
 
-    def 'non-deafult maximumVersion'() {
+    def 'non-default maximumVersion'() {
         when:
         def dep = new ProductDependency("", "", "1.2.3", "2.x.x", "1.2.4")
 
@@ -57,5 +57,13 @@ class ProductDependencyTest extends Specification {
 
         then:
         thrown(IllegalArgumentException)
+    }
+
+    def 'reasonable toString for logging' () {
+        when:
+        def string = new ProductDependency("com.palantir.foo", "my-service", "1.2.3", "2.x.x", "1.2.4").toString()
+
+        then:
+        string == "com.palantir.foo:my-service(min: 1.2.3, recommended: 1.2.4, max: 2.x.x)"
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -140,7 +140,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
 
         then:
         result.output.contains(
-                "Encountered a declared product dependency for 'group:name' although there is a discovered dependency")
+                "Please remove your declared product dependency on 'group:name' because it is already provided by a jar dependency")
         def manifest = CreateManifestTask.jsonMapper.readValue(file("build/deployment/manifest.yml"), Map)
         manifest.get("extensions").get("product-dependencies") == [
                 [


### PR DESCRIPTION
## Before this PR

Some pretty crucial log lines were not appearing by default and were likely being ignored:

```
Encountered a declared product dependency for 'com.palantir.timelock:timelock-server' although there is a discovered dependency, you should remove the declared dependency, discovered 'com.palantir.gradle.dist.ProductDependency(com.palantir.timelock, timelock-server, 0.51.0, null, 0.x.x)', declared 'com.palantir.gradle.dist.ProductDependency(com.palantir.timelock, timelock-server, 0.14.3, 0.14.3, 0.x.x)'
:email-service:createManifest (Thread[Execution worker for ':',5,main]) completed. Took 0.574 secs.
```

## After this PR

We now blast them at lifecycle level:

```
Please remove your declared product dependency on 'com.palantir.timelock:timelock-server' because it is already provided by a jar dependency.
        Provided: com.palantir.timelock:timelock-server(min: 0.51.0, recommended: null, max: 0.x.x)
        You declared: com.palantir.timelock:timelock-server(min: 0.14.3, recommended: 0.14.3, max: 0.x.x)
```