### PR TITLE
Allow opting-in to graal

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -35,6 +35,9 @@ public interface GcProfile extends Serializable {
 
     List<String> gcJvmOpts(JavaVersion javaVersion);
 
+    ImmutableList<String> GRAAL = ImmutableList.of(
+            "-XX:+UnlockExperimentalVMOptions", "-XX:+EnableJVMCI", "-XX:+UseJVMCICompiler", "-XX:+EagerJVMCI");
+
     class Throughput implements GcProfile {
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
@@ -45,6 +48,7 @@ public interface GcProfile extends Serializable {
     class ResponseTime implements GcProfile {
         private int newRatio = 2;
         private int initiatingOccupancyFraction = 68;
+        private boolean graal = false;
 
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
@@ -87,9 +91,21 @@ public interface GcProfile extends Serializable {
     }
 
     class Hybrid implements GcProfile {
+        private boolean graal = false;
+
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
-            return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseStringDeduplication");
+            ImmutableList.Builder<String> builder = ImmutableList.builder();
+
+            if (graal) {
+                builder.addAll(GRAAL);
+            }
+
+            return builder.add("-XX:+UseG1GC", "-XX:+UseStringDeduplication").build();
+        }
+
+        public final void graal(boolean value) {
+            graal = value;
         }
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -49,7 +49,6 @@ public interface GcProfile extends Serializable {
     class ResponseTime implements GcProfile {
         private int newRatio = 2;
         private int initiatingOccupancyFraction = 68;
-        private boolean graal = false;
 
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.dist.service.gc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
@@ -98,6 +99,8 @@ public interface GcProfile extends Serializable {
             ImmutableList.Builder<String> builder = ImmutableList.builder();
 
             if (graal) {
+                Preconditions.checkState(
+                        javaVersion.isJava11Compatible(), "'graal true' is only usable on Java11+:", javaVersion);
                 builder.addAll(GRAAL);
             }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
@@ -22,6 +22,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import org.awaitility.Awaitility
+import org.gradle.api.JavaVersion
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 class GcProfileIntegrationSpec extends GradleIntegrationSpec {
@@ -86,9 +88,11 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
         gc << GcProfile.PROFILE_NAMES.keySet().toArray()
     }
 
+    @IgnoreIf({ !JavaVersion.current().isJava11Compatible() })
     def 'graal can be enabled'() {
         setup:
         buildFile << """
+        sourceCompatibility = '11'
         distribution {
             gc 'hybrid', {
               graal true


### PR DESCRIPTION
## Before this PR

https://www.graalvm.org/docs/why-graal/

> The compiler of GraalVM provides performance advantages for highly abstracted programs due to its ability to remove costly object allocations in many scenarios. You can find details in this research paper and try an example. Better inlining and more aggressive speculative optimizations can lead to additional benefits for complex long-running applications, see a Stream API example.

As per https://github.com/oracle/graal/blob/master/compiler/README.md:

> JVMCI version is built into the JDK as of JDK 11.

## After this PR
==COMMIT_MSG==
distributions with `gc-profile: 'hybrid'` (aka G1) can now opt-in to try the Graal C2 compiler using `graal true` (on Java11+)
==COMMIT_MSG==

We already have the reasonably experimental shenandoah one in there, I think it's ok to have lightly used feature flags in here rather than collecting duplicate flags in gradle files.

## Possible downsides?

