### PR TITLE
[feature] go-java-launcher 1.5.1 -> 1.6.0

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -44,8 +44,8 @@ import org.gradle.util.GFileUtils;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER_BINARIES = "goJavaLauncherBinaries";
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.5.1";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.5.1";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.6.0";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.6.0";
     public static final String GROUP_NAME = "Distribution";
     private static final String SLS_CONFIGURATION_NAME = "sls";
 


### PR DESCRIPTION
This allows people to specify `javaHome: '$JAVA_11_HOME'`, to override the default of '$JAVA_HOME'.

```diff
 distribution {
     serviceName project.name
     mainClass 'com.palantir.logreceiver.LogReceiverServer'
     // 'upgrade-strategy' should only be set to 'rolling' if this version has no migrations that require downtime
     manifestExtensions 'upgrade-strategy': 'rolling'
     // 'public-proxy-endpoints' should be a list of endpoints that will be mounted on the SPP
     manifestExtensions 'public-proxy-endpoints': ['service-endpoint']
+    javaHome '$JAVA_11_HOME'
 }
```