### PR TITLE
Java services record heap dumps on OOM

### DIFF
--- a/changelog/@unreleased/pr-1026.v2.yml
+++ b/changelog/@unreleased/pr-1026.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Java services record heap dumps to `var/log/heapdump.hprof` on OOM.
+    If the file already exists from a previous failure, no new heap dump is recorded.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1026

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -44,7 +44,7 @@ import org.immutables.value.Value;
 
 public class LaunchConfigTask extends DefaultTask {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
-    private static final List<String> java8gcLoggingOptions = ImmutableList.of(
+    private static final ImmutableList<String> java8gcLoggingOptions = ImmutableList.of(
             "-XX:+PrintGCDateStamps",
             "-XX:+PrintGCDetails",
             "-XX:-TraceClassUnloading",
@@ -53,13 +53,18 @@ public class LaunchConfigTask extends DefaultTask {
             "-XX:NumberOfGCLogFiles=10",
             "-Xloggc:var/log/gc-%t-%p.log",
             "-verbose:gc");
-    private static List<String> java14Options = ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
+    private static final ImmutableList<String> java14Options =
+            ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
 
-    private static final List<String> alwaysOnJvmOptions = ImmutableList.of(
+    private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
+            "-XX:+HeapDumpOnOutOfMemoryError",
             "-Djava.io.tmpdir=var/data/tmp",
             "-XX:ErrorFile=var/log/hs_err_pid%p.log",
-            "-XX:HeapDumpPath=var/log",
+            // Provide a full filename to avoid filling disks with heap dumps.
+            // If a heap dump already exists in this location, subsequent OOMs
+            // will not dump heap.
+            "-XX:HeapDumpPath=var/log/heapdump.hprof",
             // Set DNS cache TTL to 20s to account for systems such as RDS and other
             // AWS-managed systems that modify DNS records on failover.
             "-Dsun.net.inetaddr.ttl=20");

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -390,9 +390,10 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
             .jvmOpts([
                 '-XX:+CrashOnOutOfMemoryError',
+                '-XX:+HeapDumpOnOutOfMemoryError',
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
-                '-XX:HeapDumpPath=var/log',
+                '-XX:HeapDumpPath=var/log/heapdump.hprof',
                 '-Dsun.net.inetaddr.ttl=20',
                 '-XX:+UseParallelOldGC',
                 '-Xmx4M',
@@ -413,9 +414,10 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             .classpath(actualStaticConfig.classpath())
             .jvmOpts([
                 '-XX:+CrashOnOutOfMemoryError',
+                '-XX:+HeapDumpOnOutOfMemoryError',
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
-                '-XX:HeapDumpPath=var/log',
+                '-XX:HeapDumpPath=var/log/heapdump.hprof',
                 '-Dsun.net.inetaddr.ttl=20',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
@@ -450,9 +452,10 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
             .jvmOpts([
                 '-XX:+CrashOnOutOfMemoryError',
+                '-XX:+HeapDumpOnOutOfMemoryError',
                 '-Djava.io.tmpdir=var/data/tmp',
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
-                '-XX:HeapDumpPath=var/log',
+                '-XX:HeapDumpPath=var/log/heapdump.hprof',
                 '-Dsun.net.inetaddr.ttl=20',
                 "-XX:+PrintGCDateStamps",
                 "-XX:+PrintGCDetails",


### PR DESCRIPTION
## Before this PR
Previously OOMs did not result in heap dumps, only crash files.

## After this PR
Now a heap dump is recorded to `var/log/heapdump.hprof` in the
event of an OOM. If an hprof already exists in this location, it
will not be overwritten, and no hprof will be recorded to prevent
services that quickly OOM on startup from filling the disk.
Any time a service OOMs there's action required to figure out
precisely what went wrong. Without recording heap, there may
not be any bread crumbs to understand the failure scenario.

==COMMIT_MSG==
Java services record heap dumps to `var/log/heapdump.hprof` on OOM. If the file already exists from a previous failure, no new heap dump is recorded.
==COMMIT_MSG==

## Possible downsides?
Heap dumps are large, even a single heap dump may dominate disk
utilization compared to all other logging combined. In the worst
case this may fill the disk and prevent a service from restarting,
however this is a price we pay for the ability to understand how
products have failed.
Services which already set `-XX:+HeapDumpOnOutOfMemoryError` and
expect multiple heap dumps to be recorded will need to add the
`-XX:HeapDumpPath=var/log/` option to override defaults if they wish
to avoid changing behavior.

