### PR TITLE
Fix createStartScripts doLast

### DIFF
--- a/changelog/@unreleased/pr-1045.v2.yml
+++ b/changelog/@unreleased/pr-1045.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The `createStartScripts` task can now be cached, as it no longer has
+    a lambda attached to it.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1045


### PR DESCRIPTION
The createStartScripts task is apparently never up to date, which means we're re-running some pointless tasks in everyone's builds.

![image](https://user-images.githubusercontent.com/3473798/100385672-3e282280-301b-11eb-8022-0e5ff9a58062.png)

We've already got an error-prone rule that should have caught this: https://github.com/palantir/gradle-baseline/blob/develop/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java, but the sourceset wasgroovy.  Felipe is being a hero and fully converting us in #1044 