### PR TITLE
Fix: typo in UseNUMA option in response-time gc config leads to unrecognized vm option error

### DIFF
--- a/changelog/@unreleased/pr-710.v2.yml
+++ b/changelog/@unreleased/pr-710.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix typo when specifying `-XX:+UseNUMA`
+  links:
+  - https://github.com/palantir/sls-packaging/pull/710

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -57,7 +57,7 @@ public interface GcProfile extends Serializable {
                         // "forces concurrent cycle instead of Full GC on System.gc()"
                         "-XX:+ExplicitGCInvokesConcurrent",
                         "-XX:+ClassUnloadingWithConcurrentMark",
-                        "-XX+UseNUMA");
+                        "-XX:+UseNUMA");
             }
             return ImmutableList.of("-XX:+UseParNewGC",
                     "-XX:+UseConcMarkSweepGC",


### PR DESCRIPTION
## Before this PR
We had typo in -XX+UseNUMA

## After this PR
==COMMIT_MSG==
Fix typo when specifying `-XX:+UseNUMA`
==COMMIT_MSG==

## Possible downsides?

