### PR TITLE
[fix] go-java-launcher 1.6.0 -> 1.6.1 to allow digits in process name

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -44,8 +44,8 @@ import org.gradle.util.GFileUtils;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER_BINARIES = "goJavaLauncherBinaries";
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.6.0";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.6.0";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.6.1";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.6.1";
     public static final String GROUP_NAME = "Distribution";
     private static final String SLS_CONFIGURATION_NAME = "sls";
 


### PR DESCRIPTION
## Before this PR

@hsaraogi and @hturki found that upgrading from 2.X -> 3.X stopped allowing them to use a service name with numbers in them!

## After this PR

This regression is now fixed.