### PR TITLE
Fix: Expose provider on RecommendedProductDependenciesExtension

### DIFF
--- a/changelog/@unreleased/pr-1059.v2.yml
+++ b/changelog/@unreleased/pr-1059.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Expose provider on RecommendedProductDependenciesExtension
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1059

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesExtension.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesExtension.java
@@ -47,10 +47,16 @@ public class RecommendedProductDependenciesExtension {
         }));
     }
 
-    final Provider<Set<ProductDependency>> getRecommendedProductDependenciesProvider() {
+    public final Provider<Set<ProductDependency>> getRecommendedProductDependenciesProvider() {
         return recommendedProductDependencies;
     }
 
+    /**
+     * The product dependencies of this project.
+     *
+     * @deprecated Use {@link #getRecommendedProductDependenciesProvider()} instead.
+     */
+    @Deprecated
     public final Set<ProductDependency> getRecommendedProductDependencies() {
         return recommendedProductDependencies.get();
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expose provider on RecommendedProductDependenciesExtension
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

