### PR TITLE
[improvement] Handle non jar artifacts in createManifestTask

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -289,6 +289,9 @@ public class CreateManifestTask extends DefaultTask {
             if (!artifact.getFile().exists()) {
                 log.debug("Artifact did not exist: {}", artifact.getFile());
                 return Stream.empty();
+            } else if (!artifact.getExtension().equals("jar")) {
+                log.debug("Artifact is not jar: {}", artifact.getFile());
+                return Stream.empty();
             }
 
             Manifest manifest;


### PR DESCRIPTION
## Before this PR
Large stack traces were logged if a non-jar artifact was encountered

## After this PR
We specifically handle this case, reducing the noise

@robert3005 for SA
