### PR TITLE
[fix] Mask minimum dependency from lockfile on service pubished in repo if same as project version

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -17,21 +17,30 @@
 package com.palantir.gradle.dist;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class ProductDependencyLockFile {
 
     private static final String HEADER = "# Run ./gradlew --write-locks to regenerate this file\n";
 
-    public static String asString(List<ProductDependency> deps) {
-        return deps.stream()
-                    .map(dep -> String.format("%s:%s (%s, %s)",
-                            dep.getProductGroup(),
-                            dep.getProductName(),
-                            dep.getMinimumVersion(),
-                            dep.getMaximumVersion()))
-                    .sorted()
-                    .collect(Collectors.joining("\n", HEADER, "\n"));
+    public static String asString(
+            List<ProductDependency> deps, Set<ProductId> servicesDeclaredInProject, String projectVersion) {
+        return deps.stream().map(dep -> String.format(
+                "%s:%s (%s, %s)",
+                dep.getProductGroup(),
+                dep.getProductName(), renderDepMinimumVersion(servicesDeclaredInProject, projectVersion, dep),
+                dep.getMaximumVersion())).sorted().collect(Collectors.joining("\n", HEADER, "\n"));
+    }
+
+    private static String renderDepMinimumVersion(
+            Set<ProductId> servicesDeclaredInProject, String projectVersion, ProductDependency dep) {
+        ProductId productId = new ProductId(dep.getProductGroup(), dep.getProductName());
+        if (servicesDeclaredInProject.contains(productId) && dep.getMinimumVersion().equals(projectVersion)) {
+            return "project-version";
+        } else {
+            return dep.getMinimumVersion();
+        }
     }
 
     private ProductDependencyLockFile() {}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -38,7 +38,7 @@ public final class ProductDependencyLockFile {
             Set<ProductId> servicesDeclaredInProject, String projectVersion, ProductDependency dep) {
         ProductId productId = new ProductId(dep.getProductGroup(), dep.getProductName());
         if (servicesDeclaredInProject.contains(productId) && dep.getMinimumVersion().equals(projectVersion)) {
-            return "project-version";
+            return "$projectVersion";
         } else {
             return dep.getMinimumVersion();
         }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -34,6 +34,12 @@ public final class ProductDependencyLockFile {
                 dep.getMaximumVersion())).sorted().collect(Collectors.joining("\n", HEADER, "\n"));
     }
 
+    /**
+     * If a product ends up taking a product dependency on another product that's published in the same repo,
+     * and the minimum version in that dependency tracks the project's version, then the lock file would have to be
+     * regenerated every commit, such that all PRs will end up conflicting with each other.
+     * To avoid this, we replace the minimum version of such dependencies with a placeholder, {@code $projectVersion}.
+     */
     private static String renderDepMinimumVersion(
             Set<ProductId> servicesDeclaredInProject, String projectVersion, ProductDependency dep) {
         ProductId productId = new ProductId(dep.getProductGroup(), dep.getProductName());

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -29,7 +29,8 @@ public final class ProductDependencyLockFile {
         return deps.stream().map(dep -> String.format(
                 "%s:%s (%s, %s)",
                 dep.getProductGroup(),
-                dep.getProductName(), renderDepMinimumVersion(servicesDeclaredInProject, projectVersion, dep),
+                dep.getProductName(),
+                renderDepMinimumVersion(servicesDeclaredInProject, projectVersion, dep),
                 dep.getMaximumVersion())).sorted().collect(Collectors.joining("\n", HEADER, "\n"));
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist
 
+
 import spock.lang.Specification
 
 class ProductDependencyLockFileTest extends Specification {
@@ -28,7 +29,7 @@ class ProductDependencyLockFileTest extends Specification {
         ]
 
         then:
-        ProductDependencyLockFile.asString(sample) == """\
+        ProductDependencyLockFile.asString(sample, [] as Set<ProductId>, '0.0.0') == """\
         # Run ./gradlew --write-locks to regenerate this file
         com.palantir.other:bar (0.2.0, 0.x.x)
         com.palantir.product:foo (1.20.0, 1.x.x)

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -44,7 +44,6 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
             // If we create a custom task and then do --write-locks, the original task will be invoked anyway
             // So, let's just configure the original task, yea?
             tasks.createManifest {
-                dependsOn = [] // don't want to test these dependencies
                 serviceName = "serviceName"
                 serviceGroup = "serviceGroup"
                 productType = ProductType.SERVICE_V1

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -389,7 +389,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         runTasks('--write-locks')
 
         then:
-        file('bar-server/product-dependencies.lock').readLines().contains 'com.palantir.group:foo-service (project-version, 1.x.x)'
+        file('bar-server/product-dependencies.lock').readLines().contains 'com.palantir.group:foo-service ($projectVersion, 1.x.x)'
     }
 
     def 'does not mask minimum version in product dependency that is published by this repo if different from project version'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -290,7 +290,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         file('product-dependencies.lock').delete()
 
         when:
-        runTasks(':testCreateManifest')
+        runTasks(':testCreateManifest', '--write-locks')
 
         then:
         def manifest = CreateManifestTask.jsonMapper.readValue(file('build/deployment/manifest.yml').text, Map)

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -295,6 +295,8 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         then:
         def manifest = CreateManifestTask.jsonMapper.readValue(file('build/deployment/manifest.yml').text, Map)
         manifest.get("extensions").get("product-dependencies").isEmpty()
+
+        !fileExists('product-dependencies.lock')
     }
 
     def 'filters out recommended product dependency on self'() {
@@ -334,8 +336,8 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         when:
         runTasks(':foo-server:createManifest', '-i')
 
-        then:
-        true
+        then: 'foo-server does not include transitively discovered self dependency'
+        !fileExists('foo-server/product-dependencies.lock')
     }
 
     def generateDependencies() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -334,7 +334,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         """.stripIndent())
 
         when:
-        runTasks(':foo-server:createManifest', '-i')
+        runTasks(':foo-server:createManifest', '-i', '--write-locks')
 
         then: 'foo-server does not include transitively discovered self dependency'
         !fileExists('foo-server/product-dependencies.lock')


### PR DESCRIPTION
## Before this PR

If there are multiple services in a single repo and there are interdependencies, then the project's version (which changes with every commit) gets written to some product-dependencies.lock files, forcing them to change with every commit.

This is undesirable as it will cause every PR to conflict.

## After this PR

Mask the minimum version of a product dependency, if it refers to a service published in the same repo, and the version is the same as that project's version.