### PR TITLE
response-time uses shenandoah from 14 onwards

### DIFF
--- a/changelog/@unreleased/pr-899.v2.yml
+++ b/changelog/@unreleased/pr-899.v2.yml
@@ -1,8 +1,7 @@
 type: improvement
 improvement:
-  description: For users of the `response-time` GC Profile, options to enable the
-    CMS garbage will still be set on Java 13, as the GC is just deprecated but not
-    full removed. From Java 14 onwards, CMS does not exist anymore so we auto-switch
-    to Shenandoah.
+  description: For users of the `response-time` GC Profile, the CMS garbage will still
+    be enabled on Java 13, as the GC is just _deprecated_ but not full removed. From
+    Java 14 onwards, CMS does not exist anymore so we auto-switch to Shenandoah.
   links:
   - https://github.com/palantir/sls-packaging/pull/899

--- a/changelog/@unreleased/pr-899.v2.yml
+++ b/changelog/@unreleased/pr-899.v2.yml
@@ -1,7 +1,7 @@
 type: improvement
 improvement:
   description: For users of the `response-time` GC Profile, the CMS garbage will still
-    be enabled on Java 13, as the GC is just _deprecated_ but not full removed. From
+    be enabled on Java 13, as the GC is just _deprecated_ but not fully removed. From
     Java 14 onwards, CMS does not exist anymore so we auto-switch to Shenandoah.
   links:
   - https://github.com/palantir/sls-packaging/pull/899

--- a/changelog/@unreleased/pr-899.v2.yml
+++ b/changelog/@unreleased/pr-899.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: For users of the `response-time` GC Profile, options to enable the
+    CMS garbage will still be set on Java 13, as the GC is just deprecated but not
+    full removed. From Java 14 onwards, CMS does not exist anymore so we auto-switch
+    to Shenandoah.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/899

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -52,7 +52,6 @@ public interface GcProfile extends Serializable {
             // use it up until this release.
             if (javaVersion.compareTo(JavaVersion.toVersion("14")) >= 0) {
                 return ImmutableList.of(
-                        "-XX:+UnlockExperimentalVMOptions",
                         // https://wiki.openjdk.java.net/display/shenandoah/Main
                         "-XX:+UseShenandoahGC",
                         // "forces concurrent cycle instead of Full GC on System.gc()"

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -48,7 +48,9 @@ public interface GcProfile extends Serializable {
 
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
-            if (javaVersion.compareTo(JavaVersion.toVersion("13")) >= 0) {
+            // The CMS garbage collector was removed in Java 14: https://openjdk.java.net/jeps/363. Users are free to
+            // use it up until this release.
+            if (javaVersion.compareTo(JavaVersion.toVersion("14")) >= 0) {
                 return ImmutableList.of(
                         "-XX:+UnlockExperimentalVMOptions",
                         // https://wiki.openjdk.java.net/display/shenandoah/Main

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -491,7 +491,6 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
         actualStaticConfig.jvmOpts().containsAll([
-                "-XX:+UnlockExperimentalVMOptions",
                 "-XX:+UseShenandoahGC",
                 "-XX:+ExplicitGCInvokesConcurrent",
                 "-XX:+ClassUnloadingWithConcurrentMark"


### PR DESCRIPTION
## Before this PR

We have a ton of services running on Java11, and jumping them all the way to Java14 is going to require migrating them from CMS -> Shenandoah. This is reasonably scary, partly because Shenandoah takes up more heap, but also partly because CMS has been very carefully tuned and we've found that just flipping the switch on catalog was not a magic bullet.

## After this PR
As such, I'd like to get 11 -> 13 rolling as this seems pretty non-scary, while we investigate shenandoah on 14 in parallel.

==COMMIT_MSG==
For users of the `response-time` GC Profile, options to enable the CMS garbage will still be set on Java 13, as the GC is just deprecated but not full removed. From Java 14 onwards, CMS does not exist anymore so we auto-switch to Shenandoah.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

