### PR TITLE
tolerate extra json keys in diagnostics manifest

### DIFF
--- a/changelog/@unreleased/pr-1054.v2.yml
+++ b/changelog/@unreleased/pr-1054.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: When parsing the `sls-manifest/diagnostics.json` file out of jars,
+    sls-packaging no longer performs strict validation on its structure (as this can
+    prevent the rollout of jars which include extra fields). Instead it just passes
+    everything on as long as it's a JSON object.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1054

--- a/gradle-sls-packaging/build.gradle
+++ b/gradle-sls-packaging/build.gradle
@@ -58,7 +58,7 @@ pluginBundle {
     }
 }
 
-def yourkitVersion = "2020.9-b411"
+def yourkitVersion = "2020.9-b412"
 def yourkitFilename = "YourKit-JavaProfiler-${yourkitVersion}"
 
 task downloadYourkitDist(type: Download) {
@@ -71,7 +71,7 @@ task downloadYourkitDist(type: Download) {
 task verifyYourkitDist(type: Verify, dependsOn: downloadYourkitDist) {
     src file("${buildDir}/${yourkitFilename}.zip")
     algorithm 'SHA-256'
-    checksum '03e65eedf7bd42567b38dd48a57b801ea5b8a13e8de318eb4d5435f6c9fbed7d'
+    checksum '15cb894251ca514847d26a45f13837aac450b6d60335c60d9ae48f10448362e4'
 }
 
 task extractYourkitAgent(type: Copy, dependsOn: verifyYourkitDist) {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/Diagnostics.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/Diagnostics.java
@@ -16,110 +16,40 @@
 
 package com.palantir.gradle.dist.service;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.palantir.gradle.dist.tasks.CreateManifestTask;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
-import java.util.regex.Pattern;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
-import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class Diagnostics {
     private static final Logger log = LoggerFactory.getLogger(Diagnostics.class);
+    private static final String EXAMPLE =
+            "[{\"type\":\"foo.v1\", \"docs\":\"...\"}, \"{\"type\":\"bar.v1\", " + "\"docs\":\"...\"}]";
 
-    // This is the format the sls-spec wants list items to be. <code>{ type: "foo.v1", docs: "Lorem ipsum" }</code>.
-    @Value.Immutable
-    @JsonDeserialize(as = ImmutableSupportedDiagnostic.class)
-    public interface SupportedDiagnostic extends Serializable {
-        String EXAMPLE = "[{\"type\":\"foo.v1\", \"docs\":\"...\"}, \"{\"type\":\"bar.v1\", \"docs\":\"...\"}]";
-
-        DiagnosticType type();
-
-        String docs();
-    }
-
-    public static List<SupportedDiagnostic> parse(Project proj, File file) {
+    public static List<ObjectNode> parse(Project proj, File file) {
         Path relativePath = proj.getRootDir().toPath().relativize(file.toPath());
         String string = null;
         try {
             string = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8).trim();
-            List<SupportedDiagnostic> value =
-                    CreateManifestTask.jsonMapper.readValue(string, new TypeReference<List<SupportedDiagnostic>>() {});
+            List<ObjectNode> value =
+                    CreateManifestTask.jsonMapper.readValue(string, new TypeReference<List<ObjectNode>>() {});
             log.info("Deserialized '{}': '{}'", relativePath, value);
             return value;
         } catch (IOException e) {
             throw new GradleException(
                     String.format(
                             "Failed to deserialize '%s', expecting something like '%s' but was '%s'",
-                            relativePath, SupportedDiagnostic.EXAMPLE, string),
+                            relativePath, EXAMPLE, string),
                     e);
-        }
-    }
-
-    /**
-     * A {@link DiagnosticType} is an identifier that uniquely identifies the operation and output format for the
-     * diagnostics. Type names must be specific, reasonably expected to be unique, and versioned to allow for future
-     * major changes of the payload structure. DiagnosticTypes must match the regular expression
-     * {@code ([a-z0-9]+\.)+v[0-9]+}, i.e. be lower-case, dot-delimited, and end with a version suffix. For example, the
-     * {@code threaddump.v1} diagnosticType  might indicate a value of ThreadDumpV1 from the DiagnosticLogV1 definition.
-     */
-    public static final class DiagnosticType implements Serializable {
-        private static final Pattern TYPE_PATTERN = Pattern.compile("([a-z0-9]+\\.)+v[0-9]+");
-
-        private final String diagnosticTypeString;
-
-        @JsonCreator
-        public static DiagnosticType of(String diagnosticTypeString) {
-            Preconditions.checkNotNull(diagnosticTypeString, "Diagnostic type string is required");
-            if (!TYPE_PATTERN.matcher(diagnosticTypeString).matches()) {
-                throw new SafeIllegalArgumentException(
-                        "Diagnostic types must match pattern",
-                        SafeArg.of("diagnosticType", diagnosticTypeString),
-                        SafeArg.of("pattern", TYPE_PATTERN.pattern()));
-            }
-            return new DiagnosticType(diagnosticTypeString);
-        }
-
-        private DiagnosticType(String diagnosticTypeString) {
-            this.diagnosticTypeString = diagnosticTypeString;
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return diagnosticTypeString;
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            if (this == other) {
-                return true;
-            }
-            if (other == null || getClass() != other.getClass()) {
-                return false;
-            }
-            DiagnosticType that = (DiagnosticType) other;
-            return Objects.equals(diagnosticTypeString, that.diagnosticTypeString);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(diagnosticTypeString);
         }
     }
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/MergeDiagnosticsJsonTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/MergeDiagnosticsJsonTask.java
@@ -16,7 +16,7 @@
 
 package com.palantir.gradle.dist.service;
 
-import com.palantir.gradle.dist.service.Diagnostics.SupportedDiagnostic;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.palantir.gradle.dist.tasks.CreateManifestTask;
 import java.io.File;
 import java.io.IOException;
@@ -46,10 +46,10 @@ public abstract class MergeDiagnosticsJsonTask extends DefaultTask {
 
     @TaskAction
     public final void taskAction() {
-        List<SupportedDiagnostic> aggregated = getClasspath().getFiles().stream()
+        List<ObjectNode> aggregated = getClasspath().getFiles().stream()
                 .flatMap(file -> Diagnostics.parse(getProject(), file).stream())
                 .distinct()
-                .sorted(Comparator.comparing(v -> v.type().toString()))
+                .sorted(Comparator.comparing(node -> node.get("type").asText()))
                 .collect(Collectors.toList());
 
         File out = getOutputJsonFile().getAsFile().get();

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
@@ -52,7 +52,8 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
           implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
         }
         """.stripIndent()
-        addResource("src/main/resources/sls-manifest", "diagnostics.json", '[{"type": "foo.v1", "docs" : "This does something"}]')
+        addResource("src/main/resources/sls-manifest", "diagnostics.json",
+                '[{"type": "foo.v1", "docs" : "This does something", "safe" : false}]')
 
         when:
         runTasksSuccessfully("mergeDiagnosticsJson", '-is')
@@ -62,7 +63,8 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
         outFile.text == """\
         [ {
           "type" : "foo.v1",
-          "docs" : "This does something"
+          "docs" : "This does something",
+          "safe" : false
         } ]""".stripIndent()
 
         when:
@@ -97,13 +99,16 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
             implementation project(':my-project2')
         }
         ''')
-        addResource("my-server/src/main/resources/sls-manifest", "diagnostics.json", '[{"type": "foo.v1", "docs" : "This does something"}]')
+        addResource("my-server/src/main/resources/sls-manifest", "diagnostics.json",
+                '[{"type": "foo.v1", "docs" : "This does something"}]')
 
         addSubproject('my-project1')
-        addResource("my-project1/src/main/resources/sls-manifest", "diagnostics.json", '[{"type": "myproject1.v1", "docs" : "Who knows what this does"}]')
+        addResource("my-project1/src/main/resources/sls-manifest", "diagnostics.json",
+                '[{"type": "myproject1.v1", "docs" : "Who knows what this does"}]')
 
         addSubproject('my-project2')
-        addResource("my-project2/src/main/resources/sls-manifest", "diagnostics.json", '[{"type": "myproject2.v1", "docs" : "Click me if you dare!"}]')
+        addResource("my-project2/src/main/resources/sls-manifest", "diagnostics.json",
+                '[{"type": "myproject2.v1", "docs" : "Click me if you dare!"}]')
 
         when:
         def output = runTasksSuccessfully("my-server:mergeDiagnosticsJson", '-is')


### PR DESCRIPTION
## Before this PR
@carterkozak has a PR on WC internally to add this `safe : true` field.  We realised it's actually pretty lame to have a coupling between WC and sls-packaging, so this PR removes the validation that would block this stuff.

## After this PR
==COMMIT_MSG==
When parsing the `sls-manifest/diagnostics.json` file out of jars, sls-packaging no longer performs strict validation on its structure (as this can prevent the rollout of jars which include extra fields). Instead it just passes everything on as long as it's a JSON object.
==COMMIT_MSG==

## Possible downsides?
- in theory one jar could possibly include a non-sensical diagnostics.json which would be merged into the single output file, potentially 'poisoning' the ability of downstream stuff to deserialize the whole thing.

