### PR TITLE
Add empty GC profile

### DIFF
--- a/changelog/@unreleased/pr-1015.v2.yml
+++ b/changelog/@unreleased/pr-1015.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add empty GC profile
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1015

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -33,7 +33,7 @@ public interface GcProfile extends Serializable {
             "throughput", GcProfile.Throughput.class,
             "response-time", GcProfile.ResponseTime.class,
             "hybrid", GcProfile.Hybrid.class,
-            "no-profile", GcProfile.NoProfile.class);
+            "dangerous-no-profile", GcProfile.NoProfile.class);
 
     List<String> gcJvmOpts(JavaVersion javaVersion);
 

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.gradle.api.JavaVersion;
@@ -31,7 +32,8 @@ public interface GcProfile extends Serializable {
     Map<String, Class<? extends GcProfile>> PROFILE_NAMES = ImmutableMap.of(
             "throughput", GcProfile.Throughput.class,
             "response-time", GcProfile.ResponseTime.class,
-            "hybrid", GcProfile.Hybrid.class);
+            "hybrid", GcProfile.Hybrid.class,
+            "no-profile", GcProfile.NoProfile.class);
 
     List<String> gcJvmOpts(JavaVersion javaVersion);
 
@@ -92,6 +94,17 @@ public interface GcProfile extends Serializable {
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
             return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseNUMA");
+        }
+    }
+
+    /**
+     * This GC profile does not apply any JVM flags which allows services to override GC settings without needing to
+     * unset preconfigured flags.
+     */
+    class NoProfile implements GcProfile {
+        @Override
+        public List<String> gcJvmOpts(JavaVersion javaVersion) {
+            return Collections.emptyList();
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -196,7 +196,7 @@ And the complete list of configurable properties:
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
    be applied when `init.sh` is run. When your `targetCompatibility` is Java 8 or less, this value will be blank. For
    Java 9 or higher will default to `$JAVA_<majorversion>_HOME` ie for Java 11 this would be `$JAVA_11_HOME`.
- * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default), `hybrid` and `response-time`. Additionally, there is also `no-profile` which does not apply any additional JVM flags and allows you to fully configure any GC settings through JVM options (not recommended for normal usage!). 
+ * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default), `hybrid` and `response-time`. Additionally, there is also `dangerous-no-profile` which does not apply any additional JVM flags and allows you to fully configure any GC settings through JVM options (not recommended for normal usage!). 
  * (optional) `addJava8GcLogging` add java 8 specific gc logging options.
 
 #### JVM Options

--- a/readme.md
+++ b/readme.md
@@ -196,7 +196,7 @@ And the complete list of configurable properties:
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
    be applied when `init.sh` is run. When your `targetCompatibility` is Java 8 or less, this value will be blank. For
    Java 9 or higher will default to `$JAVA_<majorversion>_HOME` ie for Java 11 this would be `$JAVA_11_HOME`.
- * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default), `hybrid` and `response-time`.
+ * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default), `hybrid` and `response-time`. Additionally, there is also `no-profile` which does not apply any additional JVM flags and allows you to fully configure any GC settings through JVM options (not recommended for normal usage!). 
  * (optional) `addJava8GcLogging` add java 8 specific gc logging options.
 
 #### JVM Options


### PR DESCRIPTION
## After this PR

Introduce an empty GC profile called `dangerous-no-profile`, that does not apply any GC flags. This is intended to allow easier overriding of GC settings for performing GC experiments or other "expert" usage and is not intended to be used by most services.

More context in https://github.com/palantir/sls-packaging/issues/998

==COMMIT_MSG==
Add empty GC profile
==COMMIT_MSG==

## Possible downsides?
Brings in the danger that users experiment with GC flags and then forget to revert the profile afterwards. Maybe we should leave it undocumented or put in some highly visible logging when selecting this empty profile?
