### PR TITLE
[fix] Don't inject services that require gradle 5.2

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesExtension.java
@@ -20,7 +20,7 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import java.util.Set;
 import javax.inject.Inject;
-import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.Project;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.util.ConfigureUtil;
@@ -30,9 +30,9 @@ public class RecommendedProductDependenciesExtension {
     private final ProviderFactory providerFactory;
 
     @Inject
-    public RecommendedProductDependenciesExtension(ObjectFactory objectFactory, ProviderFactory providerFactory) {
-        this.recommendedProductDependencies = objectFactory.setProperty(ProductDependency.class).empty();
-        this.providerFactory = providerFactory;
+    public RecommendedProductDependenciesExtension(Project project) {
+        this.recommendedProductDependencies = project.getObjects().setProperty(ProductDependency.class).empty();
+        this.providerFactory = project.getProviders();
     }
 
     /**

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.groovy
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.groovy
@@ -29,7 +29,7 @@ class RecommendedProductDependenciesPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.plugins.apply('java')
         RecommendedProductDependenciesExtension ext = project.extensions.create(
-                'recommendedProductDependencies', RecommendedProductDependenciesExtension)
+                'recommendedProductDependencies', RecommendedProductDependenciesExtension, project)
 
         project.afterEvaluate {
             ext.recommendedProductDependencies.each { recommendedProductDependency ->


### PR DESCRIPTION
## Before this PR

#427 introduced a regression such the recommended-product-dependencies plugin would now require gradle 5.2 (because we used [this feature](https://docs.gradle.org/5.2/release-notes.html#service-injection-into-plugins-and-project-extensions))

## After this PR

Implement the extension in a gradle 4.10-compatible way