### PR TITLE
Improve npe on jdk 14

### DIFF
--- a/changelog/@unreleased/pr-907.v2.yml
+++ b/changelog/@unreleased/pr-907.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable Improved NullPointerException messages on modern JDKs
+  links:
+  - https://github.com/palantir/sls-packaging/pull/907

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -185,6 +185,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getDefaultJvmOpts().set(distributionExtension.getDefaultJvmOpts());
                     task.getAddJava8GcLogging().set(distributionExtension.getAddJava8GcLogging());
                     task.getJavaHome().set(distributionExtension.getJavaHome());
+                    task.getJavaVersion().set(distributionExtension.getJavaVersion());
                     task.getEnv().set(distributionExtension.getEnv());
                 });
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -119,7 +119,7 @@ public class LaunchConfigTask extends DefaultTask {
     }
 
     @Input
-    public Property<JavaVersion> getJavaVersion() {
+    public final Property<JavaVersion> getJavaVersion() {
         return javaVersion;
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
@@ -52,6 +53,7 @@ public class LaunchConfigTask extends DefaultTask {
             "-XX:NumberOfGCLogFiles=10",
             "-Xloggc:var/log/gc-%t-%p.log",
             "-verbose:gc");
+    private static List<String> java14Options = ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessage");
 
     private static final List<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
@@ -73,6 +75,7 @@ public class LaunchConfigTask extends DefaultTask {
     private final Property<Boolean> addJava8GcLogging =
             getProject().getObjects().property(Boolean.class);
     private final Property<String> javaHome = getProject().getObjects().property(String.class);
+    private final Property<JavaVersion> javaVersion = getProject().getObjects().property(JavaVersion.class);
     private final ListProperty<String> args = getProject().getObjects().listProperty(String.class);
     private final ListProperty<String> checkArgs = getProject().getObjects().listProperty(String.class);
     private final ListProperty<String> defaultJvmOpts =
@@ -113,6 +116,11 @@ public class LaunchConfigTask extends DefaultTask {
     @Optional
     public final Property<String> getJavaHome() {
         return javaHome;
+    }
+
+    @Input
+    public Property<JavaVersion> getJavaVersion() {
+        return javaVersion;
     }
 
     @Input
@@ -165,6 +173,10 @@ public class LaunchConfigTask extends DefaultTask {
                         .classpath(relativizeToServiceLibDirectory(classpath))
                         .addAllJvmOpts(alwaysOnJvmOptions)
                         .addAllJvmOpts(addJava8GcLogging.get() ? java8gcLoggingOptions : ImmutableList.of())
+                        .addAllJvmOpts(
+                                javaVersion.get().compareTo(JavaVersion.toVersion("14")) >= 0
+                                        ? java14Options
+                                        : ImmutableList.of())
                         .addAllJvmOpts(gcJvmOptions.get())
                         .addAllJvmOpts(defaultJvmOpts.get())
                         .putAllEnv(defaultEnvironment)


### PR DESCRIPTION
## Before this PR
[Jep 358](https://openjdk.java.net/jeps/358) described an improved NPE message that would help devs debug the problem. https://bugs.openjdk.java.net/browse/JDK-8227717 added the implementation behind the flag `-XX:ShowCodeDetailsInExceptionMessages`.

## After this PR
==COMMIT_MSG==
Enable Improved NullPointerException messages on modern JDKs
==COMMIT_MSG==

We can separately decide whether we feel comfortable safe-logging the NPE message so that devs can easily take advantage of the information

## Possible downsides?
N/A

