### PR TITLE
Update YourKit version

### DIFF
--- a/changelog/@unreleased/pr-965.v2.yml
+++ b/changelog/@unreleased/pr-965.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Update YourKit version
+  links:
+  - https://github.com/palantir/sls-packaging/pull/965

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -58,7 +58,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum '47cf34fdf086fc8b5ff048205b67fefbc57e1733582479d93bdd15b320750dbb'
+    checksum 'c45ec29ceb7f511d6df0ac508c656caf822446f353644f40c50c1c736bc6b4a1'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -45,7 +45,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2019.8-b141"
+def yourkitVersion = "2019.8-b142"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {


### PR DESCRIPTION
## Before this PR

The download link for the current YourKit dependency seems to be no longer valid: https://www.yourkit.com/download/YourKit-JavaProfiler-2019.8-b141.zip

```
* What went wrong:
Execution failed for task ':gradle-sls-packaging:downloadYourkitDist'.
> de.undercouch.gradle.tasks.download.org.apache.http.client.ClientProtocolException: HTTP status code: 404, URL: https://www.yourkit.com/download/YourKit-JavaProfiler-2019.8-b141.zip
```


## After this PR

Update YourKit version to `2019.8-b142`: https://www.yourkit.com/download/YourKit-JavaProfiler-2019.8-b142.zip

==COMMIT_MSG==
Update YourKit version
==COMMIT_MSG==