### PR TITLE
Support gradle 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'com.palantir.git-version'
 apply plugin: 'com.palantir.consistent-versions'
 
 allprojects {
-    version gitVersion()
+    version System.env.CIRCLE_TAG ?: gitVersion()
     group 'com.palantir.sls-packaging'
 
     repositories {
@@ -35,5 +35,9 @@ subprojects {
     apply plugin: 'java-library'
     java {
         sourceCompatibility JavaVersion.VERSION_1_8
+    }
+
+    tasks.withType(JavaCompile) {
+        options.compilerArgs += ['-Werror', '-Xlint:deprecation']
     }
 }

--- a/changelog/@unreleased/pr-580.v2.yml
+++ b/changelog/@unreleased/pr-580.v2.yml
@@ -1,0 +1,6 @@
+type: break
+break:
+  description: sls-packaging should now be compatible with Gradle 6.0, but means sls-packaging
+    requires at least Gradle 5.1 and is no longer compatible with 4.X.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/580

--- a/changelog/@unreleased/pr-580.v2.yml
+++ b/changelog/@unreleased/pr-580.v2.yml
@@ -1,6 +1,6 @@
 type: break
 break:
-  description: sls-packaging should now be compatible with Gradle 6.0, but means sls-packaging
-    requires at least Gradle 5.1 and is no longer compatible with 4.X.
+  description: sls-packaging should now be compatible with Gradle 6.0. sls-packaging
+    now requires at least Gradle 5.1 and is no longer compatible with 4.X.
   links:
   - https://github.com/palantir/sls-packaging/pull/580

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -73,7 +73,7 @@ public class BaseDistributionExtension {
         serviceName.set(project.provider(project::getName));
         podName.set(project.provider(project::getName));
 
-        manifestExtensions = project.getObjects().mapProperty(String.class, Object.class);
+        manifestExtensions = project.getObjects().mapProperty(String.class, Object.class).empty();
 
         projectName = project.getName();
     }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.dist;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import groovy.lang.Closure;
@@ -33,6 +32,7 @@ import javax.inject.Inject;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -55,10 +55,8 @@ public class BaseDistributionExtension {
     private final ListProperty<ProductDependency> productDependencies;
     private final SetProperty<ProductId> ignoredProductDependencies;
     private final ProviderFactory providerFactory;
+    private final MapProperty<String, Object> manifestExtensions;
     private final String projectName;
-
-    // TODO(forozco): Use MapProperty once our minimum supported version is 5.1
-    private Map<String, Object> manifestExtensions;
     private Configuration productDependenciesConfig;
 
     @Inject
@@ -75,7 +73,7 @@ public class BaseDistributionExtension {
         serviceName.set(project.provider(project::getName));
         podName.set(project.provider(project::getName));
 
-        manifestExtensions = Maps.newHashMap();
+        manifestExtensions = project.getObjects().mapProperty(String.class, Object.class);
 
         projectName = project.getName();
     }
@@ -221,7 +219,7 @@ public class BaseDistributionExtension {
         this.ignoredProductDependencies.add(id);
     }
 
-    public final Map<String, Object> getManifestExtensions() {
+    public final Provider<Map<String, Object>> getManifestExtensions() {
         return this.manifestExtensions;
     }
 
@@ -234,7 +232,7 @@ public class BaseDistributionExtension {
     }
 
     public final void setManifestExtensions(Map<String, Object> extensions) {
-        manifestExtensions = extensions;
+        manifestExtensions.set(extensions);
     }
 
     public final Configuration getProductDependenciesConfig() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.java
@@ -24,12 +24,12 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 
 public class AssetDistributionExtension extends BaseDistributionExtension {
-    private MapProperty<String, String> assets;
+    private final MapProperty<String, String> assets;
 
     @Inject
     public AssetDistributionExtension(Project project) {
         super(project);
-        assets = project.getObjects().mapProperty(String.class, String.class);
+        assets = project.getObjects().mapProperty(String.class, String.class).empty();
         setProductType(ProductType.ASSET_V1);
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtension.java
@@ -15,25 +15,25 @@
  */
 package com.palantir.gradle.dist.asset;
 
-import com.google.common.collect.Maps;
 import com.palantir.gradle.dist.BaseDistributionExtension;
 import com.palantir.gradle.dist.ProductType;
 import java.util.Map;
 import javax.inject.Inject;
 import org.gradle.api.Project;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Provider;
 
 public class AssetDistributionExtension extends BaseDistributionExtension {
-    // TODO(forozco): Use MapProperty once our minimum supported version is 5.1
-    private Map<String, String> assets;
+    private MapProperty<String, String> assets;
 
     @Inject
     public AssetDistributionExtension(Project project) {
         super(project);
-        assets = Maps.newHashMap();
+        assets = project.getObjects().mapProperty(String.class, String.class);
         setProductType(ProductType.ASSET_V1);
     }
 
-    public final Map<String, String> getAssets() {
+    public final Provider<Map<String, String>> getAssets() {
         return assets;
     }
 
@@ -46,6 +46,6 @@ public class AssetDistributionExtension extends BaseDistributionExtension {
     }
 
     public final void setAssets(Map<String, String> assets) {
-        this.assets = assets;
+        this.assets.set(assets);
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -61,7 +61,7 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
             task.getArchiveBaseName().set(distributionExtension.getDistributionServiceName());
             task.getArchiveVersion().set(project.provider(() -> project.getVersion().toString()));
             task.getArchiveExtension().set("sls.tgz");
-            task.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
+            task.getDestinationDirectory().set(project.getLayout().getBuildDirectory().dir("distributions"));
 
             task.dependsOn(manifest);
         });

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -58,8 +58,10 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
             task.setGroup(AssetDistributionPlugin.GROUP_NAME);
             task.setDescription("Creates a compressed, gzipped tar file that contains required static assets.");
             task.setCompression(Compression.GZIP);
-            task.setExtension("sls.tgz");
-            task.setDestinationDir(new File(project.getBuildDir(), "distributions"));
+            task.getArchiveBaseName().set(distributionExtension.getDistributionServiceName());
+            task.getArchiveVersion().set(project.provider(() -> project.getVersion().toString()));
+            task.getArchiveExtension().set("sls.tgz");
+            task.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
 
             task.dependsOn(manifest);
         });
@@ -67,10 +69,6 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
         // HACKHACK after evaluate to configure task with all declared assets, this is required since
         // task.into doesn't support providers
         project.afterEvaluate(p -> distTar.configure(task -> {
-            // TODO(forozco): Use provider based API when minimum version is 5.1
-            task.setBaseName(distributionExtension.getDistributionServiceName().get());
-            task.setVersion(project.getVersion().toString());
-
             String archiveRootDir = String.format("%s-%s",
                     distributionExtension.getDistributionServiceName().get(), p.getVersion());
 
@@ -80,7 +78,7 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
             task.from(new File(project.getBuildDir(), "deployment"), t ->
                     t.into(new File(String.format("%s/deployment", archiveRootDir))));
 
-            distributionExtension.getAssets().forEach((key, value) ->
+            distributionExtension.getAssets().get().forEach((key, value) ->
                     task.from(p.file(key), t ->
                             t.into(String.format("%s/asset/%s", archiveRootDir, value))));
         }));

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionExtension.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.dist.pod;
 
-import com.google.common.collect.Maps;
 import com.palantir.gradle.dist.BaseDistributionExtension;
 import com.palantir.gradle.dist.ProductType;
 import groovy.lang.Closure;
@@ -24,24 +23,25 @@ import groovy.lang.DelegatesTo;
 import java.util.Map;
 import javax.inject.Inject;
 import org.gradle.api.Project;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Provider;
 import org.gradle.util.ConfigureUtil;
 
 public class PodDistributionExtension extends BaseDistributionExtension {
-    // TODO(forozco): Use MapProperty once our minimum supported version is 5.1
-    private Map<String, PodServiceDefinition> services;
-    private Map<String, PodVolumeDefinition> volumes;
+    private MapProperty<String, PodServiceDefinition> services;
+    private MapProperty<String, PodVolumeDefinition> volumes;
 
     @Inject
     public PodDistributionExtension(Project project) {
         super(project);
 
-        services = Maps.newHashMap();
-        volumes = Maps.newHashMap();
+        services = project.getObjects().mapProperty(String.class, PodServiceDefinition.class);
+        volumes = project.getObjects().mapProperty(String.class, PodVolumeDefinition.class);
 
         setProductType(ProductType.POD_V1);
     }
 
-    public final Map<String, PodServiceDefinition> getServices() {
+    public final Provider<Map<String, PodServiceDefinition>> getServices() {
         return services;
     }
 
@@ -50,7 +50,7 @@ public class PodDistributionExtension extends BaseDistributionExtension {
     }
 
     public final void setServices(Map<String, PodServiceDefinition> services) {
-        this.services = services;
+        this.services.set(services);
     }
 
     public final void service(String name, @DelegatesTo(PodServiceDefinition.class) Closure closure) {
@@ -60,7 +60,7 @@ public class PodDistributionExtension extends BaseDistributionExtension {
     }
 
 
-    public final Map<String, PodVolumeDefinition> getVolumes() {
+    public final Provider<Map<String, PodVolumeDefinition>> getVolumes() {
         return volumes;
     }
 
@@ -69,7 +69,7 @@ public class PodDistributionExtension extends BaseDistributionExtension {
     }
 
     public final void setVolumes(Map<String, PodVolumeDefinition> volumes) {
-        this.volumes = volumes;
+        this.volumes.set(volumes);
     }
 
     public final void volume(String name, @DelegatesTo(PodVolumeDefinition.class) Closure closure) {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionExtension.java
@@ -28,8 +28,8 @@ import org.gradle.api.provider.Provider;
 import org.gradle.util.ConfigureUtil;
 
 public class PodDistributionExtension extends BaseDistributionExtension {
-    private MapProperty<String, PodServiceDefinition> services;
-    private MapProperty<String, PodVolumeDefinition> volumes;
+    private final MapProperty<String, PodServiceDefinition> services;
+    private final MapProperty<String, PodVolumeDefinition> volumes;
 
     @Inject
     public PodDistributionExtension(Project project) {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/PodDistributionPlugin.java
@@ -55,11 +55,9 @@ public final class PodDistributionPlugin implements Plugin<Project> {
                 "createPodYaml", CreatePodYamlTask.class, task -> {
                     task.setGroup(PodDistributionPlugin.GROUP_NAME);
                     task.setDescription("Generates a simple yaml file describing a pods constituent services.");
+                    task.getServiceDefinitions().set(distributionExtension.getServices());
+                    task.getVolumeDefinitions().set(distributionExtension.getVolumes());
                 });
-        project.afterEvaluate(p -> podYaml.configure(task -> {
-            task.setServiceDefinitions(distributionExtension.getServices());
-            task.setVolumeDefinitions(distributionExtension.getVolumes());
-        }));
 
         TaskProvider<Tar> configTar = ConfigTarTask.createConfigTarTask(project, distributionExtension);
         configTar.configure(task -> task.dependsOn(manifest, podYaml));

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/tasks/CreatePodYamlTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/pod/tasks/CreatePodYamlTask.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -40,27 +41,20 @@ public class CreatePodYamlTask extends DefaultTask {
             .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE)
             .enable(SerializationFeature.INDENT_OUTPUT);
 
-    // TODO(forozco): Use MapProperty once our minimum supported version is 5.1
-    private Map<String, PodServiceDefinition> serviceDefinitions;
-    private Map<String, PodVolumeDefinition> volumeDefinitions;
+    private final MapProperty<String, PodServiceDefinition> serviceDefinitions =
+            getProject().getObjects().mapProperty(String.class, PodServiceDefinition.class);
+    private final MapProperty<String, PodVolumeDefinition> volumeDefinitions =
+            getProject().getObjects().mapProperty(String.class, PodVolumeDefinition.class);
     private File podYamlFile = new File(getProject().getBuildDir(), "deployment/pod.yml");
 
     @Input
-    public final Map<String, PodServiceDefinition> getServiceDefinitions() {
+    public final MapProperty<String, PodServiceDefinition> getServiceDefinitions() {
         return serviceDefinitions;
     }
 
-    public final void setServiceDefinitions(Map<String, PodServiceDefinition> serviceDefinitions) {
-        this.serviceDefinitions = serviceDefinitions;
-    }
-
     @Input
-    public final Map<String, PodVolumeDefinition> getVolumeDefinitions() {
+    public final MapProperty<String, PodVolumeDefinition> getVolumeDefinitions() {
         return volumeDefinitions;
-    }
-
-    public final void setVolumeDefinitions(Map<String, PodVolumeDefinition> volumeDefinitions) {
-        this.volumeDefinitions = volumeDefinitions;
     }
 
     @OutputFile
@@ -85,7 +79,7 @@ public class CreatePodYamlTask extends DefaultTask {
 
     private void validatePodYaml() {
         PropertyNamingStrategy.KebabCaseStrategy kebabCaseStrategy = new PropertyNamingStrategy.KebabCaseStrategy();
-        serviceDefinitions.forEach((key, value) -> {
+        serviceDefinitions.get().forEach((key, value) -> {
             if (!kebabCaseStrategy.translate(key).equals(key)) {
                 throw new GradleException(String.format(
                         SERVICE_VALIDATION_FAIL_FORMAT, key, "service names must be kebab case"));
@@ -98,14 +92,14 @@ public class CreatePodYamlTask extends DefaultTask {
             }
 
             value.getVolumeMap().forEach((volumeKey, volumeValue) -> {
-                if (!volumeDefinitions.containsKey(volumeValue)) {
+                if (!volumeDefinitions.get().containsKey(volumeValue)) {
                     throw new GradleException(String.format(SERVICE_VALIDATION_FAIL_FORMAT, key,
                             "service volume mapping cannot contain undeclared volumes"));
                 }
             });
         });
 
-        volumeDefinitions.forEach((key, value) -> {
+        volumeDefinitions.get().forEach((key, value) -> {
             if (key.length() >= 25) {
                 throw new GradleException(String.format(VOLUME_VALIDATION_FAIL_FORMAT, key,
                         "volume names must be fewer than 25 characters"));

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -45,7 +45,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     private final ListProperty<String> checkArgs;
     private final ListProperty<String> defaultJvmOpts;
     private final ListProperty<String> excludeFromVar;
-    private MapProperty<String, String> env;
+    private final MapProperty<String, String> env;
 
     private final ObjectFactory objectFactory;
 
@@ -71,7 +71,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         excludeFromVar = objectFactory.listProperty(String.class);
         excludeFromVar.addAll("log", "run");
 
-        env = objectFactory.mapProperty(String.class, String.class);
+        env = objectFactory.mapProperty(String.class, String.class).empty();
         setProductType(ProductType.SERVICE_V1);
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -16,13 +16,11 @@
 
 package com.palantir.gradle.dist.service;
 
-import com.google.common.collect.Maps;
 import com.palantir.gradle.dist.BaseDistributionExtension;
 import com.palantir.gradle.dist.ProductType;
 import com.palantir.gradle.dist.service.gc.GcProfile;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -31,6 +29,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.util.ConfigureUtil;
@@ -46,8 +45,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     private final ListProperty<String> checkArgs;
     private final ListProperty<String> defaultJvmOpts;
     private final ListProperty<String> excludeFromVar;
-    // TODO(forozco): Use MapProperty once our minimum supported version is 5.1
-    private Map<String, String> env;
+    private MapProperty<String, String> env;
 
     private final ObjectFactory objectFactory;
 
@@ -67,20 +65,13 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         gc = objectFactory.property(GcProfile.class);
         gc.set(new GcProfile.Throughput());
 
-        args = objectFactory.listProperty(String.class);
-        // TODO(dfox): use listProperty(..).empty() when a minimum Gradle of 5.0 is acceptable
-        args.set(Collections.emptyList());
-
-        checkArgs = objectFactory.listProperty(String.class);
-        checkArgs.set(Collections.emptyList());
-
-        defaultJvmOpts = objectFactory.listProperty(String.class);
-        defaultJvmOpts.set(Collections.emptyList());
-
+        args = objectFactory.listProperty(String.class).empty();
+        checkArgs = objectFactory.listProperty(String.class).empty();
+        defaultJvmOpts = objectFactory.listProperty(String.class).empty();
         excludeFromVar = objectFactory.listProperty(String.class);
         excludeFromVar.addAll("log", "run");
 
-        env = Maps.newHashMap();
+        env = objectFactory.mapProperty(String.class, String.class);
         setProductType(ProductType.SERVICE_V1);
     }
 
@@ -184,7 +175,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.excludeFromVar.set(excludeFromVar);
     }
 
-    public final Map<String, String> getEnv() {
+    public final Provider<Map<String, String>> getEnv() {
         return env;
     }
 
@@ -193,7 +184,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     }
 
     public final void setEnv(Map<String, String> env) {
-        this.env = env;
+        this.env.set(env);
     }
 
     public final Provider<GcProfile> getGc() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -97,7 +97,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                                 .map(File::getName)
                                 .collect(Collectors.joining(" "));
                         task.getManifest().getAttributes().put(
-                                "Class-Path", classPath + " " + task.getArchiveBaseName().get());
+                                "Class-Path", classPath + " " + task.getArchiveFileName().get());
                     });
                     task.onlyIf(t -> distributionExtension.getEnableManifestClasspath().get());
                 });

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -122,7 +122,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                                     .replaceAll(
                                             "(\"%JAVA_EXE%\" .* -classpath \")%CLASSPATH%(\" .*)",
                                             "$1%APP_HOME%\\\\lib\\\\"
-                                                    + manifestClassPathTask.get().getArchiveBaseName().get()
+                                                    + manifestClassPathTask.get().getArchiveFileName().get()
                                                     + "$2");
 
                             GFileUtils.writeFile(cleanedText, task.getWindowsScript());

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateInitScriptTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateInitScriptTask.java
@@ -19,8 +19,8 @@ package com.palantir.gradle.dist.service.tasks;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import com.palantir.gradle.dist.service.util.EmitFiles;
-import java.io.File;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
@@ -28,9 +28,11 @@ import org.gradle.api.tasks.TaskAction;
 
 public class CreateInitScriptTask extends DefaultTask {
     private final Property<String> serviceName = getProject().getObjects().property(String.class);
+    private final RegularFileProperty outputFile = getProject().getObjects().fileProperty();
 
-    // TODO(forozco): Use RegularFileProperty once our minimum supported version is 5.0
-    private File outputFile = new File(getProject().getBuildDir(), "scripts/init.sh");
+    public CreateInitScriptTask() {
+        outputFile.set(getProject().getLayout().getBuildDirectory().file("scripts/init.sh"));
+    }
 
     @Input
     public final Property<String> getServiceName() {
@@ -38,19 +40,15 @@ public class CreateInitScriptTask extends DefaultTask {
     }
 
     @OutputFile
-    public final File getOutputFile() {
+    public final RegularFileProperty getOutputFile() {
         return outputFile;
-    }
-
-    public final void setOutputFile(File outputFile) {
-        this.outputFile = outputFile;
     }
 
     @TaskAction
     final void createInitScript() {
         EmitFiles.replaceVars(
                 JavaServiceDistributionPlugin.class.getResourceAsStream("/init.sh"),
-                getOutputFile().toPath(),
+                getOutputFile().get().getAsFile().toPath(),
                 ImmutableMap.of("@serviceName@", serviceName.get()))
                 .toFile()
                 .setExecutable(true);

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.palantir.gradle.dist.service.gc.GcProfile;
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +32,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -78,7 +78,7 @@ public class LaunchConfigTask extends DefaultTask {
     private final ListProperty<String> checkArgs = getProject().getObjects().listProperty(String.class);
     private final ListProperty<String> defaultJvmOpts = getProject().getObjects().listProperty(String.class);
 
-    private final Property<Map> env = getProject().getObjects().property(Map.class);
+    private final MapProperty<String, String> env = getProject().getObjects().mapProperty(String.class, String.class);
 
     // TODO(forozco): Use RegularFileProperty once our minimum supported version is 5.0
     private File staticLauncher = new File(getProject().getBuildDir(), "scripts/launcher-static.yml");
@@ -86,9 +86,7 @@ public class LaunchConfigTask extends DefaultTask {
 
     private FileCollection classpath;
 
-    public LaunchConfigTask() {
-        env.set(Maps.newHashMap());
-    }
+    public LaunchConfigTask() { }
 
     @Input
     public final Property<String> getMainClass() {
@@ -137,7 +135,7 @@ public class LaunchConfigTask extends DefaultTask {
     }
 
     @Input
-    public final Property<Map> getEnv() {
+    public final MapProperty<String, String> getEnv() {
         return env;
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -37,8 +37,8 @@ public final class ConfigTarTask {
 
             task.from(new File(project.getProjectDir(), "deployment"));
             task.from(new File(project.getBuildDir(), "deployment"));
-            task.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
-            task.getArchiveBaseName().set(ext.getDistributionServiceName().get());
+            task.getDestinationDirectory().set(project.getLayout().getBuildDirectory().dir("distributions"));
+            task.getArchiveBaseName().set(ext.getDistributionServiceName());
             task.getArchiveVersion().set(project.provider(() -> project.getVersion().toString()));
             task.getArchiveExtension().set(ext.getProductType().map(productType -> {
                 try {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -37,23 +37,21 @@ public final class ConfigTarTask {
 
             task.from(new File(project.getProjectDir(), "deployment"));
             task.from(new File(project.getBuildDir(), "deployment"));
-        });
-
-        project.afterEvaluate(p -> configTar.configure(task -> {
-            // TODO(forozco): Use provider based API when minimum version is 5.1
-            task.setDestinationDir(new File(project.getBuildDir(), "distributions"));
-            task.setBaseName(ext.getDistributionServiceName().get());
-            task.setVersion(project.getVersion().toString());
-            task.setExtension(ext.getProductType().map(productType -> {
+            task.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
+            task.getArchiveBaseName().set(ext.getDistributionServiceName().get());
+            task.getArchiveVersion().set(project.provider(() -> project.getVersion().toString()));
+            task.getArchiveExtension().set(ext.getProductType().map(productType -> {
                 try {
                     String productTypeString = CreateManifestTask.jsonMapper.writeValueAsString(productType);
                     return productTypeString.substring(1, productTypeString.lastIndexOf('.')).concat(".config.tgz");
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
-            }).get());
+            }));
+        });
 
-            // TODO(forozco): make this lazy since into does not support providers, but does support callable
+        // TODO(forozco): make this lazy since into does not support providers, but does support callable
+        project.afterEvaluate(p -> configTar.configure(task -> {
             task.into(String.format("%s-%s/deployment", ext.getDistributionServiceName().get(), project.getVersion()));
         }));
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionExtensionTest.groovy
@@ -31,7 +31,7 @@ class AssetDistributionExtensionTest extends ProjectSpec {
         }
 
         then:
-        ext.getAssets() == [
+        ext.getAssets().get() == [
                 "path/to/src" : "relocated/dest",
                 "path/to/src2": "relocated/dest2",
                 "path/to/foo" : "path/to/foo"
@@ -49,6 +49,6 @@ class AssetDistributionExtensionTest extends ProjectSpec {
         }
 
         then:
-        ext.getAssets() == ["path/to/src2": "relocated/dest2"]
+        ext.getAssets().get() == ["path/to/src2": "relocated/dest2"]
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pod/PodDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pod/PodDistributionExtensionTest.groovy
@@ -39,7 +39,7 @@ class PodDistributionExtensionTest extends Specification {
         }
 
         then:
-        def ks = ext.getServices().keySet()
+        def ks = ext.getServices().get().keySet()
         ks.contains("bar")
         ks.contains("baz")
     }
@@ -57,7 +57,7 @@ class PodDistributionExtensionTest extends Specification {
         }
 
         then:
-        def ks = ext.getServices().keySet()
+        def ks = ext.getServices().get().keySet()
         ks.contains("baz")
         !ks.contains("bar")
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -54,7 +54,7 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.checkArgs.get() == ['a', 'b', 'c', 'd']
         ext.defaultJvmOpts.get() == ['a', 'b', 'c', 'd']
         ext.excludeFromVar.get() == ['log', 'run', 'a', 'b', 'c', 'd']
-        ext.env == ['a': 'b', 'c': 'd']
+        ext.env.get() == ['a': 'b', 'c': 'd']
     }
 
     def 'collection setters replace existing data'() {
@@ -82,7 +82,7 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.checkArgs.get() == ['c', 'd']
         ext.defaultJvmOpts.get() == ['c', 'd']
         ext.excludeFromVar.get() == ['c', 'd']
-        ext.env == ['foo': 'bar']
+        ext.env.get() == ['foo': 'bar']
     }
 
     def 'sensible defaults' () {


### PR DESCRIPTION
## Before this PR
We would fail to build a Java service using gradle 6.0 because of a couple deprecations.

## After this PR
==COMMIT_MSG==
Raise minimum compatible version of Gradle to 5.1 to become compatible with  Gradle 6.0
==COMMIT_MSG==

## Possible downsides?
We will only be compatible with Gradle 5.1+ which gives a ~9 month compatibility window

