### PR TITLE
Fix missing jars in classpath of generared in jar MANIFEST

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.JavaExec;
@@ -85,8 +86,13 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.setAppendix("manifest-classpath");
 
                     task.doFirst(t -> {
-                        String classPath = project.getConfigurations().getByName("runtimeClasspath")
-                                .getFiles()
+
+                        FileCollection runtimeClasspath = project.getConfigurations().getByName("runtimeClasspath");
+
+                        TaskProvider<Jar> jarTask = project.getTasks().withType(Jar.class).named(JavaPlugin.JAR_TASK_NAME);
+                        FileCollection jarOutputs = jarTask.get().getOutputs().getFiles();
+
+                        String classPath = runtimeClasspath.plus(jarOutputs).getFiles()
                                 .stream()
                                 .map(File::getName)
                                 .collect(Collectors.joining(" "));

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -89,7 +89,8 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
 
                         FileCollection runtimeClasspath = project.getConfigurations().getByName("runtimeClasspath");
 
-                        TaskProvider<Jar> jarTask = project.getTasks().withType(Jar.class).named(JavaPlugin.JAR_TASK_NAME);
+                        TaskProvider<Jar> jarTask = project.getTasks().withType(Jar.class)
+                                .named(JavaPlugin.JAR_TASK_NAME);
                         FileCollection jarOutputs = jarTask.get().getOutputs().getFiles();
 
                         String classPath = runtimeClasspath.plus(jarOutputs).getFiles()

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -89,9 +89,8 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
 
                         FileCollection runtimeClasspath = project.getConfigurations().getByName("runtimeClasspath");
 
-                        TaskProvider<Jar> jarTask = project.getTasks().withType(Jar.class)
-                                .named(JavaPlugin.JAR_TASK_NAME);
-                        FileCollection jarOutputs = jarTask.get().getOutputs().getFiles();
+                        FileCollection jarOutputs = project.getTasks().withType(Jar.class)
+                                .getByName(JavaPlugin.JAR_TASK_NAME).getOutputs().getFiles();
 
                         String classPath = runtimeClasspath.plus(jarOutputs).getFiles()
                                 .stream()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -525,8 +525,12 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
         def classpathJar = file('dist/service-name-0.0.1/service/lib/').listFiles()
                 .find({ it.name.endsWith("-manifest-classpath-0.0.1.jar") })
         classpathJar.exists()
-        readFromZip(classpathJar, "META-INF/MANIFEST.MF")
-                .contains('Class-Path: guava-19.0.jar root-project-manifest-') // etc
+
+        def zipManifest = readFromZip(classpathJar, "META-INF/MANIFEST.MF").replace('\r\n ','')
+        zipManifest.contains('Class-Path: ')
+        zipManifest.contains('guava-19.0.jar')
+        zipManifest.contains('root-project-manifest-classpath-0.0.1.jar')
+        zipManifest.contains('root-project-0.0.1.jar')
     }
 
     def 'does not produce manifest-classpath jar when disabled in extension'() {


### PR DESCRIPTION
fixes #476 

Classpath in jar MANIFEST  now contains the project jars and is consistent with the classpath generated in launcher script.
