### PR TITLE
[improvement] log what artifacts are making what recommendations

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -342,7 +342,13 @@ public class CreateManifestTask extends DefaultTask {
                                 recommendedDep.getProductName(),
                                 recommendedDep.getMinimumVersion(),
                                 recommendedDep.getMaximumVersion(),
-                                recommendedDep.getRecommendedVersion()));
+                                recommendedDep.getRecommendedVersion()))
+                        .peek(productDependency -> log.debug(
+                                "Product dependency recommendation made by artifact '{}', file '{}', dependency "
+                                + "recommendation '{}'",
+                                coord,
+                                artifact,
+                                productDependency));
             } catch (IOException | IllegalArgumentException e) {
                 log.debug("Failed to load product dependency for artifact '{}', file '{}', '{}'", coord, artifact, e);
                 return Stream.empty();

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -343,7 +343,7 @@ public class CreateManifestTask extends DefaultTask {
                                 recommendedDep.getMinimumVersion(),
                                 recommendedDep.getMaximumVersion(),
                                 recommendedDep.getRecommendedVersion()))
-                        .peek(productDependency -> log.debug(
+                        .peek(productDependency -> log.info(
                                 "Product dependency recommendation made by artifact '{}', file '{}', dependency "
                                 + "recommendation '{}'",
                                 coord,


### PR DESCRIPTION
## Before this PR
I was surprised to see that my product dependency lock files had stricter version constraints on some of my dependencies than I expected, but didn't have a quick/easy way of figuring out why the versions specified were actually there.

## After this PR
Adds a debug level log that prints out for product dependency recommendation, what the recommending artifact is and what the recommendation itself is.