### PR TITLE
$JAVA_11_HOME for java 11

### DIFF
--- a/changelog/@unreleased/pr-696.v2.yml
+++ b/changelog/@unreleased/pr-696.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: For Java 11 and above, the `javaHome` property on the `distribution`
+    extension will be set to `$JAVA_11_HOME` etc by default.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/696

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -61,11 +61,12 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         mainClass = objectFactory.property(String.class);
 
         javaHome = objectFactory.property(String.class).value(javaVersion.map(javaVersionValue -> {
-            if (javaVersionValue.compareTo(JavaVersion.VERSION_11) < 0) {
+            boolean javaVersionLessThan11 = javaVersionValue.compareTo(JavaVersion.VERSION_11) < 0;
+            if (javaVersionLessThan11) {
                 return "";
             }
 
-            return "JAVA_" + javaVersionValue.getMajorVersion() + "_HOME";
+            return "$JAVA_" + javaVersionValue.getMajorVersion() + "_HOME";
         }));
 
         addJava8GcLogging = objectFactory.property(Boolean.class).value(false);

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -57,7 +57,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         super(project);
         objectFactory = project.getObjects();
         javaVersion = objectFactory.property(JavaVersion.class).value(project.provider(() ->
-                project.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility()));
+                project.getConvention().getPlugin(JavaPluginConvention.class).getTargetCompatibility()));
         mainClass = objectFactory.property(String.class);
 
         javaHome = objectFactory.property(String.class).value(javaVersion.map(javaVersionValue -> {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -59,7 +59,14 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         javaVersion = objectFactory.property(JavaVersion.class).value(project.provider(() ->
                 project.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility()));
         mainClass = objectFactory.property(String.class);
-        javaHome = objectFactory.property(String.class);
+
+        javaHome = objectFactory.property(String.class).value(javaVersion.map(javaVersionValue -> {
+            if (javaVersionValue.compareTo(JavaVersion.VERSION_11) < 0) {
+                return "";
+            }
+
+            return "JAVA_" + javaVersionValue.getMajorVersion() + "_HOME";
+        }));
 
         addJava8GcLogging = objectFactory.property(Boolean.class).value(false);
         enableManifestClasspath = objectFactory.property(Boolean.class).value(false);

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -61,8 +61,8 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         mainClass = objectFactory.property(String.class);
 
         javaHome = objectFactory.property(String.class).value(javaVersion.map(javaVersionValue -> {
-            boolean javaVersionLessThan11 = javaVersionValue.compareTo(JavaVersion.VERSION_11) < 0;
-            if (javaVersionLessThan11) {
+            boolean javaVersionLessThanOrEqualTo8 = javaVersionValue.compareTo(JavaVersion.VERSION_1_8) <= 0;
+            if (javaVersionLessThanOrEqualTo8) {
                 return "";
             }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -105,7 +105,7 @@ class JavaServiceDistributionExtensionTest extends Specification {
         when:
         def ext = new JavaServiceDistributionExtension(project)
         project.pluginManager.apply(JavaPlugin)
-        project.getConvention().getPlugin(JavaPluginConvention).setSourceCompatibility(JavaVersion.VERSION_1_8)
+        project.getConvention().getPlugin(JavaPluginConvention).setTargetCompatibility(JavaVersion.VERSION_1_8)
 
         then:
         ext.getJavaHome().get() == ''
@@ -115,7 +115,7 @@ class JavaServiceDistributionExtensionTest extends Specification {
         when:
         def ext = new JavaServiceDistributionExtension(project)
         project.pluginManager.apply(JavaPlugin)
-        project.getConvention().getPlugin(JavaPluginConvention).setSourceCompatibility(JavaVersion.VERSION_11)
+        project.getConvention().getPlugin(JavaPluginConvention).setTargetCompatibility(JavaVersion.VERSION_11)
 
         then:
         ext.getJavaHome().get() == '$JAVA_11_HOME'

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -16,7 +16,10 @@
 
 package com.palantir.gradle.dist.service
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -96,5 +99,25 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.getCheckArgs().get() == []
         ext.getDefaultJvmOpts().get() == []
         ext.getExcludeFromVar().get() == ['log', 'run']
+    }
+
+    def 'empty java home when java 8' () {
+        when:
+        def ext = new JavaServiceDistributionExtension(project)
+        project.pluginManager.apply(JavaPlugin)
+        project.getConvention().getPlugin(JavaPluginConvention).setSourceCompatibility(JavaVersion.VERSION_1_8)
+
+        then:
+        ext.getJavaHome().get() == ''
+    }
+
+    def 'JAVA_MAJORVERSION_HOME when java >= 11' () {
+        when:
+        def ext = new JavaServiceDistributionExtension(project)
+        project.pluginManager.apply(JavaPlugin)
+        project.getConvention().getPlugin(JavaPluginConvention).setSourceCompatibility(JavaVersion.VERSION_11)
+
+        then:
+        ext.getJavaHome().get() == 'JAVA_11_HOME'
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -120,4 +120,14 @@ class JavaServiceDistributionExtensionTest extends Specification {
         then:
         ext.getJavaHome().get() == '$JAVA_11_HOME'
     }
+
+    def '$JAVA_13_HOME when java == 13' () {
+        when:
+        def ext = new JavaServiceDistributionExtension(project)
+        project.pluginManager.apply(JavaPlugin)
+        project.getConvention().getPlugin(JavaPluginConvention).setTargetCompatibility("13")
+
+        then:
+        ext.getJavaHome().get() == '$JAVA_13_HOME'
+    }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -111,13 +111,13 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.getJavaHome().get() == ''
     }
 
-    def 'JAVA_MAJORVERSION_HOME when java >= 11' () {
+    def '$JAVA_MAJORVERSION_HOME when java >= 11' () {
         when:
         def ext = new JavaServiceDistributionExtension(project)
         project.pluginManager.apply(JavaPlugin)
         project.getConvention().getPlugin(JavaPluginConvention).setSourceCompatibility(JavaVersion.VERSION_11)
 
         then:
-        ext.getJavaHome().get() == 'JAVA_11_HOME'
+        ext.getJavaHome().get() == '$JAVA_11_HOME'
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -101,33 +101,23 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.getExcludeFromVar().get() == ['log', 'run']
     }
 
-    def 'empty java home when java 8' () {
+    def 'correct java homes depending on java version' () {
         when:
         def ext = new JavaServiceDistributionExtension(project)
         project.pluginManager.apply(JavaPlugin)
-        project.getConvention().getPlugin(JavaPluginConvention).setTargetCompatibility(JavaVersion.VERSION_1_8)
+
+        def assertJavaHomeAtVersionIs = { Object javaVersion, String javaHome ->
+            project.getConvention().getPlugin(JavaPluginConvention).setTargetCompatibility(javaVersion)
+            ext.getJavaHome().get() == javaHome
+        }
 
         then:
-        ext.getJavaHome().get() == ''
-    }
-
-    def '$JAVA_MAJORVERSION_HOME when java >= 11' () {
-        when:
-        def ext = new JavaServiceDistributionExtension(project)
-        project.pluginManager.apply(JavaPlugin)
-        project.getConvention().getPlugin(JavaPluginConvention).setTargetCompatibility(JavaVersion.VERSION_11)
-
-        then:
-        ext.getJavaHome().get() == '$JAVA_11_HOME'
-    }
-
-    def '$JAVA_13_HOME when java == 13' () {
-        when:
-        def ext = new JavaServiceDistributionExtension(project)
-        project.pluginManager.apply(JavaPlugin)
-        project.getConvention().getPlugin(JavaPluginConvention).setTargetCompatibility("13")
-
-        then:
-        ext.getJavaHome().get() == '$JAVA_13_HOME'
+        assertJavaHomeAtVersionIs JavaVersion.VERSION_1_7,  ''
+        assertJavaHomeAtVersionIs JavaVersion.VERSION_1_8,  ''
+        assertJavaHomeAtVersionIs JavaVersion.VERSION_1_9,  '$JAVA_9_HOME'
+        assertJavaHomeAtVersionIs JavaVersion.VERSION_1_10, '$JAVA_10_HOME'
+        assertJavaHomeAtVersionIs JavaVersion.VERSION_11,   '$JAVA_11_HOME'
+        assertJavaHomeAtVersionIs JavaVersion.VERSION_12,   '$JAVA_12_HOME'
+        assertJavaHomeAtVersionIs '13', '$JAVA_13_HOME'
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -112,6 +112,7 @@ class JavaServiceDistributionExtensionTest extends Specification {
         }
 
         then:
+        assertJavaHomeAtVersionIs JavaVersion.VERSION_1_6,  ''
         assertJavaHomeAtVersionIs JavaVersion.VERSION_1_7,  ''
         assertJavaHomeAtVersionIs JavaVersion.VERSION_1_8,  ''
         assertJavaHomeAtVersionIs JavaVersion.VERSION_1_9,  '$JAVA_9_HOME'

--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,8 @@ And the complete list of configurable properties:
  * (optional) `excludeFromVar` a list of directories (relative to `${projectDir}/var`) to exclude from the distribution,
    defaulting to `['log', 'run']`.
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
-   be applied when `init.sh` is run.
+   be applied when `init.sh` is run. When your `targetCompatibility` is Java 8 or less, this value will be blank. For
+   Java 9 or higher will default to `$JAVA_<majorversion>_HOME` ie for Java 11 this would be `$JAVA_11_HOME`.
  * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default), `hybrid` and `response-time`.
  * (optional) `addJava8GcLogging` add java 8 specific gc logging options.
 


### PR DESCRIPTION
## Before this PR
Each repo internally has had to manually specify they're using `$JAVA_11_HOME` when using Java 11. `JAVA_11_HOME` is an environment given by our internal deployment infrastructure tool.

## After this PR
==COMMIT_MSG==
For Java 11 and above, the `javaHome` property on the `distribution` extension will be set to `$JAVA_11_HOME` etc by default.
==COMMIT_MSG==

## Possible downsides?
Is setting `$JAVA_11_HOME` tying this too much to the behaviour of our internal deployment infrastructure? Without this though every gradle java gradle project needs to manually specify this (and it is unlikely to ever change).

If someone was depending on the `javaHome` to be unset when using java 11, they now may be broken. Unknown if people are actually depending on this, as SL uses `JAVA_HOME` has java 8.

