### PR TITLE
Correctly merge product dependecies

### DIFF
--- a/changelog/@unreleased/pr-543.v2.yml
+++ b/changelog/@unreleased/pr-543.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly merge discovered product dependencies
+  links:
+  - https://github.com/palantir/sls-packaging/pull/543

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -427,7 +427,7 @@ public class CreateManifestTask extends DefaultTask {
                 .forEach(productDependency -> discoveredProductDependencies.merge(
                         new ProductId(productDependency.getProductGroup(), productDependency.getProductName()),
                         productDependency,
-                        (key, oldValue) -> ProductDependencyMerger.merge(oldValue, productDependency)));
+                        ProductDependencyMerger::merge));
         return discoveredProductDependencies;
     }
 


### PR DESCRIPTION
## Before this PR
If multiple Jar's contributed a constraint on a given coordinate we would not merge them and instead use the first constraint we encountered

## After this PR
==COMMIT_MSG==
Correctly merge discovered product dependencies
==COMMIT_MSG==

## Possible downsides?
N/A

