### PR TITLE
Bump yourkit version as current one returns 404

### DIFF
--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -45,7 +45,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2019.1-b117"
+def yourkitVersion = "2019.1-b133"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -58,7 +58,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum 'be11cbe60adef45247717ac7eded00d207edbc38639de14124847ebb0ec4e01e'
+    checksum 'f8b7391cfac0fe9400504bd705ad06479359d38df461e09b7702e54a90182337'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {


### PR DESCRIPTION
## Before this PR

Can't download yourkit 2019.1-b117 anymore

## After this PR
Bump yourkit version to latest 2019.1-b133

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
