### PR TITLE
Add recommended product dependencies to all jars

### DIFF
--- a/changelog/@unreleased/pr-1053.v2.yml
+++ b/changelog/@unreleased/pr-1053.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Recommended product dependencies are added to the manifests of all
+    jar tasks in the projects where `com.palantir.recommended-product-dependencies`
+    is applied. This means `shadowJar` from the gradle shadow plugin now picks up
+    recommended product dependencies.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1053

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ConfigureProductDependenciesTask.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ConfigureProductDependenciesTask.java
@@ -36,22 +36,20 @@ import org.gradle.api.tasks.bundling.Jar;
  */
 public class ConfigureProductDependenciesTask extends DefaultTask {
 
-    private final Jar jar;
     private final SetProperty<ProductDependency> productDependencies =
             getProject().getObjects().setProperty(ProductDependency.class);
 
-    public ConfigureProductDependenciesTask(Jar jar) {
+    public ConfigureProductDependenciesTask() {
         setDescription("Configures the 'jar' task to write the input product dependencies into its manifest");
-
-        this.jar = jar;
-        jar.dependsOn(this);
     }
 
     @TaskAction
     final void action() {
-        Preconditions.checkState(
-                !jar.getState().getExecuted(), "Attempted to configure jar task after it was executed");
-        jar.getManifest().from(createManifest(getProject(), productDependencies.get()));
+        getProject().getTasks().withType(Jar.class).configureEach(jar -> {
+            Preconditions.checkState(
+                    !jar.getState().getExecuted(), "Attempted to configure jar task after it was executed");
+            jar.getManifest().from(createManifest(getProject(), productDependencies.get()));
+        });
     }
 
     public final void setProductDependencies(Provider<Set<ProductDependency>> productDependencies) {

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.dist;
 
-import org.gradle.api.DefaultTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskProvider;
@@ -30,18 +29,15 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
         final RecommendedProductDependenciesExtension ext = project.getExtensions()
                 .create("recommendedProductDependencies", RecommendedProductDependenciesExtension.class, project);
 
-        TaskProvider<DefaultTask> configureProductDependencies =
-                project.getTasks().register("configureProductDependencies", DefaultTask.class);
+        TaskProvider<ConfigureProductDependenciesTask> configureProductDependencies = project.getTasks()
+                .register(
+                        "configureProductDependencies",
+                        ConfigureProductDependenciesTask.class,
+                        configureProductDependenciesTask -> {
+                            configureProductDependenciesTask.setProductDependencies(
+                                    ext.getRecommendedProductDependenciesProvider());
+                        });
 
-        project.getTasks().withType(Jar.class).configureEach(jar -> {
-            project.getTasks()
-                    .register("configureProductDependencies_" + jar.getName(), ConfigureProductDependenciesTask.class)
-                    .configure(configureProductDependenciesTask -> {
-                        configureProductDependencies.configure(
-                                task -> task.dependsOn(configureProductDependenciesTask));
-                        configureProductDependenciesTask.setProductDependencies(
-                                ext.getRecommendedProductDependenciesProvider());
-                    });
-        });
+        project.getTasks().withType(Jar.class).configureEach(jar -> jar.dependsOn(configureProductDependencies));
     }
 }

--- a/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
+++ b/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
@@ -98,7 +98,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         verifyCorrectRecommendedProductDeps('build/libs/root-project.jar')
     }
 
-    def 'when gradle-shadow-jar is applied, the pdeps are put into the thin and shadow jar manifest'() {
+    def 'when gradle-shadow-jar is applied, the pdeps are put into the shadow jar manifest'() {
         settingsFile  << '''
             rootProject.name = "root-project"
         '''.stripIndent()
@@ -112,7 +112,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
             
                 dependencies {
                     classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.27.0'
-                    classpath 'com.palantir.gradle.shadow-jar:gradle-shadow-jar:1.2.0'
+                    classpath 'com.palantir.gradle.shadow-jar:gradle-shadow-jar:1.3.0'
                 }
             }
             
@@ -120,14 +120,6 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
             apply plugin: 'com.palantir.recommended-product-dependencies'
             apply plugin: 'com.palantir.consistent-versions'
             apply plugin: 'com.palantir.shadow-jar'
-            
-            repositories {
-                jcenter()
-            }
-            
-            dependencies {
-                implementation 'one.util:streamex:0.7.3'
-            }
 
             recommendedProductDependencies {
                 productDependency {
@@ -140,11 +132,10 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         '''.stripIndent()
 
         when:
-        runTasksSuccessfully('--write-locks', 'jar', 'shadowJar')
+        runTasksSuccessfully('--write-locks', 'shadowJar')
 
         then:
         verifyCorrectRecommendedProductDeps('build/libs/root-project.jar')
-        verifyCorrectRecommendedProductDeps('build/libs/root-project-thin.jar')
     }
 
     def verifyCorrectRecommendedProductDeps(String jarFilePath) {

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -58,7 +58,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2020.9-b411"
+def yourkitVersion = "2020.9-b412"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {
@@ -71,7 +71,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum '03e65eedf7bd42567b38dd48a57b801ea5b8a13e8de318eb4d5435f6c9fbed7d'
+    checksum '15cb894251ca514847d26a45f13837aac450b6d60335c60d9ae48f10448362e4'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {


### PR DESCRIPTION
## Before this PR
Add `recommendProductDependencies` to all jars, not just to the `jar` task. This then should handle the case where we have a `shadowJar` from the shadow plugin.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Recommended product dependencies are added to the manifests of all jar tasks in the projects where `com.palantir.recommended-product-dependencies` is applied. This means `shadowJar` from the gradle shadow plugin now picks up recommended product dependencies.
==COMMIT_MSG==

## Possible downsides?
Maybe we add the pdeps to too many jars? Doesn't seem like too bad a downside.

