### PR TITLE
yourkit b127 -> b137

### DIFF
--- a/changelog/@unreleased/pr-749.v2.yml
+++ b/changelog/@unreleased/pr-749.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: sls-packaging now embeds libyjpagent.so from YourKit 2019.8 b137 in
+    server distributions
+  links:
+  - https://github.com/palantir/sls-packaging/pull/749

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -45,7 +45,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2019.8-b127"
+def yourkitVersion = "2019.8-b137"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {
@@ -58,7 +58,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum 'b6b18a083c2a72af1672e5b5feea543b91ce8fca1607250ec9d23b7c92fcd33f'
+    checksum '34b0fd0b2b5de5b66ae4826110baba7baaa9ba81ad2dd3a4bf9c9d19a8568623'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {


### PR DESCRIPTION
## Before this PR

I can't run `publishToMavenLocal` anymore because the yourkit dist has disappeared.

## After this PR
==COMMIT_MSG==
sls-packaging now embeds libyjpagent.so from YourKit 2019.8 b137 in server distributions
==COMMIT_MSG==

## Possible downsides?


