### PR TITLE
Disable TLS session tickets by default

### DIFF
--- a/changelog/@unreleased/pr-1048.v2.yml
+++ b/changelog/@unreleased/pr-1048.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Disable TLS session tickets by default to decouple JVM upgrades from
+    significant TLS changes.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1048

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -62,7 +62,12 @@ public class LaunchConfigTask extends DefaultTask {
             "-XX:HeapDumpPath=var/log",
             // Set DNS cache TTL to 20s to account for systems such as RDS and other
             // AWS-managed systems that modify DNS records on failover.
-            "-Dsun.net.inetaddr.ttl=20");
+            "-Dsun.net.inetaddr.ttl=20",
+            // Disable RFC 5077 TLS session ticket support due to incompatibility with common implementations.
+            // This allows us to decouple JVM upgrades from enabling session ticket support.
+            // See https://www.oracle.com/java/technologies/javase/14-relnote-issues.html#JDK-8228396
+            "-Djdk.tls.client.enableSessionTicketExtension=false",
+            "-Djdk.tls.server.enableSessionTicketExtension=false");
 
     // Reduce memory usage for some versions of glibc.
     // Default value is 8 * CORES.

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -63,8 +63,9 @@ public class LaunchConfigTask extends DefaultTask {
             // Set DNS cache TTL to 20s to account for systems such as RDS and other
             // AWS-managed systems that modify DNS records on failover.
             "-Dsun.net.inetaddr.ttl=20",
-            // Disable RFC 5077 TLS session ticket support due to incompatibility with common implementations.
-            // This allows us to decouple JVM upgrades from enabling session ticket support.
+            // PDS-123520: Disable RFC 5077 TLS session ticket support due to incompatibility with
+            // nginx in some configurations. This allows us to decouple JVM upgrades from enabling
+            // session ticket support.
             // See https://www.oracle.com/java/technologies/javase/14-relnote-issues.html#JDK-8228396
             "-Djdk.tls.client.enableSessionTicketExtension=false",
             "-Djdk.tls.server.enableSessionTicketExtension=false");

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -397,6 +397,8 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
+                '-Djdk.tls.client.enableSessionTicketExtension=false',
+                '-Djdk.tls.server.enableSessionTicketExtension=false',
                 '-XX:+UseParallelOldGC',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
@@ -420,6 +422,8 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
+                '-Djdk.tls.client.enableSessionTicketExtension=false',
+                '-Djdk.tls.server.enableSessionTicketExtension=false',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
             .env(LaunchConfigTask.defaultEnvironment)
@@ -457,6 +461,8 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
+                '-Djdk.tls.client.enableSessionTicketExtension=false',
+                '-Djdk.tls.server.enableSessionTicketExtension=false',
                 "-XX:+PrintGCDateStamps",
                 "-XX:+PrintGCDetails",
                 "-XX:-TraceClassUnloading",


### PR DESCRIPTION
## Before this PR
We've run into some incompatibilities that haven't been debugged
yet, and prefer to defer session ticket rollout until we've
upgraded JVMs.

https://www.oracle.com/java/technologies/javase/14-relnote-issues.html#JDK-8228396

## After this PR
==COMMIT_MSG==
Disable TLS session tickets by default to decouple JVM upgrades from significant TLS changes.
==COMMIT_MSG==

## Possible downsides?
Straying from defaults always introduces risk. Most java shops have not upgraded to jre14/15 yet, so it may be safer to revert to battle-tested non-session-ticket code.