### PR TITLE
Revert "[fix] Use pom extension for product dependencies (#500)"

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -112,8 +112,7 @@ public final class ProductDependencyIntrospectionPlugin implements Plugin<Projec
                 .map(dependency -> project.getDependencies().create(ImmutableMap.of(
                         "group", dependency.getProductGroup(),
                         "name", dependency.getProductName(),
-                        "version", dependency.getMinimumVersion(),
-                        "ext", "pom")))
+                        "version", dependency.getMinimumVersion())))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Product dependencies may include other subprojects and explicitly depending on the `pom` artifact won't resolve to the project.