### PR TITLE
[improvement] `product-dependencies.lock` file & ./gradlew createManifest --write-locks

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.gradle.util.GFileUtils;
+
+public final class ProductDependencyLockFile {
+
+    private static final String HEADER = "# Run ./gradlew --write-locks to regenerate this file\n";
+    private static final Pattern REGEX =
+            Pattern.compile("^(?<group>[^:]+):(?<name>[^: ]+) \\((?<min>[^,]+), (?<max>[^)]+)\\)$");
+
+    public static List<ProductDependency> fromFile(File file) {
+        try {
+            return Files.lines(file.toPath())
+                    .filter(line -> !isComment(line))
+                    .map(ProductDependencyLockFile::parseLine)
+                    .collect(toList());
+        } catch (IOException e) {
+            throw new RuntimeException("TODO");
+        }
+    }
+
+    public static void writeToFile(File file, List<ProductDependency> deps) {
+        String contents = deps.stream()
+                .map(dep -> String.format("%s:%s (%s, %s)",
+                        dep.getProductGroup(),
+                        dep.getProductName(),
+                        dep.getMinimumVersion(),
+                        dep.getMaximumVersion()))
+                .collect(Collectors.joining("\n", HEADER, ""));
+
+        GFileUtils.writeFile(contents, file);
+    }
+
+    private static ProductDependency parseLine(String line) {
+        Matcher matcher = REGEX.matcher(line);
+        Preconditions.checkState(matcher.matches(), "line must match: %s", line);
+        return new ProductDependency(
+                matcher.group("group"),
+                matcher.group("name"),
+                matcher.group("min"),
+                matcher.group("max"),
+                null);
+    }
+
+    private static boolean isComment(String line) {
+        return line.startsWith("#") || line.trim().isEmpty();
+    }
+}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -31,7 +31,7 @@ public final class ProductDependencyLockFile {
                             dep.getMinimumVersion(),
                             dep.getMaximumVersion()))
                     .sorted()
-                    .collect(Collectors.joining("\n", HEADER, "\n"));
+                    .collect(Collectors.joining("\n", HEADER, ""));
     }
 
     private ProductDependencyLockFile() {}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -16,59 +16,23 @@
 
 package com.palantir.gradle.dist;
 
