### PR TITLE
Expose product dependency list property

### DIFF
--- a/changelog/@unreleased/pr-916.v2.yml
+++ b/changelog/@unreleased/pr-916.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Expose ListProperty `getAllProductDependencies` for accessing and configuring
+    a distribution's product dependencies
+  links:
+  - https://github.com/palantir/sls-packaging/pull/916

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -131,7 +131,17 @@ public class BaseDistributionExtension {
         this.productType.set(productType);
     }
 
+    /**
+     * The product dependencies of this distribution.
+     *
+     * @deprecated use {@link #getAllProductDependencies()} instead
+     */
+    @Deprecated
     public final Provider<List<ProductDependency>> getProductDependencies() {
+        return productDependencies;
+    }
+
+    public final ListProperty<ProductDependency> getAllProductDependencies() {
         return productDependencies;
     }
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -496,7 +496,7 @@ public class CreateManifestTask extends DefaultTask {
                     task.getServiceGroup().set(ext.getDistributionServiceGroup());
                     task.getProductType().set(ext.getProductType());
                     task.setManifestFile(new File(project.getBuildDir(), "/deployment/manifest.yml"));
-                    task.getProductDependencies().set(ext.getProductDependencies());
+                    task.getProductDependencies().set(ext.getAllProductDependencies());
                     task.setConfiguration(project.provider(ext::getProductDependenciesConfig));
                     task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
                     task.getManifestExtensions().set(ext.getManifestExtensions());

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/BaseDistributionExtensionTest.groovy
@@ -80,7 +80,7 @@ class BaseDistributionExtensionTest extends Specification {
         ext.productDependency("group:name:1.2.3")
 
         then:
-        def productDependencies = ext.getProductDependencies().get()
+        def productDependencies = ext.getAllProductDependencies().get()
         productDependencies.size() == 1
         productDependencies.get(0).productGroup == "group"
         productDependencies.get(0).productName == "name"
@@ -95,7 +95,7 @@ class BaseDistributionExtensionTest extends Specification {
         ext.productDependency("group:name:1.2.3:classifier@tgz")
 
         then:
-        def productDependencies = ext.getProductDependencies().get()
+        def productDependencies = ext.getAllProductDependencies().get()
         productDependencies.size() == 1
         productDependencies.get(0).productGroup == "group"
         productDependencies.get(0).productName == "name"
@@ -110,7 +110,7 @@ class BaseDistributionExtensionTest extends Specification {
         ext.productDependency("group:name:1.2.3:classifier@tgz", "1.2.4")
 
         then:
-        def productDependencies = ext.getProductDependencies().get()
+        def productDependencies = ext.getAllProductDependencies().get()
         productDependencies.size() == 1
         productDependencies.get(0).productGroup == "group"
         productDependencies.get(0).productName == "name"
@@ -129,7 +129,7 @@ class BaseDistributionExtensionTest extends Specification {
         }
 
         then:
-        def productDependencies = ext.getProductDependencies().get()
+        def productDependencies = ext.getAllProductDependencies().get()
         productDependencies.size() == 1
         productDependencies.get(0).productGroup == "group"
         productDependencies.get(0).productName == "name"
@@ -146,7 +146,7 @@ class BaseDistributionExtensionTest extends Specification {
         }
 
         when:
-        ext.getProductDependencies().get()
+        ext.getAllProductDependencies().get()
 
         then:
         def ex = thrown(SafeRuntimeException)


### PR DESCRIPTION
## Before this PR
We only exposed a Provider for reading a distributions product dependencies

## After this PR
==COMMIT_MSG==
Expose ListProperty for accessing and configuring a distribution's product dependencies
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

