### PR TITLE
[improvement] go-java-launcher 1.5.1 -> 1.6.1, to allow $JAVA_11_HOME

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -43,8 +43,8 @@ import org.gradle.util.GFileUtils;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER_BINARIES = "goJavaLauncherBinaries";
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.5.1";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.5.1";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.6.1";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.6.1";
     public static final String GROUP_NAME = "Distribution";
     private static final String SLS_CONFIGURATION_NAME = "sls";
 


### PR DESCRIPTION
## Before this PR

We're trying to excavate out Java11 everywhere internally, but the PR has ended up with a slightly unnecessary dependency on the sls-packaging 2.X -> 3.X upgrade.

## After this PR

This is just a little backport so that Java11 excavator PR doesn't require people to do the 2.X -> 3.X upgrade... 

If we want to go with this approach, then I'd tag a `2.23.0` on the `release/2.x` branch.

