### PR TITLE
UseNUMA with G1GC.

### DIFF
--- a/changelog/@unreleased/pr-1007.v2.yml
+++ b/changelog/@unreleased/pr-1007.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    Where systems are running with multiple NUMA nodes, this would enable G1GC to make better decisions.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1007

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -91,7 +91,7 @@ public interface GcProfile extends Serializable {
     class Hybrid implements GcProfile {
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
-            return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseNUMA", "-XX:+PrintFlagsFinal");
+            return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseNUMA");
         }
     }
 }

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -91,7 +91,7 @@ public interface GcProfile extends Serializable {
     class Hybrid implements GcProfile {
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
-            return ImmutableList.of("-XX:+UseG1GC");
+            return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseNUMA", "-XX:+PrintFlagsFinal");
         }
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1073,7 +1073,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
-        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseNUMA', '-XX:+PrintFlagsFinal'])
+        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseNUMA'])
     }
 
     private static createUntarBuildFile(File buildFile) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -168,7 +168,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             repositories {
                 jcenter()
                 maven { url "https://palantir.bintray.com/releases" }
@@ -208,7 +208,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             repositories {
                 jcenter()
                 maven { url "https://palantir.bintray.com/releases" }
@@ -570,7 +570,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             repositories {
                 jcenter()
                 maven { url "https://palantir.bintray.com/releases" }
@@ -584,7 +584,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             afterEvaluate {
                 String actualTarballPath = distTar.outputs.files.singleFile.absolutePath
                 String expectedTarballPath = project.file('build/distributions/my-service.sls.tgz').absolutePath
-                
+
                 if (!actualTarballPath.equals(expectedTarballPath)) {
                     throw new GradleException("tarball path didn't match.\\n" +
                             "actual: ${actualTarballPath}\\n" +
@@ -604,7 +604,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             repositories {
                 jcenter()
                 maven { url "https://palantir.bintray.com/releases" }
@@ -649,7 +649,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             repositories {
                 jcenter()
                 maven { url "https://palantir.bintray.com/releases" }
@@ -705,14 +705,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             plugins {
                 id 'com.palantir.consistent-versions' version '${Versions.GRADLE_CONSISTENT_VERSIONS}'
             }
-            
+
             configurations {
                 fromOtherProject
             }
             dependencies {
                 fromOtherProject project(':dist')
             }
-            
+
             task verify {
                 doLast {
                     configurations.fromOtherProject.resolve()
@@ -724,7 +724,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             plugins {
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             version '0.0.1'
             distribution {
                 serviceName "my-asset"
@@ -778,7 +778,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             version '0.0.1'
             distribution {
                 serviceName "service-name"
@@ -865,7 +865,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 group = 'group'
                 version = '1.0.0'
             }
-            
+
         """.stripIndent()
         helper.addSubproject("first", """
             plugins {
@@ -909,7 +909,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             version '0.0.1'
             distribution {
                 serviceName "service-name"
@@ -1015,7 +1015,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             repositories {
                 jcenter()
                 maven { url "https://palantir.bintray.com/releases" }
@@ -1050,7 +1050,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'java'
                 id 'com.palantir.sls-java-service-distribution'
             }
-            
+
             repositories {
                 jcenter()
                 maven { url "https://palantir.bintray.com/releases" }
@@ -1073,7 +1073,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
-        actualStaticConfig.jvmOpts.contains('-XX:+UseG1GC')
+        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseNUMA', '-XX:+PrintFlagsFinal'])
     }
 
     private static createUntarBuildFile(File buildFile) {


### PR DESCRIPTION
## Before this PR
Where systems are running with a single NUMA node, this would have no effect where JDK >= 11. Refer to https://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/2198ef7e1c17/src/os/linux/vm/os_linux.cpp#l4931.

## After this PR
==COMMIT_MSG==
Where systems are running with multiple NUMA nodes, this would enable G1GC to make better decisions.
==COMMIT_MSG==

## Possible downsides?
This should be a no-op for systems with single NUMA nodes while benefiting multiple NUMA node systems.