### PR TITLE
improvement: Recommended product dependencies doesn't require Java

### DIFF
--- a/changelog/@unreleased/pr-1058.v2.yml
+++ b/changelog/@unreleased/pr-1058.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Recommended product dependencies doesn't require Java
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1058

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
@@ -26,18 +26,22 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
 
     @Override
     public final void apply(Project project) {
-        project.getPlugins().apply("java");
         final RecommendedProductDependenciesExtension ext = project.getExtensions()
                 .create("recommendedProductDependencies", RecommendedProductDependenciesExtension.class, project);
 
-        TaskProvider<?> configureProductDependenciesTask = project.getTasks()
-                .register("configureProductDependencies", ConfigureProductDependenciesTask.class, cmt -> {
-                    cmt.setProductDependencies(ext.getRecommendedProductDependenciesProvider());
-                });
+        project.getPluginManager().withPlugin("java", _plugin -> {
+            TaskProvider<?> configureProductDependenciesTask = project.getTasks()
+                    .register("configureProductDependencies", ConfigureProductDependenciesTask.class, cmt -> {
+                        cmt.setProductDependencies(ext.getRecommendedProductDependenciesProvider());
+                    });
 
-        // Ensure that the jar task depends on this wiring task
-        project.getTasks().withType(Jar.class).named(JavaPlugin.JAR_TASK_NAME).configure(jar -> {
-            jar.dependsOn(configureProductDependenciesTask);
+            // Ensure that the jar task depends on this wiring task
+            project.getTasks()
+                    .withType(Jar.class)
+                    .named(JavaPlugin.JAR_TASK_NAME)
+                    .configure(jar -> {
+                        jar.dependsOn(configureProductDependenciesTask);
+                    });
         });
     }
 }

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
@@ -26,11 +26,11 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
 
     @Override
     public final void apply(Project project) {
-        final RecommendedProductDependenciesExtension ext = project.getExtensions()
+        RecommendedProductDependenciesExtension ext = project.getExtensions()
                 .create("recommendedProductDependencies", RecommendedProductDependenciesExtension.class, project);
 
         project.getPluginManager().withPlugin("java", _plugin -> {
-            TaskProvider<?> configureProductDependenciesTask = project.getTasks()
+            TaskProvider<ConfigureProductDependenciesTask> configureProductDependenciesTask = project.getTasks()
                     .register("configureProductDependencies", ConfigureProductDependenciesTask.class, cmt -> {
                         cmt.setProductDependencies(ext.getRecommendedProductDependenciesProvider());
                     });

--- a/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
+++ b/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
@@ -32,6 +32,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         rootProject.name = "root-project"
         """.stripIndent()
         buildFile << """
+            apply plugin: 'java'
             apply plugin: 'com.palantir.recommended-product-dependencies'
 
             recommendedProductDependencies {


### PR DESCRIPTION
## Before this PR
Recommended product dependencies forced Java to be applied to the project

## After this PR
==COMMIT_MSG==
Recommended product dependencies doesn't require Java
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

