### PR TITLE
Ensure we update product-dependencies.lock when running with --write-locks

### DIFF
--- a/changelog/@unreleased/pr-875.v2.yml
+++ b/changelog/@unreleased/pr-875.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure `createManifest` is re-run when gradle is invoked with `--write-locks`
+  links:
+  - https://github.com/palantir/sls-packaging/pull/875

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -58,6 +58,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
@@ -71,6 +72,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
@@ -502,6 +504,13 @@ public class CreateManifestTask extends DefaultTask {
                             .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(
                                             project.getRootProject())
                                     .keySet()));
+                    // Ensure we re-run task to write locks
+                    task.getOutputs().upToDateWhen(new Spec<Task>() {
+                        @Override
+                        public boolean isSatisfiedBy(Task task) {
+                            return !project.getGradle().getStartParameter().isWriteDependencyLocks();
+                        }
+                    });
                 });
         project.getPluginManager().withPlugin("lifecycle-base", p -> {
             project.getTasks()


### PR DESCRIPTION
## Before this PR
We could run into issues where the lock file was not correctly updated due to caching

## After this PR
==COMMIT_MSG==
Ensure `createManifest` is re-run when gradle is invoked with `--write-locks`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

