### PR TITLE
Apply rev-api to gradle-recommended-product-dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath 'de.undercouch:gradle-download-task:4.0.4'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.3.0'
+        classpath 'com.palantir.gradle.revapi:gradle-revapi:1.3.0'
     }
 }
 

--- a/gradle-recommended-product-dependencies/build.gradle
+++ b/gradle-recommended-product-dependencies/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'org.inferred.processors'
+apply plugin: 'com.palantir.revapi'
+
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {


### PR DESCRIPTION
## Before this PR

gradle-conjure [consumes gradle-recommended-product-dependencies](https://github.com/palantir/gradle-conjure/blob/8d518ec8b3ccd06d35b33bb94de44720eb8e4718/versions.lock#L18) but we have no guarantees that its API will be kept stable.

## After this PR
==COMMIT_MSG==
Apply rev-api in order to ensure consumed jar doesn't break consumers.

Following up from https://github.com/palantir/sls-packaging/pull/800/files#r382726546.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

