### PR TITLE
Expose shenandoah as response-time-13

### DIFF
--- a/changelog/@unreleased/pr-679.v2.yml
+++ b/changelog/@unreleased/pr-679.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Expose `response-time-13` GC profile
+  links:
+  - https://github.com/palantir/sls-packaging/pull/679

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -30,6 +30,7 @@ public interface GcProfile extends Serializable {
     Map<String, Class<? extends GcProfile>> PROFILE_NAMES = ImmutableMap.of(
             "throughput", GcProfile.Throughput.class,
             "response-time", GcProfile.ResponseTime.class,
+            "response-time-13", GcProfile.ResponseTime13.class,
             "hybrid", GcProfile.Hybrid.class);
 
     List<String> gcJvmOpts();
@@ -83,10 +84,11 @@ public interface GcProfile extends Serializable {
         }
     }
 
-    class ResponseTime11 implements GcProfile {
+    class ResponseTime13 implements GcProfile {
         @Override
         public final List<String> gcJvmOpts() {
             return ImmutableList.of(
+                    "-XX:+UnlockExperimentalVMOptions",
                     // https://wiki.openjdk.java.net/display/shenandoah/Main
                     "-XX:+UseShenandoahGC",
                     // "forces concurrent cycle instead of Full GC on System.gc()"

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
@@ -21,6 +21,7 @@ import com.palantir.gradle.dist.service.gc.GcProfile
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.stream.Collectors
 import org.awaitility.Awaitility
 import spock.lang.Unroll
 
@@ -83,6 +84,9 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
         println file("touch-service-1.0.0/var/log/startup.log").text
 
         where:
-        gc << GcProfile.PROFILE_NAMES.keySet().toArray()
+        // TODO(forozco): Test response-time-13 once we test using Java 13
+        gc << GcProfile.PROFILE_NAMES.keySet().stream()
+                .filter({ it != "response-time-13"})
+                .collect(Collectors.toList())
     }
 }


### PR DESCRIPTION
## Before this PR
There was a `ResponseTime11` GC Profile in code that was not easily exposed to users that would ostensibly configure the JVM (with Java >= 11) to use Shenandoah. 

Unfortunately, "hacking" to use this profile with Java 11 would cause a process to crash with `Unrecognized VM option 'UseShenandoahGC'`. 

When run with Java 13 you'd the JVM would fail to start with the following error `Error: VM option 'UseShenandoahGC' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.`

## After this PR
==COMMIT_MSG==
Expose `response-time-13` GC profile 
==COMMIT_MSG==

## Possible downsides?
Technically this is break since users _could_ have been using the GC profile and then made it work by passing the missing JVM flag separately. I don't think thats the case though, so I feel pretty comfortable marking this as an improvement

