### PR TITLE
[feature] Configure ignored product id via closure

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -194,6 +194,7 @@ public class BaseDistributionExtension {
     public final void ignoredProductDependency(@DelegatesTo(ProductId.class) Closure closure) {
         ProductId id = new ProductId();
         ConfigureUtil.configureUsing(closure).execute(id);
+        id.isValid();
         this.ignoredProductDependencies.add(id);
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -191,6 +191,12 @@ public class BaseDistributionExtension {
         this.ignoredProductDependencies.add(new ProductId(ignoredProductId));
     }
 
+    public final void ignoredProductDependency(@DelegatesTo(ProductId.class) Closure closure) {
+        ProductId id = new ProductId();
+        ConfigureUtil.configureUsing(closure).execute(id);
+        this.ignoredProductDependencies.add(id);
+    }
+
     public final Map<String, Object> getManifestExtensions() {
         return this.manifestExtensions;
     }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductId.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductId.groovy
@@ -28,6 +28,8 @@ class ProductId implements Serializable {
     String productGroup
     String productName
 
+    ProductId() {}
+
     ProductId(String productGroup, String productName) {
         this.productGroup = productGroup
         this.productName = productName

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductId.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductId.groovy
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist
 
+import com.google.common.base.Preconditions
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 
@@ -47,5 +48,10 @@ class ProductId implements Serializable {
     @Override
     String toString() {
         return productGroup + ":" + productName
+    }
+
+    void isValid() {
+        Preconditions.checkNotNull(productGroup, "productGroup must be specified")
+        Preconditions.checkNotNull(productName, "productName must be specified")
     }
 }


### PR DESCRIPTION
## Before this PR

Can only create an ignored product dependency via methods taking values.

## After this PR

Can use a closure to configure the `ignoredProductDependency` just like you can with `productDependency`.

Fixes #351 