### PR TITLE
Fix regression: no longer require gradle 6

### DIFF
--- a/changelog/@unreleased/pr-852.v2.yml
+++ b/changelog/@unreleased/pr-852.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix regression that required gradle 6, bringing minimum gradle down
+    to 5.6, which is checked in the base plugin, and integration tests run against
+    it.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/852

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
@@ -35,7 +35,7 @@ public class SlsBaseDistPlugin implements Plugin<Project> {
 
     public static final String SLS_DIST_USAGE = "sls-dist";
 
-    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("5.3.0");
+    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("5.3");
 
     @Override
     public final void apply(Project project) {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
@@ -35,7 +35,7 @@ public class SlsBaseDistPlugin implements Plugin<Project> {
 
     public static final String SLS_DIST_USAGE = "sls-dist";
 
-    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("5.3");
+    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("5.6");
 
     @Override
     public final void apply(Project project) {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/SlsBaseDistPlugin.java
@@ -16,6 +16,8 @@
 
 package com.palantir.gradle.dist;
 
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
@@ -24,6 +26,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
+import org.gradle.util.GradleVersion;
 
 public class SlsBaseDistPlugin implements Plugin<Project> {
 
@@ -32,8 +35,16 @@ public class SlsBaseDistPlugin implements Plugin<Project> {
 
     public static final String SLS_DIST_USAGE = "sls-dist";
 
+    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("5.3.0");
+
     @Override
     public final void apply(Project project) {
+        Preconditions.checkState(
+                GradleVersion.current().compareTo(MINIMUM_GRADLE) >= 0,
+                "This gradle version is too old",
+                SafeArg.of("currentVersion", GradleVersion.current()),
+                SafeArg.of("minimumVersion", MINIMUM_GRADLE));
+
         Configuration slsConf = project.getConfigurations().create(SLS_CONFIGURATION_NAME);
         slsConf.setCanBeResolved(false);
         // Make it export a custom usage, to allow resolving it via variant-aware resolution.

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/DistTarTask.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist.service;
 
+import java.util.concurrent.Callable;
 import org.gradle.api.Project;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.provider.Provider;

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/DistTarTask.java
@@ -32,7 +32,7 @@ final class DistTarTask {
         Provider<String> serviceName = distributionExtension.getDistributionServiceName();
         distTarTask.getArchiveBaseName().set(serviceName);
 
-        Provider<String> archiveRootDir = project.provider(() -> serviceName.get() + "-" + project.getVersion());
+        Callable<String> archiveRootDir = () -> serviceName.get() + "-" + project.getVersion();
 
         distTarTask.into(archiveRootDir, root -> {
             root.from("var", t -> {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
@@ -30,6 +30,8 @@ class GradleIntegrationSpec extends IntegrationTestKitSpec {
         keepFiles = true
         settingsFile.createNewFile()
         helper = new MultiProjectIntegrationHelper(getProjectDir(), settingsFile)
+        // Run with minimum supported version
+        gradleVersion = SlsBaseDistPlugin.MINIMUM_GRADLE.version
     }
 
     protected boolean fileExists(String path) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -75,8 +75,12 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'status') == 0
         execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'restart') == 0
         execWithExitCode('dist/service-name-0.0.1/service/bin/init.sh', 'stop') == 0
-        execWithOutput('dist/service-name-0.0.1/service/bin/init.sh', 'check') ==~ /.*\n*Checking health of 'service-name'\.\.\.\s+Healthy.*\n/
-        execWithOutput('dist/service-name-0.0.1/service/monitoring/bin/check.sh') ==~ /.*\n*Checking health of 'service-name'\.\.\.\s+Healthy.*\n/
+        execWithOutput('dist/service-name-0.0.1/service/bin/init.sh', 'check').readLines().any {
+            it ==~ /Checking health of 'service-name'\.\.\.\s+Healthy/
+        }
+        execWithOutput('dist/service-name-0.0.1/service/monitoring/bin/check.sh').readLines().any {
+            it ==~ /Checking health of 'service-name'\.\.\.\s+Healthy/
+        }
     }
 
     def 'packaging tasks re-run after version change'() {


### PR DESCRIPTION
## Before this PR

#849 accidentally introduced code that only works in Gradle 6.

```
Caused by: org.gradle.internal.typeconversion.UnsupportedNotationException: Cannot convert the provided notation to a String: provider(?).
The following types/formats are supported:
  - String or CharSequence instances, for example 'some/path'.
  - Boolean values, for example true, Boolean.TRUE.
  - Number values, for example 42, 3.14.
  - A File instance
  - A Closure that returns any supported value.
  - A Callable that returns any supported value.
	at org.gradle.internal.typeconversion.ErrorHandlingNotationParser.parseNotation(ErrorHandlingNotationParser.java:57)
	at org.gradle.api.internal.file.copy.DefaultCopySpec$DefaultCopySpecResolver.getDestPath(DefaultCopySpec.java:554)
```

## After this PR
==COMMIT_MSG==
Minimum gradle is now 5.6, which is checked in the base plugin, and integration tests run against it.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

