### PR TITLE
Fix innacurate error message

### DIFF
--- a/changelog/@unreleased/pr-727.v2.yml
+++ b/changelog/@unreleased/pr-727.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Only warn users about unnecessary product dependencies when they are
+    actually unnecessary
+  links:
+  - https://github.com/palantir/sls-packaging/pull/727

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -224,12 +224,16 @@ public class CreateManifestTask extends DefaultTask {
                     productId,
                     discoveredDependency,
                     (declaredDependency, newDependency) -> {
-                        getLogger().error("Please remove your declared product dependency on '{}' because it is"
-                                + " already provided by a jar dependency:\n\n"
-                                        + "\tProvided:     {}\n"
-                                        + "\tYou declared: {}",
-                                productId, discoveredDependency, declaredDependency);
-                        return ProductDependencyMerger.merge(declaredDependency, discoveredDependency);
+                        ProductDependency mergedDependency =
+                                ProductDependencyMerger.merge(declaredDependency, discoveredDependency);
+                        if (mergedDependency.equals(discoveredDependency)) {
+                            getLogger().error("Please remove your declared product dependency on '{}' because it is"
+                                            + " already provided by a jar dependency:\n\n"
+                                            + "\tProvided:     {}\n"
+                                            + "\tYou declared: {}",
+                                    productId, discoveredDependency, declaredDependency);
+                        }
+                        return mergedDependency;
                     });
         });
         List<ProductDependency> productDeps = new ArrayList<>(allProductDependencies.values());

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -238,7 +238,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         def result = runTasks(':createManifest')
 
         then:
-        result.output.contains(
+        !result.output.contains(
                 "Please remove your declared product dependency on 'group:name' because it is already provided by a jar dependency")
         def manifest = CreateManifestTask.jsonMapper.readValue(file("build/deployment/manifest.yml"), Map)
         manifest.get("extensions").get("product-dependencies") == [


### PR DESCRIPTION
Closes #695 

## Before this PR
If a user specified a product dependency that was also discovered they would always see an error message stating that the declared dependency was unnecessary.

## After this PR
==COMMIT_MSG==
Only warn users about unnecessary product dependencies when they are actually unnecessary
==COMMIT_MSG==

## Possible downsides?
N/A