-import static java.util.stream.Collectors.toList;
-
-import com.google.common.base.Preconditions;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.gradle.util.GFileUtils;
 
 public final class ProductDependencyLockFile {
 
     private static final String HEADER = "# Run ./gradlew --write-locks to regenerate this file\n";
-    private static final Pattern REGEX =
-            Pattern.compile("^(?<group>[^:]+):(?<name>[^: ]+) \\((?<min>[^,]+), (?<max>[^)]+)\\)$");
 
-    public static List<ProductDependency> fromFile(File file) {
-        try {
-            return Files.lines(file.toPath())
-                    .filter(line -> !isComment(line))
-                    .map(ProductDependencyLockFile::parseLine)
-                    .collect(toList());
-        } catch (IOException e) {
-            throw new RuntimeException("TODO");
-        }
+    public static String asString(List<ProductDependency> deps) {
+        return deps.stream()
+                    .map(dep -> String.format("%s:%s (%s, %s)",
+                            dep.getProductGroup(),
+                            dep.getProductName(),
+                            dep.getMinimumVersion(),
+                            dep.getMaximumVersion()))
+                    .sorted()
+                    .collect(Collectors.joining("\n", HEADER, ""));
     }
 
-    public static void writeToFile(File file, List<ProductDependency> deps) {
-        String contents = deps.stream()
-                .map(dep -> String.format("%s:%s (%s, %s)",
-                        dep.getProductGroup(),
-                        dep.getProductName(),
-                        dep.getMinimumVersion(),
-                        dep.getMaximumVersion()))
-                .collect(Collectors.joining("\n", HEADER, ""));
-
-        GFileUtils.writeFile(contents, file);
-    }
-
-    private static ProductDependency parseLine(String line) {
-        Matcher matcher = REGEX.matcher(line);
-        Preconditions.checkState(matcher.matches(), "line must match: %s", line);
-        return new ProductDependency(
-                matcher.group("group"),
-                matcher.group("name"),
-                matcher.group("min"),
-                matcher.group("max"),
-                null);
-    }
-
-    private static boolean isComment(String line) {
-        return line.startsWith("#") || line.trim().isEmpty();
-    }
+    private ProductDependencyLockFile() {}
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -31,7 +31,7 @@ public final class ProductDependencyLockFile {
                             dep.getMinimumVersion(),
                             dep.getMaximumVersion()))
                     .sorted()
-                    .collect(Collectors.joining("\n", HEADER, ""));
+                    .collect(Collectors.joining("\n", HEADER, "\n"));
     }
 
     private ProductDependencyLockFile() {}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -214,7 +214,6 @@ public class CreateManifestTask extends DefaultTask {
             GFileUtils.writeFile(ProductDependencyLockFile.asString(productDependencies), lockfile);
         } else {
             String latest = ProductDependencyLockFile.asString(productDependencies);
-            System.out.println("ACTUAL" + latest);
             String fromDisk = GFileUtils.readFile(lockfile);
             Preconditions.checkState(
                     fromDisk.equals(latest),

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -234,16 +234,17 @@ public class CreateManifestTask extends DefaultTask {
         File lockfile = getProject().file("product-dependencies.lock");
         Path relativePath = getProject().getRootDir().toPath().relativize(lockfile.toPath());
         String upToDateContents = ProductDependencyLockFile.asString(productDeps);
+        boolean lockfileExists = lockfile.exists();
 
         if (getProject().getGradle().getStartParameter().isWriteDependencyLocks()) {
             GFileUtils.writeFile(upToDateContents, lockfile);
-            if (!lockfile.exists()) {
+            if (!lockfileExists) {
                 getLogger().lifecycle("Created {}\n\t{}", relativePath, upToDateContents.replaceAll("\n", "\n\t"));
-            } else if (!GFileUtils.readFile(lockfile).equals(upToDateContents)) {
+            } else {
                 getLogger().lifecycle("Updated {}", relativePath);
             }
         } else {
-            if (!lockfile.exists()) {
+            if (!lockfileExists) {
                 throw new GradleException(String.format(
                         "%s does not exist, please run `./gradlew %s --write-locks` and commit the resultant file",
                         relativePath, getName()));

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -257,7 +257,7 @@ public class CreateManifestTask extends DefaultTask {
         }
     }
 
-    /** Provide a rich diff so the user understands what change will be made before they run --write-locks */
+    /** Provide a rich diff so the user understands what change will be made before they run --write-locks. */
     private Optional<String> diff(File existing, String upToDateContents) {
         try {
             File tempFile = Files.createTempFile("product-dependencies", "lock").toFile();

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -184,9 +184,9 @@ public class CreateManifestTask extends DefaultTask {
                         return ProductDependencyMerger.merge(declaredDependency, discoveredDependency);
                     });
         });
-        List<ProductDependency> productDependencies = new ArrayList<>(allProductDependencies.values());
+        List<ProductDependency> productDeps = new ArrayList<>(allProductDependencies.values());
 
-        ensureLockfileIsUpToDate(productDependencies);
+        ensureLockfileIsUpToDate(productDeps);
 
         jsonMapper.writeValue(getManifestFile(), SlsManifest.builder()
                 .manifestVersion("1.0")
@@ -195,12 +195,12 @@ public class CreateManifestTask extends DefaultTask {
                 .productName(serviceName.get())
                 .productVersion(getProjectVersion())
                 .putAllExtensions(manifestExtensions)
-                .putExtensions("product-dependencies", productDependencies)
+                .putExtensions("product-dependencies", productDeps)
                 .build()
         );
     }
 
-    private void ensureLockfileIsUpToDate(List<ProductDependency> productDependencies) {
+    private void ensureLockfileIsUpToDate(List<ProductDependency> productDeps) {
         File lockfile = getProject().file("product-dependencies.lock");
         Path relativePath = getProject().getRootDir().toPath().relativize(lockfile.toPath());
 
@@ -211,9 +211,9 @@ public class CreateManifestTask extends DefaultTask {
         }
 
         if (getProject().getGradle().getStartParameter().isWriteDependencyLocks()) {
-            GFileUtils.writeFile(ProductDependencyLockFile.asString(productDependencies), lockfile);
+            GFileUtils.writeFile(ProductDependencyLockFile.asString(productDeps), lockfile);
         } else {
-            String latest = ProductDependencyLockFile.asString(productDependencies);
+            String latest = ProductDependencyLockFile.asString(productDeps);
             String fromDisk = GFileUtils.readFile(lockfile);
             Preconditions.checkState(
                     fromDisk.equals(latest),

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -28,10 +28,10 @@ class ProductDependencyLockFileTest extends Specification {
         ]
 
         then:
-        ProductDependencyLockFile.asString(sample) == """
+        ProductDependencyLockFile.asString(sample) == """\
         # Run ./gradlew --write-locks to regenerate this file
         com.palantir.other:bar (0.2.0, 0.x.x)
         com.palantir.product:foo (1.20.0, 1.x.x)
-        """.stripIndent().trim()
+        """.stripIndent()
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -16,12 +16,11 @@
 
 package com.palantir.gradle.dist
 
-
 import spock.lang.Specification
 
 class ProductDependencyLockFileTest extends Specification {
 
-    def 'serialize' () {
+    def 'serialize'() {
         when:
         List<ProductDependency> sample = [
                 new ProductDependency("com.palantir.product", "foo", "1.20.0", "1.x.x", null),

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -30,8 +30,8 @@ class ProductDependencyLockFileTest extends Specification {
         then:
         ProductDependencyLockFile.asString(sample) == """
         # Run ./gradlew --write-locks to regenerate this file
-        com.palantir.product:foo (1.20.0, 1.x.x)
         com.palantir.other:bar (0.2.0, 0.x.x)
+        com.palantir.product:foo (1.20.0, 1.x.x)
         """.stripIndent().trim()
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -16,52 +16,23 @@
 
 package com.palantir.gradle.dist
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
+
 import spock.lang.Specification
 
 class ProductDependencyLockFileTest extends Specification {
 
-    private static final List<ProductDependency> sample = [
-            new ProductDependency("com.palantir.product", "foo", "1.20.0", "1.x.x", null),
-            new ProductDependency("com.palantir.other", "bar", "0.2.0", "0.x.x", null)
-    ]
-
-    @Rule
-    TemporaryFolder folder = new TemporaryFolder()
-
-    def 'deserialize' () {
-        when:
-        def file = folder.newFile("whatever.lock")
-        file << """
-        # Run ./gradlew --write-locks to regenerate this file
-        com.palantir.product:foo (1.20.0, 1.x.x)
-        com.palantir.other:bar (0.2.0, 0.x.x)
-        """.stripIndent()
-
-        then:
-        ProductDependencyLockFile.fromFile(file) == sample
-    }
-
     def 'serialize' () {
         when:
-        def file = folder.newFile("whatever.lock")
-        ProductDependencyLockFile.writeToFile(file, sample)
+        List<ProductDependency> sample = [
+                new ProductDependency("com.palantir.product", "foo", "1.20.0", "1.x.x", null),
+                new ProductDependency("com.palantir.other", "bar", "0.2.0", "0.x.x", null)
+        ]
 
         then:
-        file.text == """
+        ProductDependencyLockFile.asString(sample) == """
         # Run ./gradlew --write-locks to regenerate this file
         com.palantir.product:foo (1.20.0, 1.x.x)
         com.palantir.other:bar (0.2.0, 0.x.x)
         """.stripIndent().trim()
-    }
-
-    def 'round-trip' () {
-        when:
-        def file = folder.newFile("whatever.lock")
-        ProductDependencyLockFile.writeToFile(file, sample)
-
-        then:
-        ProductDependencyLockFile.fromFile(file) == sample
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ProductDependencyLockFileTest extends Specification {
+
+    private static final List<ProductDependency> sample = [
+            new ProductDependency("com.palantir.product", "foo", "1.20.0", "1.x.x", null),
+            new ProductDependency("com.palantir.other", "bar", "0.2.0", "0.x.x", null)
+    ]
+
+    @Rule
+    TemporaryFolder folder = new TemporaryFolder()
+
+    def 'deserialize' () {
+        when:
+        def file = folder.newFile("whatever.lock")
+        file << """
+        # Run ./gradlew --write-locks to regenerate this file
+        com.palantir.product:foo (1.20.0, 1.x.x)
+        com.palantir.other:bar (0.2.0, 0.x.x)
+        """.stripIndent()
+
+        then:
+        ProductDependencyLockFile.fromFile(file) == sample
+    }
+
+    def 'serialize' () {
+        when:
+        def file = folder.newFile("whatever.lock")
+        ProductDependencyLockFile.writeToFile(file, sample)
+
+        then:
+        file.text == """
+        # Run ./gradlew --write-locks to regenerate this file
+        com.palantir.product:foo (1.20.0, 1.x.x)
+        com.palantir.other:bar (0.2.0, 0.x.x)
+        """.stripIndent().trim()
+    }
+
+    def 'round-trip' () {
+        when:
+        def file = folder.newFile("whatever.lock")
+        ProductDependencyLockFile.writeToFile(file, sample)
+
+        then:
+        ProductDependencyLockFile.fromFile(file) == sample
+    }
+}

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -124,11 +124,11 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
                 }
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """
+        file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
         group1:name1 (1.0.0, 2.0.0)
         group2:name2 (1.0.0, 2.x.x)
-        """.stripIndent().trim()
+        """.stripIndent()
 
         when:
         runTasks(':distTar', ':untar')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -124,6 +124,11 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
                 }
             }
         """.stripIndent()
+        file('product-dependencies.lock').text = """
+        # Run ./gradlew --write-locks to regenerate this file
+        group1:name1 (1.0.0, 2.0.0)
+        group2:name2 (1.0.0, 2.x.x)
+        """.stripIndent().trim()
 
         when:
         runTasks(':distTar', ':untar')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -293,6 +293,11 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
                 }
             }
         """.stripIndent()
+        file('product-dependencies.lock').text = """
+        # Run ./gradlew --write-locks to regenerate this file
+        group1:name1 (1.0.0, 1.3.x)
+        group2:name2 (1.0.0, 1.x.x)
+        """.stripIndent().trim()
 
         when:
         runTasks(':build', ':distTar', ':untar')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -293,11 +293,11 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
                 }
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """
+        file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
         group2:name2 (1.0.0, 1.x.x)
-        """.stripIndent().trim()
+        """.stripIndent()
 
         when:
         runTasks(':build', ':distTar', ':untar')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -297,10 +297,6 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         manifest.get("extensions").get("product-dependencies").isEmpty()
     }
 
-    String emptyLockfile() {
-        return "# Run ./gradlew --write-locks to regenerate this file\n"
-    }
-
     def 'filters out recommended product dependency on self'() {
         setup:
         buildFile << """
@@ -334,7 +330,6 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 args 'server', 'var/conf/my-service.yml'
             }
         """.stripIndent())
-        file('foo-server/product-dependencies.lock').delete()
 
         when:
         runTasks(':foo-server:createManifest', '-i')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -50,6 +50,11 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 productDependenciesConfig = configurations.runtime
             }
         """.stripIndent()
+        file('product-dependencies.lock') << """
+        # Run ./gradlew --write-locks to regenerate this file
+        group:name (1.0.0, 1.x.x)
+        group:name2 (2.0.0, 2.x.x)
+        """.stripIndent().trim()
     }
 
     def 'throws if duplicate dependencies are declared'() {
@@ -97,6 +102,11 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 runtime 'a:a:1.0'
             }
         """.stripIndent()
+        file('product-dependencies.lock') << """
+        # Run ./gradlew --write-locks to regenerate this file
+        group:name (1.0.0, 1.x.x)
+        group:name2 (2.0.0, 2.x.x)
+        """.stripIndent().trim()
 
         when:
         runTasks(':testCreateManifest')
@@ -134,6 +144,11 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 ]
             }
         """.stripIndent()
+        file('product-dependencies.lock').text = """
+        # Run ./gradlew --write-locks to regenerate this file
+        group:name (1.1.0, 1.x.x)
+        group:name2 (2.0.0, 2.x.x)
+        """.stripIndent().trim()
 
         when:
         def result = runTasks(':testCreateManifest')
@@ -175,6 +190,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 ]
             }
         """.stripIndent()
+        file('product-dependencies.lock').text = emptyLockfile()
 
         when:
         runTasks(':testCreateManifest')
@@ -192,6 +208,10 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 runtime 'd:d:1.0'
             }
         """.stripIndent()
+        file('product-dependencies.lock').text = """
+        # Run ./gradlew --write-locks to regenerate this file
+        group:name2 (2.1.0, 2.6.x)
+        """.stripIndent().trim()
 
         when:
         runTasks(':testCreateManifest')
@@ -246,6 +266,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 serviceName = "name2"
             }
         """.stripIndent()
+        file('product-dependencies.lock').text = emptyLockfile()
 
         when:
         runTasks(':testCreateManifest')
@@ -253,6 +274,10 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         then:
         def manifest = CreateManifestTask.jsonMapper.readValue(file('build/deployment/manifest.yml').text, Map)
         manifest.get("extensions").get("product-dependencies").isEmpty()
+    }
+
+    String emptyLockfile() {
+        return "# Run ./gradlew --write-locks to regenerate this file\n"
     }
 
     def 'filters out recommended product dependency on self'() {
@@ -288,6 +313,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 args 'server', 'var/conf/my-service.yml'
             }
         """.stripIndent())
+        file('foo-server/product-dependencies.lock').text = emptyLockfile()
 
         when:
         runTasks(':foo-server:createManifest', '-i')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -50,11 +50,11 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 productDependenciesConfig = configurations.runtime
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """
+        file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
         group:name (1.0.0, 1.x.x)
         group:name2 (2.0.0, 2.x.x)
-        """.stripIndent().trim()
+        """.stripIndent()
     }
 
     def 'throws if duplicate dependencies are declared'() {
@@ -102,11 +102,11 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 runtime 'a:a:1.0'
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """
+        file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
         group:name (1.0.0, 1.x.x)
         group:name2 (2.0.0, 2.x.x)
-        """.stripIndent().trim()
+        """.stripIndent()
 
         when:
         runTasks(':testCreateManifest')
@@ -144,11 +144,11 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 ]
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """
+        file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
         group:name (1.1.0, 1.x.x)
         group:name2 (2.0.0, 2.x.x)
-        """.stripIndent().trim()
+        """.stripIndent()
 
         when:
         def result = runTasks(':testCreateManifest')
@@ -208,10 +208,10 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 runtime 'd:d:1.0'
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """
+        file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
         group:name2 (2.0.0, 2.x.x)
-        """.stripIndent().trim()
+        """.stripIndent()
 
         when:
         runTasks(':testCreateManifest')
@@ -238,10 +238,10 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 runtime 'e:e:1.0'
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """
+        file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
         group:name2 (2.1.0, 2.6.x)
-        """.stripIndent().trim()
+        """.stripIndent()
 
         when:
         runTasks(':testCreateManifest')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -102,7 +102,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 runtime 'a:a:1.0'
             }
         """.stripIndent()
-        file('product-dependencies.lock') << """
+        file('product-dependencies.lock').text = """
         # Run ./gradlew --write-locks to regenerate this file
         group:name (1.0.0, 1.x.x)
         group:name2 (2.0.0, 2.x.x)
@@ -210,7 +210,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         """.stripIndent()
         file('product-dependencies.lock').text = """
         # Run ./gradlew --write-locks to regenerate this file
-        group:name2 (2.1.0, 2.6.x)
+        group:name2 (2.0.0, 2.x.x)
         """.stripIndent().trim()
 
         when:
@@ -238,6 +238,10 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 runtime 'e:e:1.0'
             }
         """.stripIndent()
+        file('product-dependencies.lock').text = """
+        # Run ./gradlew --write-locks to regenerate this file
+        group:name2 (2.1.0, 2.6.x)
+        """.stripIndent().trim()
 
         when:
         runTasks(':testCreateManifest')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -50,7 +50,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 productDependenciesConfig = configurations.runtime
             }
         """.stripIndent()
-        file('product-dependencies.lock') << """
+        file('product-dependencies.lock').text = """
         # Run ./gradlew --write-locks to regenerate this file
         group:name (1.0.0, 1.x.x)
         group:name2 (2.0.0, 2.x.x)
@@ -190,7 +190,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 ]
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = emptyLockfile()
+        file('product-dependencies.lock').delete()
 
         when:
         runTasks(':testCreateManifest')
@@ -270,7 +270,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 serviceName = "name2"
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = emptyLockfile()
+        file('product-dependencies.lock').delete()
 
         when:
         runTasks(':testCreateManifest')
@@ -317,7 +317,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 args 'server', 'var/conf/my-service.yml'
             }
         """.stripIndent())
-        file('foo-server/product-dependencies.lock').text = emptyLockfile()
+        file('foo-server/product-dependencies.lock').delete()
 
         when:
         runTasks(':foo-server:createManifest', '-i')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -57,6 +57,23 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         """.stripIndent()
     }
 
+    def 'fails if lockfile is not up to date'() {
+        buildFile << """
+            testCreateManifest {
+                productDependencies = [
+                    new com.palantir.gradle.dist.ProductDependency("group", "name", "1.0.0", "1.x.x", "1.2.0"),
+                ]
+            }
+        """.stripIndent()
+
+        when:
+        def buildResult = runTasksAndFail(':testCreateManifest')
+
+        then:
+        buildResult.output.contains(
+                "product-dependencies.lock is out of date, please run `./gradlew testCreateManifest --write-locks` to update it")
+    }
+
     def 'throws if duplicate dependencies are declared'() {
         setup:
         buildFile << """

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ And the complete list of configurable properties:
 
 ## Product dependencies
 
-'Product dependencies' are declarative metadata about the services your product/asset/pod requires in order to function. When you run `./gradlew distTar`, your product dependencies are embedded in the resultant dist in the `deployment/manifest.yml` file.
+'Product dependencies' are declarative metadata about the products your product/asset/pod requires in order to function. When you run `./gradlew distTar`, your product dependencies are embedded in the resultant dist in the `deployment/manifest.yml` file.
 
 Most of your product dependencies should be inferred automatically from on the libraries you depend on.  Any one of these jars may contain an embedded 'recommended product dependency' in its MANIFEST.MF (embedded using the [Recommended Product Dependencies Plugin][]).
 


### PR DESCRIPTION
## Before this PR

As part of the sls-packaging 2.X -> 3.X push, we are asking people to delete all the explicit code that defines their product dependencies and instead rely on sls-packaging to magically infer them from manifest entries discovered in their runtimeClasspath.

```diff
-productDependency {
-  productGroup = 'com.palantir.timelock'
-  productName = 'timelock'
-  detectConstraints = true
-}
```

This is a bit scary for people because it means an automated PR that upgrades some dependencies might actually cause a silent change to your product dependencies (which can greatly limit the ability to deploy your product) - this would be impossible to catch in code review.

## After this PR

Any project that produces a manifest will now have a new `product-dependencies.lock` file, checked in to their repo, e.g.:

```
# Run ./gradlew --write-locks to regenerate this file
com.palantir.timelock:timelock (0.51.0, 0.x.x)
com.palantir.foo:bar (2.12.0, 2.x.x)
```

The createManifest task _will fail_ if this lockfile is not up to date - this ensures that the checked-in representation of your product dependencies always accurately reflects the current state of the world.

```
* What went wrong:
Execution failed for task ':some-service:createManifest'.
> some-service/product-dependencies.lock is out of date, please run `./gradlew createManifest --write-locks` to update it:
  @@ -1,6 +1,6 @@
   # Run ./gradlew --write-locks to regenerate this file
   com.palantir.cassandra:sls-cassandra (3.24.0, 3.x.x)
  -com.palantir.baz:baz (3.12.1, 3.x.x)
  +com.palantir.baz:baz (3.13.1, 3.x.x)
   com.palantir.rescue:rescue (3.22.0, 4.x.x)
   com.palantir.other:product (1.18.1, 1.x.x)
   com.palantir.foo:bar (0.51.0, 0.x.x)
```

There's an added bonus that since we only allow policy-bot to auto-approve excavator PRs that touch certain whitelisted files, any automated changes to this product-dependencies.lock file will not be auto-approved.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
