### PR TITLE
Correctly configure run task

### DIFF
--- a/changelog/@unreleased/pr-647.v2.yml
+++ b/changelog/@unreleased/pr-647.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly configure `run` task lazily
+  links:
+  - https://github.com/palantir/sls-packaging/pull/647

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -32,9 +32,11 @@ import com.palantir.gradle.dist.tasks.ConfigTarTask;
 import com.palantir.gradle.dist.tasks.CreateManifestTask;
 import java.io.File;
 import java.util.stream.Collectors;
+import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -202,6 +204,12 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.setGroup(JavaServiceDistributionPlugin.GROUP_NAME);
             task.setDescription("Runs the specified project using configured mainClass and with default args.");
             task.dependsOn("jar");
+            task.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task _task) {
+                    task.setMain(distributionExtension.getMainClass().get());
+                }
+            });
         });
 
         // HACKHACK setClasspath of JavaExec is eager so we configure it after evaluation to ensure everything has
@@ -210,7 +218,6 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.setClasspath(project.files(
                     jarTask.get().getArchiveFile().get(),
                     p.getConfigurations().getByName("runtimeClasspath")));
-            task.setMain(distributionExtension.getMainClass().get());
             task.setArgs(distributionExtension.getArgs().get());
             task.setJvmArgs(distributionExtension.getDefaultJvmOpts().get());
         }));

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/ServiceDistributionPluginTests.groovy
@@ -1056,6 +1056,9 @@ class ServiceDistributionPluginTests extends GradleIntegrationSpec {
                 serviceName 'service-name'
                 gc 'hybrid'
             }
+            
+            task Foo {} 
+            tasks.run.dependsOn Foo
 
             // most convenient way to untar the dist is to use gradle
             task untar (type: Copy) {


### PR DESCRIPTION
## Before this PR
#644 introduced a bug that would cause builds fail at configuration time if the `run` tasks was realized.

## After this PR
==COMMIT_MSG==
Correctly configure `run` task lazily
==COMMIT_MSG==

## Possible downsides?
N/A

