### PR TITLE
Fix: CreateStartScripts works with gradle 6.4+

### DIFF
--- a/changelog/@unreleased/pr-921.v2.yml
+++ b/changelog/@unreleased/pr-921.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: <!-- User-facing outcomes this PR delivers -->
+  links:
+  - https://github.com/palantir/sls-packaging/pull/921

--- a/changelog/@unreleased/pr-921.v2.yml
+++ b/changelog/@unreleased/pr-921.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: <!-- User-facing outcomes this PR delivers -->
+  description: Correctly configure start scripts in Gradle 6.4+
   links:
   - https://github.com/palantir/sls-packaging/pull/921

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -127,6 +127,11 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     // Since we write out the name of this task's output (when it's enabled), we should depend on it
                     task.dependsOn(manifestClassPathTask);
                     task.getLazyMainClassName().set(mainClassName);
+
+                    if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
+                        task.getMainClass().set(mainClassName);
+                    }
+
                     task.doLast(t -> {
                         if (distributionExtension.getEnableManifestClasspath().get()) {
                             // Replace standard classpath with pathing jar in order to circumnavigate length limits:

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -128,10 +128,6 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.dependsOn(manifestClassPathTask);
                     task.getLazyMainClassName().set(mainClassName);
 
-                    if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
-                        task.getMainClass().set(mainClassName);
-                    }
-
                     task.doLast(t -> {
                         if (distributionExtension.getEnableManifestClasspath().get()) {
                             // Replace standard classpath with pathing jar in order to circumnavigate length limits:

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LazyCreateStartScriptTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LazyCreateStartScriptTask.java
@@ -21,6 +21,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.application.CreateStartScripts;
 
+// TODO(forozco): Remove once we raise our minimum supported gradle version to 6.6.
 public class LazyCreateStartScriptTask extends CreateStartScripts {
     private final Property<String> mainClassName = getProject().getObjects().property(String.class);
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LazyCreateStartScriptTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LazyCreateStartScriptTask.java
@@ -20,10 +20,17 @@ import javax.annotation.Nullable;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.application.CreateStartScripts;
+import org.gradle.util.GradleVersion;
 
 // TODO(forozco): Remove once we raise our minimum supported gradle version to 6.6.
 public class LazyCreateStartScriptTask extends CreateStartScripts {
     private final Property<String> mainClassName = getProject().getObjects().property(String.class);
+
+    public LazyCreateStartScriptTask() {
+        if (GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("6.6")) >= 0) {
+            getMainClass().set(mainClassName);
+        }
+    }
 
     @Input
     public final Property<String> getLazyMainClassName() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LazyCreateStartScriptTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LazyCreateStartScriptTask.java
@@ -22,12 +22,12 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.application.CreateStartScripts;
 import org.gradle.util.GradleVersion;
 
-// TODO(forozco): Remove once we raise our minimum supported gradle version to 6.6.
+// TODO(forozco): Remove once we raise our minimum supported gradle version to 6.4
 public class LazyCreateStartScriptTask extends CreateStartScripts {
     private final Property<String> mainClassName = getProject().getObjects().property(String.class);
 
     public LazyCreateStartScriptTask() {
-        if (GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("6.6")) >= 0) {
+        if (GradleVersion.current().compareTo(GradleVersion.version("6.4")) >= 0) {
             getMainClass().set(mainClassName);
         }
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/LazyCreateStartScriptTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/LazyCreateStartScriptTaskIntegrationSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.service
+
+import nebula.test.IntegrationSpec
+
+class LazyCreateStartScriptTaskIntegrationSpec extends IntegrationSpec {
+    def 'correctly populates main class'() {
+        when:
+        buildFile << """
+        import com.palantir.gradle.dist.service.tasks.LazyCreateStartScriptTask;
+        task createStartScripts(type: LazyCreateStartScriptTask) {
+            applicationName = 'test-service'
+            lazyMainClassName = 'myMainClass'
+            outputDir = file('build/scripts')
+        }
+        """.stripIndent()
+        def successfully = runTasksSuccessfully('createStartScripts')
+
+        then:
+        file('build/scripts/test-service').text.contains 'myMainClass'
+        file('build/scripts/test-service.bat').text.contains 'myMainClass'
+    }
+}


### PR DESCRIPTION
## Before this PR

@fmance had his start script broken on windows

## After this PR
==COMMIT_MSG==
Correctly configure start scripts in Gradle 6.4+
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

