### PR TITLE
[fix] createManifest is always run as part of check

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -386,6 +386,9 @@ public class CreateManifestTask extends DefaultTask {
                 });
         project.afterEvaluate(p ->
                 createManifest.configure(task -> task.setManifestExtensions(ext.getManifestExtensions())));
+        project.getPluginManager().withPlugin("base", p -> {
+            project.getTasks().getByName("check").dependsOn(createManifest);
+        });
 
         // We want `./gradlew --write-locks` to magically fix up the product-dependencies.lock file
         // We can't do this at configuration time because it would mess up gradle-consistent-versions.

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -66,6 +66,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.GFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -386,8 +387,8 @@ public class CreateManifestTask extends DefaultTask {
                 });
         project.afterEvaluate(p ->
                 createManifest.configure(task -> task.setManifestExtensions(ext.getManifestExtensions())));
-        project.getPluginManager().withPlugin("base", p -> {
-            project.getTasks().getByName("check").dependsOn(createManifest);
+        project.getPluginManager().withPlugin("lifecycle-base", p -> {
+            project.getTasks().getByName(LifecycleBasePlugin.CHECK_TASK_NAME).dependsOn(createManifest);
         });
 
         // We want `./gradlew --write-locks` to magically fix up the product-dependencies.lock file

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -508,8 +508,6 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
     }
 
     def "check depends on createManifest"() {
-        file("product-dependencies.lock").delete()
-
         when:
         def result = runTasks(':check')
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -442,6 +442,16 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         file('bar-server/product-dependencies.lock').readLines().contains 'com.palantir.group:foo-service (0.0.0, 1.x.x)'
     }
 
+    def "check depends on createManifest"() {
+        file("product-dependencies.lock").delete()
+
+        when:
+        def result = runTasks(':check')
+
+        then:
+        result.task(":createManifest") != null
+    }
+
     def generateDependencies() {
         DependencyGraph dependencyGraph = new DependencyGraph(
                 "a:a:1.0 -> b:b:1.0|c:c:1.0", "b:b:1.0", "c:c:1.0", "d:d:1.0", "e:e:1.0",


### PR DESCRIPTION
## Before this PR
There was no explicit link between `createMaifest` and `check` allowing for a build to pass without the product-dependency lock file having been verified.

## After this PR
We explicitly add a dependency between `check` and `createManifest`
