### PR TITLE
Tolerate multiple declared dependencies

### DIFF
--- a/changelog/@unreleased/pr-919.v2.yml
+++ b/changelog/@unreleased/pr-919.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tolerate multiple product dependencies on the `distribution` extension.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/919

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -225,11 +225,8 @@ public class CreateManifestTask extends DefaultTask {
                         "Encountered product dependency declaration that was also ignored for '%s', either remove the "
                                 + "dependency or ignore",
                         productId));
-            } else if (allProductDependencies.containsKey(productId)) {
-                throw new IllegalArgumentException(
-                        String.format("Encountered duplicate declared product dependencies for '%s'", productId));
             }
-            allProductDependencies.put(productId, declaredDep);
+            allProductDependencies.merge(productId, declaredDep, ProductDependencyMerger::merge);
         });
 
         // Merge all discovered and declared product dependencies

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -141,7 +141,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         runTasksAndFail('createManifest').task(':createManifest').outcome == TaskOutcome.FAILED
     }
 
-    def 'throws if duplicate dependencies are declared'() {
+    def 'merges declared product dependencies'() {
         setup:
         buildFile << """
             createManifest {
@@ -153,10 +153,10 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         """.stripIndent()
 
         when:
-        def buildResult = runTasksAndFail(':createManifest')
+        def buildResult = runTasks(':createManifest', '--write-locks')
 
         then:
-        buildResult.output.contains('Encountered duplicate declared product')
+        buildResult.task(':createManifest').outcome == TaskOutcome.SUCCESS
     }
 
     def 'throws if declared dependency is also ignored'() {


### PR DESCRIPTION
## Before this PR
We would throw if we encountered multiple product dependencies on the same product on the `distribution` extension. I believe this was originally intended to prevent users from accidentally having duplicate scripts in their repo. As we've further automated builds this constraint has made it hard for other plugins to programmatically add product dependencies since they may conflict with ones provided by the user or another plugin.

## After this PR
==COMMIT_MSG==
Tolerate multiple product dependencies on the `distribution` extension.
==COMMIT_MSG==

## Possible downsides?
It eases the constraint which could allow unnecessary product dependencies to proliferate in gradle scripts. I don't think this would be a big issue, since nearly all product dependencies are inferred from JARs or injected by build automation

