### PR TITLE
Make DistTarTask public for broader usage

### DIFF
--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/DistTarTask.java
@@ -24,8 +24,8 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Tar;
 
-final class DistTarTask {
-    static void configure(
+public final class DistTarTask {
+    public static void configure(
             Project project,
             Tar distTarTask,
             JavaServiceDistributionExtension distributionExtension,


### PR DESCRIPTION
## Before this PR
Custom gradle plugins which build on top of the DistTarTask cannot access its configure method currently. This was the case some time ago when the class was written in groovy but now
the package private visibility is enforced by Java.

## After this PR
==COMMIT_MSG==
Make DistTarTask public for broader usage
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

