### PR TITLE
Support gradle 6.4

### DIFF
--- a/changelog/@unreleased/pr-886.v2.yml
+++ b/changelog/@unreleased/pr-886.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '`run` works with gradle 6.4 and up'
+  links:
+  - https://github.com/palantir/sls-packaging/pull/886

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -47,6 +47,7 @@ import org.gradle.api.tasks.bundling.Compression;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Tar;
 import org.gradle.util.GFileUtils;
+import org.gradle.util.GradleVersion;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER_BINARIES = "goJavaLauncherBinaries";
@@ -217,12 +218,16 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.setGroup(JavaServiceDistributionPlugin.GROUP_NAME);
             task.setDescription("Runs the specified project using configured mainClass and with default args.");
             task.dependsOn("jar");
-            task.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task _task) {
-                    task.setMain(mainClassName.get());
-                }
-            });
+            if (GradleVersion.current().compareTo(GradleVersion.version("6.4")) < 0) {
+                task.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task _task) {
+                        task.setMain(mainClassName.get());
+                    }
+                });
+            } else {
+                task.getMainClass().set(mainClassName);
+            }
         });
 
         // HACKHACK setClasspath of JavaExec is eager so we configure it after evaluation to ensure everything has


### PR DESCRIPTION
## Before this PR
`run` task would fail at configuration time with gradle >= 6.4 because of an implementation change in `JavaExec` which broke the way we lazily configured the main class. 

## After this PR
==COMMIT_MSG==
`run` works with gradle 6.4 and up
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

