### PR TITLE
[fix] Use pom extension for product dependencies

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -112,7 +112,8 @@ public final class ProductDependencyIntrospectionPlugin implements Plugin<Projec
                 .map(dependency -> project.getDependencies().create(ImmutableMap.of(
                         "group", dependency.getProductGroup(),
                         "name", dependency.getProductName(),
-                        "version", dependency.getMinimumVersion())))
+                        "version", dependency.getMinimumVersion(),
+                        "ext", "pom")))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Before this PR
Resolving configurations would download potentially large distribution artifacts for product dependencies.

## After this PR
Resolving configurations only downloads POMs for for product dependencies.
