### PR TITLE
Expose javaVersion property in ServiceDistributionExtension

### DIFF
--- a/changelog/@unreleased/pr-680.v2.yml
+++ b/changelog/@unreleased/pr-680.v2.yml
@@ -1,7 +1,8 @@
 type: feature
 feature:
   description: Add `javaVersion` property to JavaServiceDistributionExtension which
-    specifies the version of Java the service intends to run with. javaVersion defaults
-    to the source compatibility of the project
+    specifies the version of Java the service intends to run with. `javaVersion` defaults
+    to the source compatibility of the project. When `javaVersion` is greater than Java 13
+    "response-time" GC profile will use Shenandoah instead of CMS
   links:
   - https://github.com/palantir/sls-packaging/pull/680

--- a/changelog/@unreleased/pr-680.v2.yml
+++ b/changelog/@unreleased/pr-680.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: Add `javaVersion` property to JavaServiceDistributionExtension which
+    specifies the version of Java the service intends to run with. javaVersion defaults
+    to the source compatibility of the project
+  links:
+  - https://github.com/palantir/sls-packaging/pull/680

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -74,8 +74,12 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         setProductType(ProductType.SERVICE_V1);
     }
 
-    public final Property<JavaVersion> getJavaVersion() {
+    public final Provider<JavaVersion> getJavaVersion() {
         return javaVersion;
+    }
+
+    public final Provider<List<String>> getGcJvmOptions() {
+        return javaVersion.flatMap(version -> getGc().map(gcProfile -> gcProfile.gcJvmOpts(version)));
     }
 
     public final void javaVersion(Object version) {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -29,6 +29,7 @@ import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -55,7 +56,8 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     public JavaServiceDistributionExtension(Project project) {
         super(project);
         objectFactory = project.getObjects();
-        javaVersion = objectFactory.property(JavaVersion.class).value(JavaVersion.VERSION_1_8);
+        javaVersion = objectFactory.property(JavaVersion.class).value(project.provider(() ->
+                project.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility()));
         mainClass = objectFactory.property(String.class);
         javaHome = objectFactory.property(String.class);
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -36,6 +37,7 @@ import org.gradle.util.ConfigureUtil;
 
 public class JavaServiceDistributionExtension extends BaseDistributionExtension {
 
+    private final Property<JavaVersion> javaVersion;
     private final Property<String> mainClass;
     private final Property<String> javaHome;
     private final Property<Boolean> addJava8GcLogging;
@@ -53,17 +55,14 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     public JavaServiceDistributionExtension(Project project) {
         super(project);
         objectFactory = project.getObjects();
+        javaVersion = objectFactory.property(JavaVersion.class).value(JavaVersion.VERSION_1_8);
         mainClass = objectFactory.property(String.class);
         javaHome = objectFactory.property(String.class);
 
-        addJava8GcLogging = objectFactory.property(Boolean.class);
-        addJava8GcLogging.set(false);
+        addJava8GcLogging = objectFactory.property(Boolean.class).value(false);
+        enableManifestClasspath = objectFactory.property(Boolean.class).value(false);
 
-        enableManifestClasspath = objectFactory.property(Boolean.class);
-        enableManifestClasspath.set(false);
-
-        gc = objectFactory.property(GcProfile.class);
-        gc.set(new GcProfile.Throughput());
+        gc = objectFactory.property(GcProfile.class).value(new GcProfile.Throughput());
 
         args = objectFactory.listProperty(String.class).empty();
         checkArgs = objectFactory.listProperty(String.class).empty();
@@ -73,6 +72,14 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
 
         env = objectFactory.mapProperty(String.class, String.class).empty();
         setProductType(ProductType.SERVICE_V1);
+    }
+
+    public final Property<JavaVersion> getJavaVersion() {
+        return javaVersion;
+    }
+
+    public final void javaVersion(Object version) {
+        javaVersion.set(JavaVersion.toVersion(version));
     }
 
     public final Provider<String> getMainClass() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -167,7 +167,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getServiceName().set(distributionExtension.getDistributionServiceName());
                     task.getArgs().set(distributionExtension.getArgs());
                     task.getCheckArgs().set(distributionExtension.getCheckArgs());
-                    task.getGc().set(distributionExtension.getGc());
+                    task.getGcJvmOptions().set(distributionExtension.getGcJvmOptions());
                     task.getDefaultJvmOpts().set(distributionExtension.getDefaultJvmOpts());
                     task.getAddJava8GcLogging().set(distributionExtension.getAddJava8GcLogging());
                     task.getJavaHome().set(distributionExtension.getJavaHome());
@@ -222,7 +222,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.setArgs(distributionExtension.getArgs().get());
             task.setJvmArgs(ImmutableList.builder()
                     .addAll(distributionExtension.getDefaultJvmOpts().get())
-                    .addAll(distributionExtension.getGc().get().gcJvmOpts())
+                    .addAll(distributionExtension.getGcJvmOptions().get())
                     .build());
         }));
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import org.gradle.api.JavaVersion;
 
 public interface GcProfile extends Serializable {
     long serialVersionUID = 1L;
@@ -32,11 +33,11 @@ public interface GcProfile extends Serializable {
             "response-time", GcProfile.ResponseTime.class,
             "hybrid", GcProfile.Hybrid.class);
 
-    List<String> gcJvmOpts();
+    List<String> gcJvmOpts(JavaVersion javaVersion);
 
     class Throughput implements GcProfile {
         @Override
-        public final List<String> gcJvmOpts() {
+        public final List<String> gcJvmOpts(JavaVersion javaVersion) {
             return ImmutableList.of("-XX:+UseParallelOldGC");
         }
     }
@@ -46,7 +47,17 @@ public interface GcProfile extends Serializable {
         private int initiatingOccupancyFraction = 68;
 
         @Override
-        public final List<String> gcJvmOpts() {
+        public final List<String> gcJvmOpts(JavaVersion javaVersion) {
+            // HACKHACK constant for Java13 only exists in Gradle 6.0
+            if (javaVersion == JavaVersion.VERSION_HIGHER) {
+                return ImmutableList.of(
+                        "-XX:+UnlockExperimentalVMOptions",
+                        // https://wiki.openjdk.java.net/display/shenandoah/Main
+                        "-XX:+UseShenandoahGC",
+                        // "forces concurrent cycle instead of Full GC on System.gc()"
+                        "-XX:+ExplicitGCInvokesConcurrent",
+                        "-XX:+ClassUnloadingWithConcurrentMark");
+            }
             return ImmutableList.of("-XX:+UseParNewGC",
                     "-XX:+UseConcMarkSweepGC",
                     /*
@@ -76,22 +87,10 @@ public interface GcProfile extends Serializable {
 
     class Hybrid implements GcProfile {
         @Override
-        public final List<String> gcJvmOpts() {
+        public final List<String> gcJvmOpts(JavaVersion javaVersion) {
             return ImmutableList.of(
                     "-XX:+UseG1GC",
                     "-XX:+UseStringDeduplication");
-        }
-    }
-
-    class ResponseTime11 implements GcProfile {
-        @Override
-        public final List<String> gcJvmOpts() {
-            return ImmutableList.of(
-                    // https://wiki.openjdk.java.net/display/shenandoah/Main
-                    "-XX:+UseShenandoahGC",
-                    // "forces concurrent cycle instead of Full GC on System.gc()"
-                    "-XX:+ExplicitGCInvokesConcurrent",
-                    "-XX:+ClassUnloadingWithConcurrentMark");
         }
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -48,7 +48,7 @@ public interface GcProfile extends Serializable {
 
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
-            // HACKHACK constant for Java13 only exists in Gradle 6.0
+            // TODO(forozco): Update to use proper constant once we can support gradle 6.0
             if (javaVersion == JavaVersion.VERSION_HIGHER) {
                 return ImmutableList.of(
                         "-XX:+UnlockExperimentalVMOptions",

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -56,7 +56,8 @@ public interface GcProfile extends Serializable {
                         "-XX:+UseShenandoahGC",
                         // "forces concurrent cycle instead of Full GC on System.gc()"
                         "-XX:+ExplicitGCInvokesConcurrent",
-                        "-XX:+ClassUnloadingWithConcurrentMark");
+                        "-XX:+ClassUnloadingWithConcurrentMark",
+                        "-XX+UseNUMA");
             }
             return ImmutableList.of("-XX:+UseParNewGC",
                     "-XX:+UseConcMarkSweepGC",

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.gradle.dist.service.gc.GcProfile;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -72,7 +71,7 @@ public class LaunchConfigTask extends DefaultTask {
 
     private final Property<String> mainClass = getProject().getObjects().property(String.class);
     private final Property<String> serviceName = getProject().getObjects().property(String.class);
-    private final Property<GcProfile> gc = getProject().getObjects().property(GcProfile.class);
+    private final ListProperty<String> gcJvmOptions = getProject().getObjects().listProperty(String.class);
     private final Property<Boolean> addJava8GcLogging = getProject().getObjects().property(Boolean.class);
     private final Property<String> javaHome = getProject().getObjects().property(String.class);
     private final ListProperty<String> args = getProject().getObjects().listProperty(String.class);
@@ -100,14 +99,9 @@ public class LaunchConfigTask extends DefaultTask {
         return serviceName;
     }
 
-    public final Property<GcProfile> getGc() {
-        return gc;
-    }
-
-    // HACKHACK Property<GcProfile> failed to serialise
     @Input
-    public final GcProfile gc() {
-        return gc.get();
+    public final ListProperty<String> getGcJvmOptions() {
+        return gcJvmOptions;
     }
 
     @Input
@@ -170,7 +164,7 @@ public class LaunchConfigTask extends DefaultTask {
                 .classpath(relativizeToServiceLibDirectory(classpath))
                 .addAllJvmOpts(alwaysOnJvmOptions)
                 .addAllJvmOpts(addJava8GcLogging.get() ? java8gcLoggingOptions : ImmutableList.of())
-                .addAllJvmOpts(gc.get().gcJvmOpts())
+                .addAllJvmOpts(gcJvmOptions.get())
                 .addAllJvmOpts(defaultJvmOpts.get())
                 .putAllEnv(defaultEnvironment)
                 .putAllEnv(env.get())


### PR DESCRIPTION
Closes #533 

## Before this PR
Users had no way of telling us what version of Java they expect to run with, the best they could do was implicitly specify the version using `JAVA_HOME`.

This made tuning GC and other JVM options hard since we had no way of telling what we options we could safely use.

## After this PR
==COMMIT_MSG==
Add `javaVersion` property to JavaServiceDistributionExtension which specifies the version of Java the service intends to run with. javaVersion defaults to the source compatibility of the project
==COMMIT_MSG==

## Possible downsides?
It could be a little confusing that users have to specify a different javaVersion in addition to JAVA_HOME to change which version of Java they use. We _could_ specify a convention where the default java home is `JAVA_${javaVersion}_HOME` so that users (at least internally) don't have to think about it.
