### PR TITLE
Automatically wire up the --enable-preview option if necessary

### DIFF
--- a/changelog/@unreleased/pr-1033.v2.yml
+++ b/changelog/@unreleased/pr-1033.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: sls-packaging will automatically include the `--enable-preview` jvm
+    arg in launcher-static.yml if `com.palantir.baseline-enable-preview-flag` is applied.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1033

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -78,7 +78,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         distributionExtension.defaultJvmOpts(project.provider(() -> {
             Object maybeProvider = project.getExtensions().getExtraProperties().get("enablePreview");
             if (maybeProvider instanceof Provider && ((Provider<Boolean>) maybeProvider).get()) {
-                return Collections.singletonList("--enablePreview");
+                return Collections.singletonList("--enable-preview");
             } else {
                 return Collections.emptyList();
             }


### PR DESCRIPTION
## Before this PR

In baseline 3.52.0 we added this new plugin as a one-liner to add the --enable-preview flag wherever necessary (https://github.com/palantir/gradle-baseline/pull/1549). We're using the extraProperties thing to avoid taking a compile dependency on baseline.

## After this PR
==COMMIT_MSG==
sls-packaging will automatically include the `--enable-preview` jvm arg in launcher-static.yml if `com.palantir.baseline-enable-preview-flag` is applied.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

