### PR TITLE
[fix] Explicitly set newRatio=2

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -42,6 +42,7 @@ public interface GcProfile extends Serializable {
     }
 
     class ResponseTime implements GcProfile {
+        private int initialNewRatio = 2;
         private int initiatingOccupancyFraction = 68;
 
         @Override
@@ -53,7 +54,7 @@ public interface GcProfile extends Serializable {
                      *
                      * https://bugs.openjdk.java.net/browse/JDK-8153578
                      */
-                    "-XX:NewRatio=2",
+                    "-XX:NewRatio=" + initialNewRatio,
                     "-XX:+UseCMSInitiatingOccupancyOnly",
                     "-XX:CMSInitiatingOccupancyFraction=" + initiatingOccupancyFraction,
                     "-XX:+CMSClassUnloadingEnabled",
@@ -66,6 +67,10 @@ public interface GcProfile extends Serializable {
 
         public final void initiatingOccupancyFraction(int occupancyFraction) {
             this.initiatingOccupancyFraction = occupancyFraction;
+        }
+
+        public final void initialNewRatio(int newRatio) {
+            this.initialNewRatio = newRatio;
         }
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -48,6 +48,12 @@ public interface GcProfile extends Serializable {
         public final List<String> gcJvmOpts() {
             return ImmutableList.of("-XX:+UseParNewGC",
                     "-XX:+UseConcMarkSweepGC",
+                    /*
+                     * When setting UseConcMarkSweepGC the default value of NewRatio (2) is completely ignored.
+                     *
+                     * https://bugs.openjdk.java.net/browse/JDK-8153578
+                     */
+                    "-XX:NewRatio=2",
                     "-XX:+UseCMSInitiatingOccupancyOnly",
                     "-XX:CMSInitiatingOccupancyFraction=" + initiatingOccupancyFraction,
                     "-XX:+CMSClassUnloadingEnabled",

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -42,7 +42,7 @@ public interface GcProfile extends Serializable {
     }
 
     class ResponseTime implements GcProfile {
-        private int initialNewRatio = 2;
+        private int newRatio = 2;
         private int initiatingOccupancyFraction = 68;
 
         @Override
@@ -54,7 +54,7 @@ public interface GcProfile extends Serializable {
                      *
                      * https://bugs.openjdk.java.net/browse/JDK-8153578
                      */
-                    "-XX:NewRatio=" + initialNewRatio,
+                    "-XX:NewRatio=" + newRatio,
                     "-XX:+UseCMSInitiatingOccupancyOnly",
                     "-XX:CMSInitiatingOccupancyFraction=" + initiatingOccupancyFraction,
                     "-XX:+CMSClassUnloadingEnabled",
@@ -69,8 +69,8 @@ public interface GcProfile extends Serializable {
             this.initiatingOccupancyFraction = occupancyFraction;
         }
 
-        public final void initialNewRatio(int newRatio) {
-            this.initialNewRatio = newRatio;
+        public final void newRatio(int newerRatio) {
+            this.newRatio = newerRatio;
         }
     }
 


### PR DESCRIPTION
## Before this PR
Our "Response" GC profile used CMS and did not explicitly set `NewRatio`, assuming that the default value of 2 would be respected. It turns out that CMS "ergonomically" selects a smaller new gen size to keep GC https://bugs.openjdk.java.net/browse/JDK-8153578

## After this PR
We explicitly set `NewRatio` to 2, increasing the size of the newGen and hopefully improving time spent in GC