### PR TITLE
Fix inter project product dependencies

### DIFF
--- a/changelog/@unreleased/pr-870.v2.yml
+++ b/changelog/@unreleased/pr-870.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Inter-project product dependencies are now correctly wired up to point
+    to the projects themselves, and additionally to recursively collect those transitive
+    projects' product dependencies.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/870

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/GradleWorkarounds.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/GradleWorkarounds.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import java.lang.reflect.Proxy;
+import org.gradle.api.DomainObjectCollection;
+import org.gradle.api.GradleException;
+import org.gradle.api.provider.ListProperty;
+
+@SuppressWarnings("UnstableApiUsage")
+final class GradleWorkarounds {
+
+    /**
+     * Allow a {@link ListProperty} to be used with {@link DomainObjectCollection#addAllLater}.
+     *
+     * <p>Fixed in gradle 6: https://github.com/gradle/gradle/pull/10288
+     */
+    @SuppressWarnings("unchecked")
+    static <T> ListProperty<T> fixListProperty(ListProperty<T> property) {
+        Class<?> propertyInternalClass = org.gradle.api.internal.provider.CollectionPropertyInternal.class;
+        return (ListProperty<T>) Proxy.newProxyInstance(
+                GradleWorkarounds.class.getClassLoader(),
+                new Class<?>[] {org.gradle.api.internal.provider.CollectionProviderInternal.class, ListProperty.class},
+                (proxy, method, args) -> {
+                    // Find matching method on CollectionPropertyInternal
+                    // org.gradle.api.internal.provider.CollectionProviderInternal
+                    if (method.getDeclaringClass()
+                            == org.gradle.api.internal.provider.CollectionProviderInternal.class) {
+                        if (method.getName().equals("getElementType")) {
+                            // Proxy to `propertyInternalClass` which we know DefaultListProperty implements.
+                            return propertyInternalClass
+                                    .getMethod(method.getName(), method.getParameterTypes())
+                                    .invoke(property, args);
+                        } else if (method.getName().equals("size")) {
+                            return property.get().size();
+                        }
+                        throw new GradleException(
+                                String.format("Could not proxy method '%s' to object %s", method, property));
+                    } else {
+                        return method.invoke(property, args);
+                    }
+                });
+    }
+
+    private GradleWorkarounds() {}
+}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -58,10 +58,6 @@ public final class ProductDependencyIntrospectionPlugin implements Plugin<Projec
             dependencies.set(allProductDependencies.map(pdeps ->
                     createAllProductDependencies(project, pdeps, getInRepoProductIds(project.getRootProject()))));
             conf.getDependencies().addAllLater(GradleWorkarounds.fixListProperty(dependencies));
-
-            if (!allProductDependencies.isPresent()) {
-                log.info("Lock file not present, not populating product dependencies configuration: {}", conf);
-            }
         });
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.palantir.gradle.dist.BaseDistributionExtension;
 import com.palantir.gradle.dist.ConfigureProductDependenciesTask;
 import com.palantir.gradle.dist.ProductDependency;
+import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.ProductDependencyLockFile;
 import com.palantir.gradle.dist.ProductDependencyMerger;
 import com.palantir.gradle.dist.ProductId;
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -88,7 +87,8 @@ public class CreateManifestTask extends DefaultTask {
             .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE)
             .enable(SerializationFeature.INDENT_OUTPUT);
 
-    private final Supplier<Set<ProductId>> inRepoProductIds = Suppliers.memoize(this::getInRepoProductIds);
+    private final SetProperty<ProductId> inRepoProductIds =
+            getProject().getObjects().setProperty(ProductId.class);
     private final Property<String> serviceName = getProject().getObjects().property(String.class);
     private final Property<String> serviceGroup = getProject().getObjects().property(String.class);
     private final Property<ProductType> productType = getProject().getObjects().property(ProductType.class);
@@ -167,6 +167,10 @@ public class CreateManifestTask extends DefaultTask {
     @Input
     final SetProperty<ProductId> getIgnoredProductIds() {
         return ignoredProductIds;
+    }
+
+    final SetProperty<ProductId> getInRepoProductIds() {
+        return inRepoProductIds;
     }
 
     @Input
@@ -482,18 +486,6 @@ public class CreateManifestTask extends DefaultTask {
         }
     }
 
-    private Set<ProductId> getInRepoProductIds() {
-        // get products we publish via BaseDistributionExtension from all other projects
-        return getProject().getRootProject().getAllprojects().stream()
-                .flatMap(p -> Optional.ofNullable(p.getExtensions().findByType(BaseDistributionExtension.class))
-                        .map(Stream::of)
-                        .orElseGet(Stream::empty))
-                .map(extension -> new ProductId(
-                        extension.getDistributionServiceGroup().get(),
-                        extension.getDistributionServiceName().get()))
-                .collect(Collectors.toSet());
-    }
-
     public static TaskProvider<CreateManifestTask> createManifestTask(Project project, BaseDistributionExtension ext) {
         TaskProvider<CreateManifestTask> createManifest = project.getTasks()
                 .register("createManifest", CreateManifestTask.class, task -> {
@@ -505,6 +497,10 @@ public class CreateManifestTask extends DefaultTask {
                     task.setConfiguration(project.provider(ext::getProductDependenciesConfig));
                     task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
                     task.getManifestExtensions().set(ext.getManifestExtensions());
+                    task.getInRepoProductIds()
+                            .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(
+                                            project.getRootProject())
+                                    .keySet()));
                 });
         project.getPluginManager().withPlugin("lifecycle-base", p -> {
             project.getTasks()

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -169,6 +169,7 @@ public class CreateManifestTask extends DefaultTask {
         return ignoredProductIds;
     }
 
+    @Input
     final SetProperty<ProductId> getInRepoProductIds() {
         return inRepoProductIds;
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -877,7 +877,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 mainClass "dummy.service.MainClass"
                 productDependency {
                     productGroup = 'group'
-                    productName = 'second'
+                    productName = 'second-product'
                     minimumVersion = project.version
                 }
             }
@@ -888,6 +888,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'com.palantir.sls-java-service-distribution'
             }
             distribution {
+                serviceName = 'second-product'
                 mainClass "dummy.service.MainClass"
             }
         """.stripIndent())


### PR DESCRIPTION
## Before this PR

Inter-project pdeps could fail to resolve in some circumstances, particularly when the `serviceGroup` and `serviceName` of the project didn't match the `productGroup` and `productName` of the actual dependency.

## After this PR
==COMMIT_MSG==
Inter-project product dependencies are now correctly wired up to point to the projects themselves, and additionally to recursively collect those transitive projects' product dependencies.

Fixes #527
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

