### PR TITLE
Fix: prefer in declared dependency when merging in repo pdeps

### DIFF
--- a/changelog/@unreleased/pr-945.v2.yml
+++ b/changelog/@unreleased/pr-945.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Prefer in declared dependency when merging in repo pdeps
+  links:
+  - https://github.com/palantir/sls-packaging/pull/945


### PR DESCRIPTION
## Before this PR
A user would see inconsistent lock behaviour if a pdep on another service in the same repo was declared as well as being discovered. The underlying issue was with how we merge product dependencies where the minimum version was the current version (and the current version was not orderable i.e. dirty)

## After this PR
==COMMIT_MSG==
Prefer in declared dependency when merging in repo pdeps
==COMMIT_MSG==

## Possible downsides?
N/A

