### PR TITLE
[fix] Fix documentation error with addJava8GcLogging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ And the complete list of configurable properties:
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
    be applied when `init.sh` is run.
  * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default), `hybrid` and `response-time`.
- * (optional) `addJava8GCLogging` add java 8 specific gc logging options.
+ * (optional) `addJava8GcLogging` add java 8 specific gc logging options.
 
 #### JVM Options
 


### PR DESCRIPTION
This shouldn't bump versions, it's just a documentation change.