### PR TITLE
Disable string deduplication

### DIFF
--- a/changelog/@unreleased/pr-1005.v2.yml
+++ b/changelog/@unreleased/pr-1005.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable string deduplication for the G1 collector
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1005

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -91,7 +91,7 @@ public interface GcProfile extends Serializable {
     class Hybrid implements GcProfile {
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
-            return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseStringDeduplication");
+            return ImmutableList.of("-XX:+UseG1GC");
         }
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1073,7 +1073,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
-        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseStringDeduplication'])
+        actualStaticConfig.jvmOpts.contains('-XX:+UseG1GC')
     }
 
     private static createUntarBuildFile(File buildFile) {


### PR DESCRIPTION
Internally we've seen that string deduplication can cause GC overheads to go way up (from 1.5% STW to ~15% STW). This may contribute to the number of people who've tried G1 and needed to turn it off. Given the all-or-nothing nature of this flag, this makes the default garbage collector be rather unsuitable for general use - it has overly sharp edges. We should probably make the hybrid profile not enable it by default, and instead enable it in specific places where it makes sense, if at all.

