### PR TITLE
Fix YourKit download URL

### DIFF
--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -45,7 +45,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2019.1-b112"
+def yourkitVersion = "2019.1-b117"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -58,7 +58,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum 'fff95879664ff9bfbfe1fadd54a19d75eb934cf9726152f8444c4d6e963e9afb'
+    checksum 'be11cbe60adef45247717ac7eded00d207edbc38639de14124847ebb0ec4e01e'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {


### PR DESCRIPTION
Recent CI builds have been failing because this URL now returns a 404. This is updates the version to use the download link currently posted on the YourKit website.