### PR TITLE
Disable tests which start mock service

### DIFF
--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -24,11 +24,17 @@ import com.palantir.gradle.dist.service.tasks.LaunchConfigTask
 import java.util.zip.ZipFile
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
+import spock.lang.Ignore
 
 class ServiceDistributionPluginTests extends GradleIntegrationSpec {
     private static final OBJECT_MAPPER = new ObjectMapper(new YAMLFactory())
             .registerModule(new GuavaModule())
 
+    /*
+     * Disabled until we resolve an issue where zombie processes are not being correctly cleaned up in CI.
+     * https://discuss.circleci.com/t/pid-1-in-circleci-rust-1-34-1-browsers-not-reaping-zombies/30214/3
+     */
+    @Ignore
     def 'produce distribution bundle and check start, stop, restart, check behavior'() {
         given:
         createUntarBuildFile(buildFile)
@@ -78,6 +84,11 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
         execWithOutput('dist/service-name-0.0.1/service/monitoring/bin/check.sh') ==~ /.*\n*Checking health of 'service-name'\.\.\.\s+Healthy.*\n/
     }
 
+    /*
+     * Disabled until we resolve an issue where zombie processes are not being correctly cleaned up in CI.
+     * https://discuss.circleci.com/t/pid-1-in-circleci-rust-1-34-1-browsers-not-reaping-zombies/30214/3
+     */
+    @Ignore
     def 'packaging tasks re-run after version change'() {
         given:
         createUntarBuildFile(buildFile)


### PR DESCRIPTION
We've encountered an issue where a change to the CI environment is causing processes to persist as zombie processes instead of properly being cleaned up. This causes our builds to fails due to timeout since go-java-launcher polls will wait for up to 4 minutes for its subprocesses to get cleaned up.

I'd like to get develop green and publishable again while we find a solution to the root cause.