### PR TITLE
[fix] Re-run CreateManifestTask if lock file changed

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -232,6 +232,10 @@ public class CreateManifestTask extends DefaultTask {
         }
     }
 
+    /**
+     * Intentionally checking whether file exists as gradle's {@link org.gradle.api.tasks.Optional} only operates on
+     * whether the method returns null or not. Otherwise, it will fail when the file doesn't exist.
+     */
     @InputFile
     @org.gradle.api.tasks.Optional
     final File getLockfileIfExists() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -62,6 +62,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -231,8 +232,17 @@ public class CreateManifestTask extends DefaultTask {
         }
     }
 
-    @OutputFile
-    final File getLockfile() {
+    @InputFile
+    @org.gradle.api.tasks.Optional
+    final File getLockfileIfExists() {
+        File file = getLockfile();
+        if (file.exists()) {
+            return file;
+        }
+        return null;
+    }
+
+    private File getLockfile() {
         return getProject().file(ProductDependencyLockFile.LOCK_FILE);
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -214,7 +214,7 @@ public class CreateManifestTask extends DefaultTask {
     }
 
     private void requireAbsentLockfile() {
-        File lockfile = getProject().file("product-dependencies.lock");
+        File lockfile = getLockfile();
         Path relativePath = getProject().getRootDir().toPath().relativize(lockfile.toPath());
 
         if (!lockfile.exists()) {
@@ -231,8 +231,13 @@ public class CreateManifestTask extends DefaultTask {
         }
     }
 
+    @OutputFile
+    final File getLockfile() {
+        return getProject().file(ProductDependencyLockFile.LOCK_FILE);
+    }
+
     private void ensureLockfileIsUpToDate(List<ProductDependency> productDeps) {
-        File lockfile = getProject().file(ProductDependencyLockFile.LOCK_FILE);
+        File lockfile = getLockfile();
         Path relativePath = getProject().getRootDir().toPath().relativize(lockfile.toPath());
         String upToDateContents = ProductDependencyLockFile.asString(
                 productDeps, collectProductsPublishedInRepo(), getProjectVersion());

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -52,14 +52,23 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 productDependenciesConfig = configurations.runtime
             }
         """.stripIndent()
-        file('product-dependencies.lock').text = """\
-        # Run ./gradlew --write-locks to regenerate this file
-        group:name (1.0.0, 1.x.x)
-        group:name2 (2.0.0, 2.x.x)
-        """.stripIndent()
     }
 
     def 'fails if lockfile is not up to date'() {
+        buildFile << """
+            dependencies {
+                runtime 'b:b:1.0'
+            }
+        """.stripIndent()
+
+        file('product-dependencies.lock').text = """\
+            # Run ./gradlew --write-locks to regenerate this file
+            group:name2 (2.0.0, 2.x.x)
+        """.stripIndent()
+
+        // run it first to ensure cache is warmed up
+        runTasks(':createManifest')
+
         buildFile << """
             createManifest {
                 productDependencies = [

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -86,7 +86,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 "product-dependencies.lock is out of date, please run `./gradlew createManifest --write-locks` to update it")
     }
 
-    def 'fails if lockfile has suddenly appeared since last invocation'() {
+    def 'fails if unexpected lockfile exists'() {
         runTasks('createManifest') // ensure task is run once
         runTasks('createManifest').task(':createManifest').outcome == TaskOutcome.UP_TO_DATE
 
@@ -97,7 +97,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         runTasksAndFail('createManifest').task(':createManifest').outcome == TaskOutcome.FAILED
     }
 
-    def 'fails if lockfile has suddenly disappeared since last invocation'() {
+    def 'fails if lock file disappears'() {
         buildFile << """
             dependencies {
                 runtime 'b:b:1.0'
@@ -119,7 +119,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         runTasksAndFail('createManifest').task(':createManifest').outcome == TaskOutcome.FAILED
     }
 
-    def 'fails if lockfile has changed contents since last invocation'() {
+    def 'fails if lockfile has changed contents'() {
         buildFile << """
             dependencies {
                 runtime 'b:b:1.0'


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR

Modifying the `product-dependencies.lock` file after it has been written would not cause `createManifest` to re-run (it would be considered UP_TO_DATE), which means it wouldn't verify if the locks are still correct.

## After this PR

Mark `product-dependencies.lock` as an _input_ of CreateManifestTask, so the task is re-run if the file changed.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
