### PR TITLE
go-java-launcher 1.9.1 -> 1.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:1.0.1'
         classpath 'com.netflix.nebula:gradle-info-plugin:9.1.1'
-        classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.26.0'
+        classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.25.0'
         classpath 'com.gradle.publish:plugin-publish-plugin:0.12.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:17.3.1'

--- a/changelog/@unreleased/go-java-launcher-1.10.0.v2.yml
+++ b/changelog/@unreleased/go-java-launcher-1.10.0.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: |
+    Upgrade go-java-launcher to 1.10.0 which is built against Go 1.15
+  links:
+  - https://github.com/palantir/sls-packaging/pull/992

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -51,8 +51,8 @@ import org.gradle.util.GradleVersion;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     private static final String GO_JAVA_LAUNCHER_BINARIES = "goJavaLauncherBinaries";
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.9.1";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.9.1";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.10.0";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.10.0";
     public static final String GROUP_NAME = "Distribution";
 
     @SuppressWarnings("checkstyle:methodlength")


### PR DESCRIPTION
## Before this PR
go-java-launcher was built against go 1.10.3, which is old.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Upgrade go-java-launcher 1.9.1 -> 1.10.0
==COMMIT_MSG==

## Possible downsides?
Go in these binaries is upgraded to 1.15. Could there be any downstream effects due to this?

