### PR TITLE
[fix] Lazily configure product dependencies config

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -402,7 +402,10 @@ public class CreateManifestTask extends DefaultTask {
         project.afterEvaluate(p ->
                 createManifest.configure(task -> task.setManifestExtensions(ext.getManifestExtensions())));
         project.getPluginManager().withPlugin("lifecycle-base", p -> {
-            project.getTasks().getByName(LifecycleBasePlugin.CHECK_TASK_NAME).dependsOn(createManifest);
+            project
+                    .getTasks()
+                    .named(LifecycleBasePlugin.CHECK_TASK_NAME)
+                    .configure(task -> task.dependsOn(createManifest));
         });
 
         // We want `./gradlew --write-locks` to magically fix up the product-dependencies.lock file

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -57,12 +57,10 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
@@ -96,59 +94,55 @@ public class CreateManifestTask extends DefaultTask {
     private File manifestFile;
 
     @Input
-    public final Property<String> getServiceName() {
+    final Property<String> getServiceName() {
         return serviceName;
     }
 
     @Input
-    public final Property<String> getServiceGroup() {
+    final Property<String> getServiceGroup() {
         return serviceGroup;
     }
 
     @Input
-    public final Property<ProductType> getProductType() {
+    final Property<ProductType> getProductType() {
         return productType;
     }
 
     @Input
-    public final Map<String, Object> getManifestExtensions() {
+    final Map<String, Object> getManifestExtensions() {
         return manifestExtensions;
     }
 
-    public final void setManifestExtensions(Map<String, Object> manifestExtensions) {
+    private void setManifestExtensions(Map<String, Object> manifestExtensions) {
         this.manifestExtensions = manifestExtensions;
     }
 
     @Input
-    public final ListProperty<ProductDependency> getProductDependencies() {
+    final ListProperty<ProductDependency> getProductDependencies() {
         return productDependencies;
     }
 
     @Input
-    public final SetProperty<ProductId> getIgnoredProductIds() {
+    final SetProperty<ProductId> getIgnoredProductIds() {
         return ignoredProductIds;
     }
 
     @InputFiles
-    public final FileCollection getProductDependenciesConfig() {
-        return productDependenciesConfig.get();
-    }
-
-    public final void setProductDependenciesConfig(Provider<Configuration> productDependenciesConfig) {
-        this.productDependenciesConfig.set(productDependenciesConfig);
+    final Property<Configuration> getProductDependenciesConfig() {
+        return productDependenciesConfig;
     }
 
     @Input
-    public final String getProjectVersion() {
+    final String getProjectVersion() {
         return getProject().getVersion().toString();
     }
 
     @OutputFile
-    public final File getManifestFile() {
+    final File getManifestFile() {
         return manifestFile;
     }
 
-    public final void setManifestFile(File manifestFile) {
+    private void setManifestFile(File manifestFile) {
         this.manifestFile = manifestFile;
     }
 
@@ -402,7 +396,7 @@ public class CreateManifestTask extends DefaultTask {
                     task.getProductType().set(ext.getProductType());
                     task.setManifestFile(new File(project.getBuildDir(), "/deployment/manifest.yml"));
                     task.getProductDependencies().set(ext.getProductDependencies());
-                    task.setProductDependenciesConfig(project.provider(ext::getProductDependenciesConfig));
+                    task.getProductDependenciesConfig().set(project.provider(ext::getProductDependenciesConfig));
                     task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
                 });
         project.afterEvaluate(p ->

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -92,9 +92,7 @@ public class CreateManifestTask extends DefaultTask {
             getProject().getObjects().property(Configuration.class);
 
     // TODO(forozco): Use MapProperty, RegularFileProperty once our minimum supported version is 5.1
-    @SuppressWarnings("unchecked")
-    private Property<Map<String, Object>> manifestExtensions =
-            (Property<Map<String, Object>>) (Property) getProject().getObjects().property(Map.class);
+    private Map<String, Object> manifestExtensions = Maps.newHashMap();
     private File manifestFile;
 
     @Input

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -113,7 +113,7 @@ public class CreateManifestTask extends DefaultTask {
         return manifestExtensions;
     }
 
-    private void setManifestExtensions(Map<String, Object> manifestExtensions) {
+    final void setManifestExtensions(Map<String, Object> manifestExtensions) {
         this.manifestExtensions = manifestExtensions;
     }
 
@@ -142,7 +142,7 @@ public class CreateManifestTask extends DefaultTask {
         return manifestFile;
     }
 
-    private void setManifestFile(File manifestFile) {
+    final void setManifestFile(File manifestFile) {
         this.manifestFile = manifestFile;
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -50,7 +50,6 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                 productType = ProductType.SERVICE_V1
                 manifestExtensions = [:]
                 manifestFile = new File(project.buildDir, "/deployment/manifest.yml")
-                productDependenciesConfig = configurations.runtime
             }
         """.stripIndent()
     }


### PR DESCRIPTION
## Before this PR

After #420, users can no longer change the value of `productDependenciesConfig` in the `BaseDistributionExtension`.

## After this PR

Fixed the above, by making it be lazily initialized in CreateManifestTask.