### PR TITLE
[improvement] Upgrade YourKit 2017.02-b75 -> 2019.1-b112

### DIFF
--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -45,7 +45,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2017.02-b75"
+def yourkitVersion = "2019.1-b112"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {
@@ -58,7 +58,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum '562d566c710f00f6b5d72a5ea29111896cccc634485f27fc7397d32bae971d54'
+    checksum 'fff95879664ff9bfbfe1fadd54a19d75eb934cf9726152f8444c4d6e963e9afb'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {

--- a/gradle-sls-packaging/src/main/resources/yourkit-license-redist.txt
+++ b/gradle-sls-packaging/src/main/resources/yourkit-license-redist.txt
@@ -1,4 +1,4 @@
-The following files can be redistributable under the license below:
+The following files can be redistributed under the license below:
 
 yjpagent.dll
 libyjpagent.so
@@ -6,7 +6,8 @@ libyjpagent.jnilib
 yjp-controller-api-redist.jar
 
 -------------------------------------------------------------------
-Copyright (c) 2003-2017, YourKit
+
+Copyright (c) 2003-2019, YourKit
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
YourKit sometimes crashes when using a client on Mac OS X to connect to an sls service running on a remote server.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
I confirmed that the crash no longer happens after upgrading to the latest YourKit build, possibly due to the fix in build 110 (https://www.yourkit.com/download/yjp_2019_1_builds.jsp). Upgrading the library in case other people are hitting the same problem. 

Warning: this will require users to upgrade their clients which might require getting another license. Feel free to close the PR if we want to avoid such breaks.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
