### PR TITLE
[improvement] createManifest no longer requires compiling project source code

### DIFF
--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -559,6 +559,107 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         result.output.contains('Could not determine minimum version among two non-orderable minimum versions')
     }
 
+    def "createManifest does not force compilation of sibling projects"() {
+        setup:
+        buildFile << """
+        allprojects {
+            project.version = '1.0.0'
+            group "com.palantir.group"
+        }
+        """
+        helper.addSubproject("foo-api", """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'foo-service'
+                    minimumVersion = '0.0.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        """.stripIndent())
+        helper.addSubproject("foo-server", """
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            
+            dependencies {
+                compile project(':foo-api')
+            }
+
+            distribution {
+                serviceGroup 'com.palantir.group'
+                serviceName 'foo-service'
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+                args 'server', 'var/conf/my-service.yml'
+            }
+        """.stripIndent())
+
+        when:
+        def result = runTasks('foo-server:createManifest')
+
+        then:
+        result.task(":foo-server:createManifest").outcome == TaskOutcome.SUCCESS
+        result.task(':foo-api:jar') == null
+    }
+
+    def "createManifest discovers in repo product dependencies"() {
+        setup:
+        buildFile << """
+        allprojects {
+            project.version = '1.0.0'
+            group "com.palantir.group"
+        }
+        """
+        helper.addSubproject("bar-api", """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'bar-service'
+                    minimumVersion = '0.0.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        """.stripIndent())
+        helper.addSubproject("foo-server", """
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            
+            dependencies {
+                compile project(':bar-api')
+            }
+
+            distribution {
+                serviceGroup 'com.palantir.group'
+                serviceName 'foo-service'
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+                args 'server', 'var/conf/my-service.yml'
+            }
+        """.stripIndent())
+
+        when:
+        def result = runTasks('foo-server:createManifest', '--write-locks')
+
+        then:
+        result.task(":foo-server:createManifest").outcome == TaskOutcome.SUCCESS
+        result.task(':bar-api:jar') == null
+
+        def manifest = CreateManifestTask.jsonMapper.readValue(file("foo-server/build/deployment/manifest.yml"), Map)
+        manifest.get("extensions").get("product-dependencies") == [
+                [
+                        "product-group"      : "com.palantir.group",
+                        "product-name"       : "bar-service",
+                        "minimum-version"    : "0.0.0",
+                        "recommended-version": "1.0.0",
+                        "maximum-version"    : "1.x.x",
+                ],
+        ]
+    }
+
     def "check depends on createManifest"() {
         when:
         def result = runTasks(':check')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -602,6 +602,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         then:
         result.task(":foo-server:createManifest").outcome == TaskOutcome.SUCCESS
         result.task(':foo-api:jar') == null
+        result.tasks.size() == 1
     }
 
     def "createManifest discovers in repo product dependencies"() {

--- a/versions.props
+++ b/versions.props
@@ -4,6 +4,6 @@ com.palantir.safe-logging:* = 1.8.2
 com.palantir.sls.versions:sls-versions = 0.9.0
 org.immutables:value = 2.7.5
 
-com.netflix.nebula:nebula-test = 7.1.8
+com.netflix.nebula:nebula-test = 7.1.7
 junit:junit = 4.12
 org.awaitility:awaitility = 3.1.6


### PR DESCRIPTION
## Before this PR
To discover in repo product dependencies, `createManifest` would cause all project dependencies to run `Jar` causing them to fully compile.

## After this PR
Project dependencies are no longer compiled