### PR TITLE
[fix] Fix gradle 4.10

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -58,7 +58,6 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentResult;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPlugin;
@@ -135,7 +134,8 @@ public class CreateManifestTask extends DefaultTask {
     final Set<String> getProductDependenciesConfig() {
         // HACKHACK serializable way of representing all dependencies
         return productDependenciesConfig.get().getIncoming().getResolutionResult().getAllComponents().stream()
-                .map(ComponentResult::getId)
+                // intentionally using a lambda as otherwise we break gradle 4.10 support
+                .map(result -> result.getId())
                 .map(ComponentIdentifier::getDisplayName)
                 .collect(Collectors.toSet());
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
@@ -18,12 +18,9 @@ package com.palantir.gradle.dist
 
 import nebula.test.IntegrationTestKitSpec
 import nebula.test.multiproject.MultiProjectIntegrationHelper
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
 
 class GradleIntegrationSpec extends IntegrationTestKitSpec {
     protected MultiProjectIntegrationHelper helper
-    protected String gradleVersion
 
     def setup() {
         keepFiles = true
@@ -35,28 +32,4 @@ class GradleIntegrationSpec extends IntegrationTestKitSpec {
     protected boolean fileExists(String path) {
         new File(projectDir, path).exists()
     }
-
-    BuildResult runTasks(String... tasks) {
-        BuildResult result = with(tasks).build()
-        return checkForDeprecations(result)
-    }
-
-    BuildResult runTasksAndFail(String... tasks) {
-        BuildResult result = with(tasks).buildAndFail()
-        return checkForDeprecations(result)
-    }
-
-    private GradleRunner with(String... tasks) {
-        def runner = GradleRunner.create()
-                .withProjectDir(projectDir)
-                .withArguments(calculateArguments(tasks))
-                .withDebug(debug)
-                .withPluginClasspath()
-                .forwardOutput()
-        if (gradleVersion != null) {
-            runner.withGradleVersion(gradleVersion)
-        }
-        runner
-    }
-
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
@@ -18,9 +18,12 @@ package com.palantir.gradle.dist
 
 import nebula.test.IntegrationTestKitSpec
 import nebula.test.multiproject.MultiProjectIntegrationHelper
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
 
 class GradleIntegrationSpec extends IntegrationTestKitSpec {
     protected MultiProjectIntegrationHelper helper
+    protected String gradleVersion
 
     def setup() {
         keepFiles = true
@@ -32,4 +35,28 @@ class GradleIntegrationSpec extends IntegrationTestKitSpec {
     protected boolean fileExists(String path) {
         new File(projectDir, path).exists()
     }
+
+    BuildResult runTasks(String... tasks) {
+        BuildResult result = with(tasks).build()
+        return checkForDeprecations(result)
+    }
+
+    BuildResult runTasksAndFail(String... tasks) {
+        BuildResult result = with(tasks).buildAndFail()
+        return checkForDeprecations(result)
+    }
+
+    private GradleRunner with(String... tasks) {
+        def runner = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments(calculateArguments(tasks))
+                .withDebug(debug)
+                .withPluginClasspath()
+                .forwardOutput()
+        if (gradleVersion != null) {
+            runner.withGradleVersion(gradleVersion)
+        }
+        runner
+    }
+
 }


### PR DESCRIPTION
## Before this PR

Was breaking on gradle 4.10:

```
> Invalid receiver type interface org.gradle.api.artifacts.result.ResolvedComponentResult; not a subtype of implementation type interface org.gradle.api.artifacts.result.ComponentResult
```

## After this PR

Works in gradle 4.10 (probably).