### PR TITLE
Properly configure shenandoah

### DIFF
--- a/changelog/@unreleased/pr-926.v2.yml
+++ b/changelog/@unreleased/pr-926.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Correctly set `-XX:+UnlockExperimentalVMOptions` when using `response-time`
+    gc profile with JDK 14+
+  links:
+  - https://github.com/palantir/sls-packaging/pull/926

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -52,6 +52,7 @@ public interface GcProfile extends Serializable {
             // use it up until this release.
             if (javaVersion.compareTo(JavaVersion.toVersion("14")) >= 0) {
                 return ImmutableList.of(
+                        "-XX:+UnlockExperimentalVMOptions",
                         // https://wiki.openjdk.java.net/display/shenandoah/Main
                         "-XX:+UseShenandoahGC",
                         // "forces concurrent cycle instead of Full GC on System.gc()"


### PR DESCRIPTION
## Before this PR
I had incorrectly suggested that we no longer needed `-XX:+UnlockExperimentalVMOptions` to use Shenandoah with JDK 14. https://github.com/palantir/sls-packaging/pull/899#discussion_r430408172

## After this PR
==COMMIT_MSG==
Correctly set `-XX:+UnlockExperimentalVMOptions` when using `response-time` gc profile with JDK 14+
==COMMIT_MSG==

## Possible downsides?
N/A

