### PR TITLE
libyjpagent.so 2019.8-b142 -> 2020.9-b411

### DIFF
--- a/changelog/@unreleased/pr-1017.v2.yml
+++ b/changelog/@unreleased/pr-1017.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Upgrade the embedded yourkit libyjpagent.so to 2020.9-b411
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1017

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -45,7 +45,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2019.8-b142"
+def yourkitVersion = "2020.9-b411"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {
@@ -58,7 +58,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum 'c45ec29ceb7f511d6df0ac508c656caf822446f353644f40c50c1c736bc6b4a1'
+    checksum '03e65eedf7bd42567b38dd48a57b801ea5b8a13e8de318eb4d5435f6c9fbed7d'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {


### PR DESCRIPTION
## Before this PR

There's an internal thread where there are concerns that the libyjpagent.so file statically linked against an old version of zlib. Figured we might as well dial it up to latest.

## After this PR
==COMMIT_MSG==
Upgrade the embedded yourkit libyjpagent.so to 2020.9-b411
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

