### PR TITLE
Add support for arm64 architectures

### DIFF
--- a/changelog/@unreleased/pr-753.v2.yml
+++ b/changelog/@unreleased/pr-753.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add support for Linux arm64
+  links:
+  - https://github.com/palantir/sls-packaging/pull/753

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -51,8 +51,8 @@ import org.gradle.util.GFileUtils;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER_BINARIES = "goJavaLauncherBinaries";
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.7.0";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.7.0";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.8.0";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.8.0";
     public static final String GROUP_NAME = "Distribution";
 
     @SuppressWarnings("checkstyle:methodlength")

--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -19,18 +19,22 @@
 pushd "`dirname \"$0\"`/../.." > /dev/null
 
 # Select launcher binary for this OS
-case "`uname`" in
-  Linux*)
-    LAUNCHER_CMD=service/bin/linux-amd64/go-java-launcher
-    GO_INIT_CMD=service/bin/linux-amd64/go-init
+case "`uname -sm`" in
+  Linux x86_64)
+    NATIVE_ARCH="linux-amd64"
+    ;;
+  Linux aarch64)
+    NATIVE_ARCH="linux-arm64"
     ;;
   Darwin*)
-    LAUNCHER_CMD=service/bin/darwin-amd64/go-java-launcher
-    GO_INIT_CMD=service/bin/darwin-amd64/go-init
+    NATIVE_ARCH="darwin-amd64"
     ;;
   *)
     echo "Unsupported operating system: $(uname)"; exit 1
 esac
+
+LAUNCHER_CMD="service/bin/${NATIVE_ARCH}/go-java-launcher"
+GO_INIT_CMD="service/bin/${NATIVE_ARCH}/go-init"
 
 ACTION=$1
 SCRIPT_DIR="service/bin"

--- a/gradle-sls-packaging/src/main/resources/init.sh
+++ b/gradle-sls-packaging/src/main/resources/init.sh
@@ -20,10 +20,10 @@ pushd "`dirname \"$0\"`/../.." > /dev/null
 
 # Select launcher binary for this OS
 case "`uname -sm`" in
-  Linux x86_64)
+  "Linux x86_64")
     NATIVE_ARCH="linux-amd64"
     ;;
-  Linux aarch64)
+  "Linux aarch64")
     NATIVE_ARCH="linux-arm64"
     ;;
   Darwin*)

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,8 @@ content of the package. The package will follow this structure:
                 [service-name].bat            # Windows start script
                 init.sh                       # daemonizing script
                 darwin-amd64/go-java-launcher # Native Java launcher binary (MacOS)
-                linux-amd64/go-java-launcher  # Native Java launcher binary (Linux)
+                linux-amd64/go-java-launcher  # Native Java launcher binary (Linux x86_64)
+                linux-arm64/go-java-launcher  # Native Java launcher binary (Linux arm64)
                 launcher-static.yml           # generated configuration for go-java-launcher
                 launcher-check.yml            # generated configuration for check.sh go-java-launcher
             lib/


### PR DESCRIPTION
## Before this PR
sls-packaging supports Linux x86_64 and MacOS x86_64.

## After this PR
==COMMIT_MSG==
Add support for Linux arm64
==COMMIT_MSG==

## Possible downsides?
Increased size of output tgz files due to additional native architecture support.