### PR TITLE
Fix typo in Java 14 flags

### DIFF
--- a/changelog/@unreleased/pr-913.v2.yml
+++ b/changelog/@unreleased/pr-913.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix typo in Java flags
+  links:
+  - https://github.com/palantir/sls-packaging/pull/913

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -53,7 +53,7 @@ public class LaunchConfigTask extends DefaultTask {
             "-XX:NumberOfGCLogFiles=10",
             "-Xloggc:var/log/gc-%t-%p.log",
             "-verbose:gc");
-    private static List<String> java14Options = ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessage");
+    private static List<String> java14Options = ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
 
     private static final List<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",


### PR DESCRIPTION
## Before this PR
There was a typo in the Java 14 flags we set causing the JVM to fail at startup

## After this PR
==COMMIT_MSG==
Fix typo in Java flags
==COMMIT_MSG==

## Possible downsides?
N/A

