### PR TITLE
Actually configure run task correctly

### DIFF
--- a/changelog/@unreleased/pr-649.v2.yml
+++ b/changelog/@unreleased/pr-649.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Run task correctly uses the discovered mainClass
+  links:
+  - https://github.com/palantir/sls-packaging/pull/649

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -207,7 +207,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.doFirst(new Action<Task>() {
                 @Override
                 public void execute(Task _task) {
-                    task.setMain(distributionExtension.getMainClass().get());
+                    task.setMain(mainClassName.get());
                 }
             });
         });


### PR DESCRIPTION
## Before this PR
#647 correctly made run task configuration lazy, but it sourced the mainClass directly from the extension instead of falling back to the discovered main class

## After this PR
==COMMIT_MSG==
Run task correctly uses the discovered mainClass
==COMMIT_MSG==

## Possible downsides?
No, just a bug fix

