### PR TITLE
Stop using VERSION_HIGHER instead of 13

### DIFF
--- a/changelog/@unreleased/pr-711.v2.yml
+++ b/changelog/@unreleased/pr-711.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Shenandoah GC selection logic will remain the same when using Gradle
+    6, and not require a higher level of Java that when running with Gradle 5.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/711

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -48,8 +48,7 @@ public interface GcProfile extends Serializable {
 
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
-            // TODO(forozco): Update to use proper constant once we can support gradle 6.0
-            if (javaVersion == JavaVersion.VERSION_HIGHER) {
+            if (javaVersion.compareTo(JavaVersion.toVersion("13")) >= 0) {
                 return ImmutableList.of(
                         "-XX:+UnlockExperimentalVMOptions",
                         // https://wiki.openjdk.java.net/display/shenandoah/Main


### PR DESCRIPTION
## Before this PR
We compare against `JavaVersion.VERSION_HIGHER` to work out whether we should use Shenandoah GC. This means that in Gradle 5, we'll use Shenandoah for Java 13, but when people use Gradle 6 the behavior will change at we'll only use Shenandoah for Java 14 and above. The behaviour should be the same between Java 13 and 14. 

## After this PR
==COMMIT_MSG==
Shenandoah GC selection logic will remain the same when using Gradle 6, and not require a higher level of Java that when running with Gradle 5.
==COMMIT_MSG==

