### PR TITLE
[wip] Populate the 'diagnostics' manifest extension, discovering info from runtimeClasspath (and local files)

### DIFF
--- a/changelog/@unreleased/pr-1034.v2.yml
+++ b/changelog/@unreleased/pr-1034.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: 'For java services, a new `diagnostics` extension of the sls manifest
+    will be populated based on the `sls-manifest/diagnostics.json` file found locally
+    or in any jar in runtimeClasspath. Contents should look like `{["type": "foo.v1"]}`,
+    as defined in the sls-spec.'
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1034

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -207,6 +207,20 @@ public class CreateManifestTask extends DefaultTask {
     @TaskAction
     final void createManifest() throws Exception {
         validateProjectVersion();
+        jsonMapper.writeValue(
+                getManifestFile(),
+                SlsManifest.builder()
+                        .manifestVersion("1.0")
+                        .productType(productType.get())
+                        .productGroup(serviceGroup.get())
+                        .productName(serviceName.get())
+                        .productVersion(getProjectVersion())
+                        .putAllExtensions(manifestExtensions.get())
+                        .putExtensions("product-dependencies", computeProductDependencies())
+                        .build());
+    }
+
+    private List<ProductDependency> computeProductDependencies() {
         if (manifestExtensions.get().containsKey("product-dependencies")) {
             throw new IllegalArgumentException("Use productDependencies configuration option instead of setting "
                     + "'product-dependencies' key in manifestExtensions");
@@ -261,17 +275,7 @@ public class CreateManifestTask extends DefaultTask {
             ensureLockfileIsUpToDate(productDeps);
         }
 
-        jsonMapper.writeValue(
-                getManifestFile(),
-                SlsManifest.builder()
-                        .manifestVersion("1.0")
-                        .productType(productType.get())
-                        .productGroup(serviceGroup.get())
-                        .productName(serviceName.get())
-                        .productVersion(getProjectVersion())
-                        .putAllExtensions(manifestExtensions.get())
-                        .putExtensions("product-dependencies", productDeps)
-                        .build());
+        return productDeps;
     }
 
     private void requireAbsentLockfile() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -222,10 +222,9 @@ public class CreateManifestTask extends DefaultTask {
     }
 
     // See the internal sls-spec's debug.md document
-    private List<Diagnostics.SupportedDiagnostic> findSupportedDiagnosticTypesFromClasspath() {
-        List<Diagnostics.DiagnosticType> fromRuntimeClasspath = Diagnostics.loadFromConfiguration(
+    private Diagnostics.SupportedDiagnostics findSupportedDiagnosticTypesFromClasspath() {
+        return Diagnostics.loadFromConfiguration(
                 getProject(), getProject().getConfigurations().getByName("runtimeClasspath"));
-        return Diagnostics.asManifestExtension(fromRuntimeClasspath);
     }
 
     private List<ProductDependency> computeProductDependencies() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -217,7 +217,15 @@ public class CreateManifestTask extends DefaultTask {
                         .productVersion(getProjectVersion())
                         .putAllExtensions(manifestExtensions.get())
                         .putExtensions("product-dependencies", computeProductDependencies())
+                        .putExtensions("diagnostics", findSupportedDiagnosticTypesFromClasspath())
                         .build());
+    }
+
+    // See the internal sls-spec's debug.md document
+    private List<Diagnostics.SupportedDiagnostic> findSupportedDiagnosticTypesFromClasspath() {
+        List<Diagnostics.DiagnosticType> fromRuntimeClasspath = Diagnostics.loadFromConfiguration(
+                getProject(), getProject().getConfigurations().getByName("runtimeClasspath"));
+        return Diagnostics.asManifestExtension(fromRuntimeClasspath);
     }
 
     private List<ProductDependency> computeProductDependencies() {

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/Diagnostics.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/Diagnostics.java
@@ -1,0 +1,196 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.Iterables;
+import com.google.common.io.Files;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class Diagnostics {
+    private static final Logger log = LoggerFactory.getLogger(Diagnostics.class);
+    static final String PATH_IN_JAR = "sls-debug/diagnostics.json";
+
+    static List<DiagnosticType> loadFromConfiguration(Project current, Configuration configuration) {
+        return configuration.getResolvedConfiguration().getResolvedArtifacts().stream()
+                .map(artifact -> {
+                    ComponentIdentifier id = artifact.getId().getComponentIdentifier();
+                    if (id instanceof ProjectComponentIdentifier) {
+                        Project dependencyProject = current.project(((ProjectComponentIdentifier) id).getProjectPath());
+                        return maybeGetSourceFileFromLocalProject(dependencyProject);
+                    } else {
+                        return maybeExtractFromJar(artifact.getFile(), id);
+                    }
+                })
+                .filter(Optional::isPresent)
+                .flatMap(isPresent -> isPresent.get().types().stream())
+                .distinct() // would be kinda weird if multiple jars claim to provide the same diagnostic type??
+                .sorted(Comparator.comparing(DiagnosticType::toString))
+                .collect(Collectors.toList());
+    }
+
+    static List<SupportedDiagnostic> asManifestExtension(List<DiagnosticType> items) {
+        return items.stream().map(ImmutableSupportedDiagnostic::of).collect(Collectors.toList());
+    }
+
+    @Value.Immutable
+    @JsonDeserialize(as = ImmutableEmbeddedInJar.class)
+    interface EmbeddedInJar {
+        List<DiagnosticType> types();
+    }
+
+    @Value.Immutable
+    interface SupportedDiagnostic {
+        @Value.Parameter
+        DiagnosticType type();
+    }
+
+    private static Optional<EmbeddedInJar> maybeGetSourceFileFromLocalProject(Project proj) {
+        JavaPluginConvention javaPlugin = proj.getConvention().findPlugin(JavaPluginConvention.class);
+        if (javaPlugin == null) {
+            return Optional.empty();
+        }
+
+        Set<File> sourceFiles = javaPlugin
+                .getSourceSets()
+                .getByName("main")
+                .getResources()
+                .getAsFileTree()
+                .filter(file -> {
+                    return file.toString().endsWith(PATH_IN_JAR);
+                })
+                .getFiles();
+        if (sourceFiles.isEmpty()) {
+            return Optional.empty();
+        }
+        if (sourceFiles.size() > 1) {
+            throw new GradleException("Expecting to find 0 or 1 files, found: " + sourceFiles);
+        }
+        File file = Iterables.getOnlyElement(sourceFiles);
+        try {
+            return Optional.of(CreateManifestTask.jsonMapper.readValue(file, EmbeddedInJar.class));
+        } catch (IOException e) {
+            throw new GradleException(
+                    "Failed to deserialize '" + file + "', expecting something like "
+                            + "{\"types\":[\"foo.v1\", \"bar.v1\"]} ",
+                    e);
+        }
+    }
+
+    private static Optional<EmbeddedInJar> maybeExtractFromJar(File jarFile, ComponentIdentifier idForLogging) {
+        if (!jarFile.exists()) {
+            log.debug("Artifact did not exist: {}", jarFile);
+            return Optional.empty();
+        } else if (!Files.getFileExtension(jarFile.getName()).equals("jar")) {
+            log.debug("Artifact is not a jar: {}", jarFile);
+            return Optional.empty();
+        }
+
+        try (ZipFile zipFile = new ZipFile(jarFile)) {
+            ZipEntry zipEntry = zipFile.getEntry(PATH_IN_JAR);
+            if (zipEntry == null) {
+                log.debug("Unable to find '{}' in JAR: {}", PATH_IN_JAR, idForLogging);
+                return Optional.empty();
+            }
+
+            try (InputStream is = zipFile.getInputStream(zipEntry)) {
+                return Optional.of(CreateManifestTask.jsonMapper.readValue(is, EmbeddedInJar.class));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load from jar: " + idForLogging);
+        }
+    }
+
+    /**
+     * A {@link DiagnosticType} is an identifier that uniquely identifies the operation and output format for the
+     * diagnostics. Type names must be specific, reasonably expected to be unique, and versioned to allow for future
+     * major changes of the payload structure. DiagnosticTypes must match the regular expression
+     * {@code ([a-z0-9]+\.)+v[0-9]+}, i.e. be lower-case, dot-delimited, and end with a version suffix. For example, the
+     * {@code threaddump.v1} diagnosticType  might indicate a value of ThreadDumpV1 from the DiagnosticLogV1 definition.
+     */
+    public static final class DiagnosticType {
+        private static final Pattern TYPE_PATTERN = Pattern.compile("([a-z0-9]+\\.)+v[0-9]+");
+
+        private final String diagnosticTypeString;
+
+        @JsonCreator
+        public static DiagnosticType of(String diagnosticTypeString) {
+            Preconditions.checkNotNull(diagnosticTypeString, "Diagnostic type string is required");
+            if (!TYPE_PATTERN.matcher(diagnosticTypeString).matches()) {
+                throw new SafeIllegalArgumentException(
+                        "Diagnostic types must match pattern",
+                        SafeArg.of("diagnosticType", diagnosticTypeString),
+                        SafeArg.of("pattern", TYPE_PATTERN.pattern()));
+            }
+            return new DiagnosticType(diagnosticTypeString);
+        }
+
+        private DiagnosticType(String diagnosticTypeString) {
+            this.diagnosticTypeString = diagnosticTypeString;
+        }
+
+        @Override
+        @JsonValue
+        public String toString() {
+            return diagnosticTypeString;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other == null || getClass() != other.getClass()) {
+                return false;
+            }
+            DiagnosticType that = (DiagnosticType) other;
+            return Objects.equals(diagnosticTypeString, that.diagnosticTypeString);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(diagnosticTypeString);
+        }
+    }
+
+    private Diagnostics() {}
+}

--- a/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/Diagnostics.java
+++ b/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/tasks/Diagnostics.java
@@ -127,7 +127,7 @@ final class Diagnostics {
         String string = null;
         try {
             string = new String(java.nio.file.Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8).trim();
-            SupportedDiagnostics value = CreateManifestTask.jsonMapper.readValue(file, SupportedDiagnostics.class);
+            SupportedDiagnostics value = CreateManifestTask.jsonMapper.readValue(string, SupportedDiagnostics.class);
             log.info("Found diagnostics in local project '{}': '{}'", relativePath, value);
             return Optional.of(value);
         } catch (IOException e) {


### PR DESCRIPTION
## Before this PR

@bmoylan is working on the Debug Service, spec'd out internally here: https://github.p.b/deployability/sls-spec/pull/521).

Essentially, servers might be capable of responding to a few different types of request (e.g. _jstack.v1_ or _heap.histogram.v1_), and we want a user interface to be able to display clickable buttons to trigger these.  To make this declarative, the sls-spec PR above requires information about which types are supported to be embedded in the manifest that is present in all sls.tgzs.

## After this PR
==COMMIT_MSG==
For java services, `createManifest` task will now populate the `diagnostics` extension of the sls manifest.
==COMMIT_MSG==

For example, 
```diff
 {
   "manifest-version" : "1.0",
   "product-type" : "service.v1",
   "product-group" : "com.palantir.log-receiver",
   "product-name" : "log-receiver",
   "product-version" : "1.125.0-1-g594cdd6.dirty",
   "extensions" : {
     "upgrade-strategy" : "rolling",
     "public-proxy-endpoints" : [ "service-endpoint" ],
     "product-dependencies" : [ {
       "product-group" : "com.palantir.s",
       "product-name" : "a",
       "minimum-version" : "1.51.0",
       "maximum-version" : "2.x.x"
     }, {
       "product-group" : "com.palantir.mp",
       "product-name" : "mp",
       "minimum-version" : "3.297.0",
       "maximum-version" : "3.x.x"
     } ],
+    "diagnostics" : [ {
+      "type" : "bar.v1"
+    }, {
+      "type" : "foo.v1"
+    } ]
   }
 }
```

Needs:
- [ ] docs
- [ ] tests
- [ ] proper up-to-dateness stuff
- [ ] any more logging / observability??

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

