### PR TITLE
Improvement: Use G1GC as default for java 11 in throughput mode

### DIFF
--- a/changelog/@unreleased/pr-924.v2.yml
+++ b/changelog/@unreleased/pr-924.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Set G1GC as default on java 11+ in throughput mode
+  links:
+  - https://github.com/palantir/sls-packaging/pull/924

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -38,6 +38,9 @@ public interface GcProfile extends Serializable {
     class Throughput implements GcProfile {
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
+            if (javaVersion.compareTo(JavaVersion.toVersion("11")) >= 0) {
+                return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseStringDeduplication");
+            }
             return ImmutableList.of("-XX:+UseParallelOldGC");
         }
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -371,6 +371,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaHome 'foo'
+                javaVersion 11
                 args 'myArg1', 'myArg2'
                 checkArgs 'myCheckArg1', 'myCheckArg2'
                 env "key1": "val1",
@@ -394,7 +395,8 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
-                '-XX:+UseParallelOldGC',
+                '-XX:+UseG1GC',
+                '-XX:+UseStringDeduplication',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
             .env(LaunchConfigTask.defaultEnvironment + [


### PR DESCRIPTION
## Before this PR
We would force new jvms to ParallelOldGC even though java 9 makes G1 the default

## After this PR
==COMMIT_MSG==
Set G1GC as default on java 11+ in throughput mode
==COMMIT_MSG==

## Possible downsides?
This will change people's gc's just because they're running new version but we find it acceptable for response-time already
