### PR TITLE
Run task inherits GC options

### DIFF
--- a/changelog/@unreleased/pr-678.v2.yml
+++ b/changelog/@unreleased/pr-678.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Service Distributions "run" task correctly respects the GC profile
+  links:
+  - https://github.com/palantir/sls-packaging/pull/678

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.gradle.dist.service;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.asset.AssetDistributionPlugin;
@@ -219,7 +220,10 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     jarTask.get().getArchiveFile().get(),
                     p.getConfigurations().getByName("runtimeClasspath")));
             task.setArgs(distributionExtension.getArgs().get());
-            task.setJvmArgs(distributionExtension.getDefaultJvmOpts().get());
+            task.setJvmArgs(ImmutableList.builder()
+                    .addAll(distributionExtension.getDefaultJvmOpts().get())
+                    .addAll(distributionExtension.getGc().get().gcJvmOpts())
+                    .build());
         }));
 
         TaskProvider<Tar> distTar = project.getTasks().register("distTar", Tar.class, task -> {


### PR DESCRIPTION
## Before this PR
The GC profile was ignored when running locally

## After this PR
==COMMIT_MSG==
Service Distributions "run" task correctly respects the GC profile
==COMMIT_MSG==

## Possible downsides?
N/A
