### PR TITLE
[fix] Sensible defaults for providers

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -22,6 +22,7 @@ import com.palantir.gradle.dist.ProductType;
 import com.palantir.gradle.dist.service.gc.GcProfile;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -53,23 +54,33 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     @Inject
     public JavaServiceDistributionExtension(Project project) {
         super(project);
-
         objectFactory = project.getObjects();
         mainClass = objectFactory.property(String.class);
         javaHome = objectFactory.property(String.class);
+
         addJava8GcLogging = objectFactory.property(Boolean.class);
         addJava8GcLogging.set(false);
+
         enableManifestClasspath = objectFactory.property(Boolean.class);
         enableManifestClasspath.set(false);
+
         gc = objectFactory.property(GcProfile.class);
         gc.set(new GcProfile.Throughput());
+
         args = objectFactory.listProperty(String.class);
+        // TODO(dfox): use listPropert(..).empty() when a minimum Gradle of 5.0 is acceptable
+        args.set(Collections.emptyList());
+
         checkArgs = objectFactory.listProperty(String.class);
+        checkArgs.set(Collections.emptyList());
+
         defaultJvmOpts = objectFactory.listProperty(String.class);
+        defaultJvmOpts.set(Collections.emptyList());
+
         excludeFromVar = objectFactory.listProperty(String.class);
         excludeFromVar.addAll("log", "run");
-        env = Maps.newHashMap();
 
+        env = Maps.newHashMap();
         setProductType(ProductType.SERVICE_V1);
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -68,7 +68,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         gc.set(new GcProfile.Throughput());
 
         args = objectFactory.listProperty(String.class);
-        // TODO(dfox): use listPropert(..).empty() when a minimum Gradle of 5.0 is acceptable
+        // TODO(dfox): use listProperty(..).empty() when a minimum Gradle of 5.0 is acceptable
         args.set(Collections.emptyList());
 
         checkArgs = objectFactory.listProperty(String.class);

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -84,4 +84,17 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.excludeFromVar.get() == ['c', 'd']
         ext.env == ['foo': 'bar']
     }
+
+    def 'sensible defaults' () {
+        when:
+        def ext = new JavaServiceDistributionExtension(project)
+
+        then:
+        ext.getAddJava8GcLogging().get() == false
+        ext.getEnableManifestClasspath().get() == false
+        ext.getArgs().get() == []
+        ext.getCheckArgs().get() == []
+        ext.getDefaultJvmOpts().get() == []
+        ext.getExcludeFromVar().get() == ['log', 'run']
+    }
 }


### PR DESCRIPTION
## Before this PR

I upgraded a project to 3.X and saw the following:

```
./gradlew --write-locks -s

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':apollo-catalog'.
> Failed to notify project evaluation listener.
   > No value has been specified for this provider.
   > No value has been specified for this provider.

        ... 100 more
Caused by: java.lang.IllegalStateException: No value has been specified for this provider.
        at org.gradle.api.internal.provider.Collectors$NoValueCollector.collectInto(Collectors.java:294)
        at org.gradle.api.internal.provider.AbstractCollectionProperty.get(AbstractCollectionProperty.java:145)
        at org.gradle.api.internal.provider.AbstractCollectionProperty.get(AbstractCollectionProperty.java:37)
        at com.palantir.gradle.dist.service.JavaServiceDistributionPlugin.lambda$null$5(JavaServiceDistributionPlugin.java:132)
```

## After this PR

No errors if you just want to use the defaults!