### PR TITLE
[improvement] Add `-XX:-OmitStackTraceInFastThrow` to default jvm opts

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -56,6 +56,7 @@ public class LaunchConfigTask extends DefaultTask {
 
     private static final List<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
+            "-XX:-OmitStackTraceInFastThrow",
             "-Djava.io.tmpdir=var/data/tmp",
             "-XX:ErrorFile=var/log/hs_err_pid%p.log",
             "-XX:HeapDumpPath=var/log",

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -411,6 +411,7 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
             .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
             .jvmOpts([
                 '-XX:+CrashOnOutOfMemoryError',
+                '-XX:-OmitStackTraceInFastThrow',
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
@@ -434,6 +435,7 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
             .classpath(actualStaticConfig.classpath())
             .jvmOpts([
                 '-XX:+CrashOnOutOfMemoryError',
+                '-XX:-OmitStackTraceInFastThrow',
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
@@ -471,6 +473,7 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
             .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
             .jvmOpts([
                 '-XX:+CrashOnOutOfMemoryError',
+                '-XX:-OmitStackTraceInFastThrow',
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',


### PR DESCRIPTION
## Before this PR
The JVM will have its default behavior, where if an exception is thrown many times, eventually the stacktrace will be omitted. This can make debugging difficult at times when there is a bug that causes an exception to be thrown over and over, but it isn't noticed until the old logs with the stacktrace have been rolled.

See http://jawspeak.com/2010/05/26/hotspot-caused-exceptions-to-lose-their-stack-traces-in-production-and-the-fix/
## After this PR
Stacktraces will always be present. While this disables a performance optimization, I can't think of a situation where we want these stacktraces to be optimized away. In general we should fix our code so that we don't throw the same exception over and over, rendering the optimization unnecessary.