### PR TITLE
[wip] [improvement] Create sls dist publication that captures product dependencies in the POM

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -35,7 +35,7 @@ import org.gradle.util.GFileUtils;
 
 public final class ProductDependencyIntrospectionPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(ProductDependencyIntrospectionPlugin.class);
-    private static final String PRODUCT_DEPENDENCIES_CONFIGURATION = "productDependencies";
+    static final String PRODUCT_DEPENDENCIES_CONFIGURATION = "productDependencies";
 
     @Override
     public void apply(Project project) {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class SlsBaseDistPlugin implements Plugin<Project> {
+
+    /**
+     * The name of the outgoing configuration. This will include the SLS artifact being published, and if running on
+     * Gradle 5.3+, it will also include the SLS product dependencies.
+     */
+    public static final String SLS_CONFIGURATION_NAME = "sls";
+
+    @Override
+    public final void apply(Project project) {
+        project.getConfigurations().create(SLS_CONFIGURATION_NAME);
+
+        if (SlsDistPublicationPlugin.canApply()) {
+            project.getPluginManager().apply(SlsDistPublicationPlugin.class);
+        }
+    }
+}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
@@ -27,7 +27,7 @@ import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
-import org.gradle.api.publish.plugins.PublishingPlugin;
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.util.GradleVersion;
 
 /**
@@ -46,7 +46,7 @@ public class SlsDistPublicationPlugin implements Plugin<Project> {
     @Override
     public final void apply(Project project) {
         checkPreconditions();
-        project.getPluginManager().apply(PublishingPlugin.class);
+        project.getPluginManager().apply(MavenPublishPlugin.class);
         project.getPluginManager().apply(ProductDependencyIntrospectionPlugin.class);
 
         // Created in SlsBaseDistPlugin

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.dist;
 
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import javax.inject.Inject;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -43,8 +44,7 @@ public class SlsDistPublicationPlugin implements Plugin<Project> {
 
     @Override
     public final void apply(Project project) {
-        Preconditions.checkState(project.getPlugins().hasPlugin(SlsBaseDistPlugin.class),
-                "This plugin must be applied through SlsBaseDistPlugin");
+        checkPreconditions();
         project.getPluginManager().apply(ProductDependencyIntrospectionPlugin.class);
 
         // Created in SlsBaseDistPlugin
@@ -67,6 +67,12 @@ public class SlsDistPublicationPlugin implements Plugin<Project> {
                 dist.from(component);
             });
         });
+    }
+
+    private void checkPreconditions() {
+        Preconditions.checkState(canApply(),
+                "Cannot apply plugin since gradle version is too low",
+                SafeArg.of("minimumGradleVersion", MINIMUM_GRADLE_VERSION));
     }
 
     static boolean canApply() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.plugins.PublishingPlugin;
 import org.gradle.util.GradleVersion;
 
 /**
@@ -45,6 +46,7 @@ public class SlsDistPublicationPlugin implements Plugin<Project> {
     @Override
     public final void apply(Project project) {
         checkPreconditions();
+        project.getPluginManager().apply(PublishingPlugin.class);
         project.getPluginManager().apply(ProductDependencyIntrospectionPlugin.class);
 
         // Created in SlsBaseDistPlugin

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import com.palantir.logsafe.Preconditions;
+import javax.inject.Inject;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.component.AdhocComponentWithVariants;
+import org.gradle.api.component.SoftwareComponentFactory;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.util.GradleVersion;
+
+/**
+ * Sets up a dist publication that includes the product's SLS dependencies as gradle runtime dependencies.
+ */
+public class SlsDistPublicationPlugin implements Plugin<Project> {
+    private static final String PUBLICATION_NAME = "slsDist";
+    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.3");
+    private final SoftwareComponentFactory componentFactory;
+
+    @Inject
+    public SlsDistPublicationPlugin(SoftwareComponentFactory componentFactory) {
+        this.componentFactory = componentFactory;
+    }
+
+    @Override
+    public final void apply(Project project) {
+        Preconditions.checkState(project.getPlugins().hasPlugin(SlsBaseDistPlugin.class),
+                "This plugin must be applied through SlsBaseDistPlugin");
+        project.getPluginManager().apply(ProductDependencyIntrospectionPlugin.class);
+
+        // Created in SlsBaseDistPlugin
+        NamedDomainObjectProvider<Configuration> outgoingConfiguration =
+                project.getConfigurations().named(SlsBaseDistPlugin.SLS_CONFIGURATION_NAME);
+        // Pick up product dependencies from the lock file, in order to publish them
+        outgoingConfiguration.configure(conf -> {
+            conf.extendsFrom(project
+                    .getConfigurations()
+                    .getByName(ProductDependencyIntrospectionPlugin.PRODUCT_DEPENDENCIES_CONFIGURATION));
+        });
+
+        project.getExtensions().configure(PublishingExtension.class, publishing -> {
+            publishing.getPublications().create(PUBLICATION_NAME, MavenPublication.class, dist -> {
+                AdhocComponentWithVariants component = componentFactory.adhoc("dist");
+                // Note: both dependencies and outgoing artifacts are wired up from this configuration
+                component.addVariantsFromConfiguration(
+                        outgoingConfiguration.get(),
+                        cvd -> cvd.mapToMavenScope("runtime"));
+                dist.from(component);
+            });
+        });
+    }
+
+    static boolean canApply() {
+        return GradleVersion.current().compareTo(MINIMUM_GRADLE_VERSION) >= 0;
+    }
+}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsDistPublicationPlugin.java
@@ -31,7 +31,7 @@ import org.gradle.api.publish.plugins.PublishingPlugin;
 import org.gradle.util.GradleVersion;
 
 /**
- * Sets up a dist publication that includes the product's SLS dependencies as gradle runtime dependencies.
+ * Sets up an {@code slsDist} publication that includes the product's SLS dependencies as gradle runtime dependencies.
  */
 public class SlsDistPublicationPlugin implements Plugin<Project> {
     private static final String PUBLICATION_NAME = "slsDist";

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.dist.asset;
 
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
+import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.pod.PodDistributionPlugin;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import com.palantir.gradle.dist.tasks.ConfigTarTask;
@@ -32,10 +33,10 @@ import org.gradle.api.tasks.bundling.Tar;
 public final class AssetDistributionPlugin implements Plugin<Project> {
     public static final String GROUP_NAME = "Distribution";
     public static final String ASSET_CONFIGURATION = "assetBundle";
-    private static final String SLS_CONFIGURATION_NAME = "sls";
 
     @Override
     public void apply(Project project) {
+        project.getPluginManager().apply(SlsBaseDistPlugin.class);
         if (project.getPlugins().hasPlugin(JavaServiceDistributionPlugin.class)) {
             throw new InvalidUserCodeException("The plugins 'com.palantir.sls-asset-distribution' and "
                     + "'com.palantir.sls-java-service-distribution' cannot be used in the same Gradle project.");
@@ -88,7 +89,6 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
         TaskProvider<Tar> configTar = ConfigTarTask.createConfigTarTask(project,  distributionExtension);
         configTar.configure(task -> task.dependsOn(manifest));
 
-        project.getConfigurations().create(SLS_CONFIGURATION_NAME);
-        project.getArtifacts().add(SLS_CONFIGURATION_NAME, distTar);
+        project.getArtifacts().add(SlsBaseDistPlugin.SLS_CONFIGURATION_NAME, distTar);
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionPlugin.java
@@ -16,6 +16,7 @@
 package com.palantir.gradle.dist.pod;
 
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
+import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.asset.AssetDistributionPlugin;
 import com.palantir.gradle.dist.pod.tasks.CreatePodYamlTask;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
@@ -29,10 +30,10 @@ import org.gradle.api.tasks.bundling.Tar;
 
 public final class PodDistributionPlugin implements Plugin<Project> {
     private static final String GROUP_NAME = "Distribution";
-    private static final String SLS_CONFIGURATION_NAME = "sls";
 
     @Override
     public void apply(Project project) {
+        project.getPluginManager().apply(SlsBaseDistPlugin.class);
         if (project.getPlugins().hasPlugin(JavaServiceDistributionPlugin.class)) {
             throw new InvalidUserCodeException("The plugins 'com.palantir.sls-pod-distribution' and "
                     + "'com.palantir.sls-java-service-distribution' cannot be used in the same Gradle project.");
@@ -63,7 +64,6 @@ public final class PodDistributionPlugin implements Plugin<Project> {
         TaskProvider<Tar> configTar = ConfigTarTask.createConfigTarTask(project, distributionExtension);
         configTar.configure(task -> task.dependsOn(manifest, podYaml));
 
-        project.getConfigurations().create(SLS_CONFIGURATION_NAME);
-        project.getArtifacts().add(SLS_CONFIGURATION_NAME, configTar);
+        project.getArtifacts().add(SlsBaseDistPlugin.SLS_CONFIGURATION_NAME, configTar);
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -15,7 +15,10 @@
  */
 package com.palantir.gradle.dist.service;
 
+import static com.palantir.gradle.dist.SlsBaseDistPlugin.SLS_CONFIGURATION_NAME;
+
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
+import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.asset.AssetDistributionPlugin;
 import com.palantir.gradle.dist.pod.PodDistributionPlugin;
 import com.palantir.gradle.dist.service.tasks.CopyLauncherBinariesTask;
@@ -48,10 +51,10 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.6.2";
     private static final String GO_INIT = "com.palantir.launching:go-init:1.6.2";
     public static final String GROUP_NAME = "Distribution";
-    private static final String SLS_CONFIGURATION_NAME = "sls";
 
     @SuppressWarnings("checkstyle:methodlength")
     public void apply(Project project) {
+        project.getPluginManager().apply(SlsBaseDistPlugin.class);
         if (project.getPlugins().hasPlugin(AssetDistributionPlugin.class)) {
             throw new InvalidUserCodeException("The plugins 'com.palantir.sls-asset-distribution' and "
                     + "'com.palantir.sls-java-service-distribution' cannot be used in the same Gradle project.");
@@ -222,8 +225,6 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                 distributionExtension.getExcludeFromVar().get(),
                 distributionExtension.getEnableManifestClasspath().get()));
 
-        // Create configuration and exported artifacts
-        project.getConfigurations().create(SLS_CONFIGURATION_NAME);
         project.getArtifacts().add(SLS_CONFIGURATION_NAME, distTar);
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.gradle.dist.service;
 
-import static com.palantir.gradle.dist.SlsBaseDistPlugin.SLS_CONFIGURATION_NAME;
-
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.asset.AssetDistributionPlugin;
@@ -225,6 +223,6 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                 distributionExtension.getExcludeFromVar().get(),
                 distributionExtension.getEnableManifestClasspath().get()));
 
-        project.getArtifacts().add(SLS_CONFIGURATION_NAME, distTar);
+        project.getArtifacts().add(SlsBaseDistPlugin.SLS_CONFIGURATION_NAME, distTar);
     }
 }


### PR DESCRIPTION
## Before this PR

This plugin was not controlling the way we publish dists via the three plugins (java-service, asset, pod).
We only created a configuration called `sls` and declared an outgoing artifact on it, then relied on an internal plugin to wrap that into a maven publication and figure out where to publish it.

## After this PR
==COMMIT_MSG==
If running on gradle 5.3 or higher, a maven publication called `slsDist` will be created from any of the three dist plugins, that wires in the dist artifact (from the `sls` configuation) and additionally adds the discovered product dependencies as maven runtime dependencies.

The motivation here is to automate figuring out the full set of services (and their versions) you need to start up in your integration tests, given a set of products you know you need.
Once these dependencies are written to the POM, we can leverage gradle's dependency resolution in order to find a full set of product dependencies that are transitively necessary to actually run the requested products.

If running on gradle < 5.3, no changes in behaviour.
==COMMIT_MSG==

Next steps:
our internal publishing plugin needs to start picking up this `slsDist` publication if it exists, otherwise fall back to creating the publication as it currently does.

Remaining work:
- [ ] tests
- [ ] `com.palantir.sls-java-service-distribution` has no integration tests???
- [ ] (optionally) figure out running all tests against older gradle

## Potential downsides

A our circle templates / other gradle plugins might expect the publication to be called `dist` (by directly referencing a publish task derived from that name). Need to investigate if this coupling exists.