### PR TITLE
go-java-launcher 1.6.2 -> 1.7.0

### DIFF
--- a/changelog/@unreleased/pr-631.v2.yml
+++ b/changelog/@unreleased/pr-631.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: go-java-launcher 1.6.2 -> 1.7.0.
+               Enables fallback to to $JAVA_HOME if configured javaHome is not found
+  links:
+  - https://github.com/palantir/sls-packaging/pull/631

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -46,8 +46,8 @@ import org.gradle.util.GFileUtils;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER_BINARIES = "goJavaLauncherBinaries";
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.6.2";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.6.2";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.7.0";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.7.0";
     public static final String GROUP_NAME = "Distribution";
 
     @SuppressWarnings("checkstyle:methodlength")


### PR DESCRIPTION
==COMMIT_MSG==
Enables fallback to to $JAVA_HOME if configured javaHome is not found
==COMMIT_MSG==

