### PR TITLE
[fix] Configure run task correctly

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -193,6 +193,9 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         project.afterEvaluate(p -> runTask.configure(task -> {
             task.setClasspath(project.files(
                     jarTask.get().getArchivePath(), p.getConfigurations().getByName("runtimeClasspath")));
+            task.setMain(distributionExtension.getMainClass().get());
+            task.setArgs(distributionExtension.getArgs().get());
+            task.setJvmArgs(distributionExtension.getDefaultJvmOpts().get());
         }));
 
         TaskProvider<Tar> distTar = project.getTasks().register("distTar", Tar.class, task -> {


### PR DESCRIPTION
## Before this PR

People upgrading to 3.X found a regression with `./gradlew run`.

## After this PR

Fixes #428 

TODO

- [ ] tests

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
