### PR TITLE
Use manifest classpath in launcher YAML files and startScript when configured

### DIFF
--- a/changelog/@unreleased/pr-618.v2.yml
+++ b/changelog/@unreleased/pr-618.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use manifest classpath in launcher YAML files and startScript when it is configured.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/580

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -146,7 +146,8 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             } else {
                 task.setClasspath(
                         jarTask.get().getOutputs().getFiles().plus(
-                                distributionExtension.getProductDependenciesConfig()));
+                                javaPlugin.getSourceSets().getByName("main").getRuntimeClasspath()));
+
             }
         }));
 
@@ -165,13 +166,6 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getAddJava8GcLogging().set(distributionExtension.getAddJava8GcLogging());
                     task.getJavaHome().set(distributionExtension.getJavaHome());
                     task.getEnv().set(distributionExtension.getEnv());
-                    if (distributionExtension.getEnableManifestClasspath().get()) {
-                        task.setClasspath(manifestClassPathTask.get().getOutputs().getFiles());
-                    } else {
-                        task.setClasspath(
-                                jarTask.get().getOutputs().getFiles().plus(
-                                        distributionExtension.getProductDependenciesConfig()));
-                    }
                 });
 
         TaskProvider<CreateInitScriptTask> initScript = project.getTasks().register(
@@ -228,6 +222,16 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.dependsOn(startScripts, initScript, checkScript, yourkitAgent, yourkitLicense);
             task.dependsOn(copyLauncherBinaries, launchConfigTask, manifest, manifestClassPathTask);
         });
+
+        project.afterEvaluate(p -> launchConfigTask.configure(task -> {
+            if (distributionExtension.getEnableManifestClasspath().get()) {
+                task.setClasspath(manifestClassPathTask.get().getOutputs().getFiles());
+            } else {
+                task.setClasspath(
+                        jarTask.get().getOutputs().getFiles().plus(
+                                distributionExtension.getProductDependenciesConfig()));
+            }
+        }));
 
         project.afterEvaluate(p -> DistTarTask.configure(
                 distTar.get(),

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -148,6 +148,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                 "createLaunchConfig", LaunchConfigTask.class, task -> {
                     task.setGroup(JavaServiceDistributionPlugin.GROUP_NAME);
                     task.setDescription("Generates launcher-static.yml and launcher-check.yml configurations.");
+                    task.dependsOn(manifestClassPathTask);
 
                     task.getMainClass().set(distributionExtension.getMainClass());
                     task.getServiceName().set(distributionExtension.getDistributionServiceName());
@@ -158,9 +159,13 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getAddJava8GcLogging().set(distributionExtension.getAddJava8GcLogging());
                     task.getJavaHome().set(distributionExtension.getJavaHome());
                     task.getEnv().set(distributionExtension.getEnv());
-                    task.setClasspath(
-                            jarTask.get().getOutputs().getFiles().plus(
-                                    distributionExtension.getProductDependenciesConfig()));
+                    if (distributionExtension.getEnableManifestClasspath().get()) {
+                        task.setClasspath(manifestClassPathTask.get().getOutputs().getFiles());
+                    } else {
+                        task.setClasspath(
+                                jarTask.get().getOutputs().getFiles().plus(
+                                        distributionExtension.getProductDependenciesConfig()));
+                    }
                 });
 
         TaskProvider<CreateInitScriptTask> initScript = project.getTasks().register(

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -138,10 +138,16 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.setMainClassName(distributionExtension.getMainClass().get());
             task.setApplicationName(distributionExtension.getDistributionServiceName().get());
             task.setDefaultJvmOpts(distributionExtension.getDefaultJvmOpts().get());
+            task.dependsOn(manifestClassPathTask);
 
             JavaPluginConvention javaPlugin = project.getConvention().findPlugin(JavaPluginConvention.class);
-            task.setClasspath(jarTask.get().getOutputs().getFiles().plus(
-                    javaPlugin.getSourceSets().getByName("main").getRuntimeClasspath()));
+            if (distributionExtension.getEnableManifestClasspath().get()) {
+                task.setClasspath(manifestClassPathTask.get().getOutputs().getFiles());
+            } else {
+                task.setClasspath(
+                        jarTask.get().getOutputs().getFiles().plus(
+                                distributionExtension.getProductDependenciesConfig()));
+            }
         }));
 
         TaskProvider<LaunchConfigTask> launchConfigTask = project.getTasks().register(

--- a/readme.md
+++ b/readme.md
@@ -178,8 +178,8 @@ And the complete list of configurable properties:
    for details on the custom environment block.
  * (optional) `defaultJvmOpts` a list of default JVM options to set on the program.
  * (optional) `enableManifestClasspath` a boolean flag; if set to true, then the explicit Java
-   classpath is omitted from the generated Windows start script and instead inferred
-   from a JAR file whose MANIFEST contains the classpath entries.
+   classpath is omitted from the generated start scripts and static launcher config and instead
+   inferred from a JAR file whose MANIFEST contains the classpath entries.
  * (optional) `excludeFromVar` a list of directories (relative to `${projectDir}/var`) to exclude from the distribution,
    defaulting to `['log', 'run']`.
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Use manifest classpath in launcher YAML files and startScript when configured
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

