### PR TITLE
Add support for optional dependencies

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -7,3 +7,9 @@ acceptedBreaks:
       new: "method org.gradle.api.provider.SetProperty<com.palantir.gradle.dist.ProductDependency>\
         \ com.palantir.gradle.dist.RecommendedProductDependenciesExtension::getRecommendedProductDependenciesProvider()"
       justification: "not really a break"
+  "4.26.0":
+    com.palantir.sls-packaging:gradle-recommended-product-dependencies:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class com.palantir.gradle.dist.ProductDependency"
+      new: "class com.palantir.gradle.dist.ProductDependency"
+      justification: "Old class is semantically equivalent to optional=false"

--- a/changelog/@unreleased/pr-1074.v2.yml
+++ b/changelog/@unreleased/pr-1074.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: |-
+    Support `optional` field in the `ProductDependency` class.
+    It also allows discovered dependencies to be set optional through the `optionalProductDependency` declaration in the manifest.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1074

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
@@ -45,6 +45,9 @@ public final class ProductDependency implements Serializable {
     @JsonProperty("maximum-version")
     private String maximumVersion;
 
+    @JsonProperty("optional")
+    private boolean optional = false;
+
     public ProductDependency() {}
 
     public ProductDependency(
@@ -192,6 +195,14 @@ public final class ProductDependency implements Serializable {
 
     public void setMaximumVersion(String maximumVersion) {
         this.maximumVersion = maximumVersion;
+    }
+
+    public boolean getOptional() {
+        return optional;
+    }
+
+    public void setOptional(boolean optional) {
+        this.optional = optional;
     }
 
     @Override

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
@@ -164,8 +164,13 @@ public final class ProductDependency implements Serializable {
     @Override
     public String toString() {
         return String.format(
-                "%s:%s(min: %s, recommended: %s, max: %s)",
-                productGroup, productName, minimumVersion, recommendedVersion, maximumVersion);
+                "%s:%s(min: %s, recommended: %s, max: %s)%s",
+                productGroup,
+                productName,
+                minimumVersion,
+                recommendedVersion,
+                maximumVersion,
+                optional ? " optional" : "");
     }
 
     public String getProductGroup() {
@@ -229,11 +234,12 @@ public final class ProductDependency implements Serializable {
                 && productName.equals(that.productName)
                 && minimumVersion.equals(that.minimumVersion)
                 && Objects.equals(recommendedVersion, that.recommendedVersion)
-                && maximumVersion.equals(that.maximumVersion);
+                && maximumVersion.equals(that.maximumVersion)
+                && optional == that.optional;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(productGroup, productName, minimumVersion, recommendedVersion, maximumVersion);
+        return Objects.hash(productGroup, productName, minimumVersion, recommendedVersion, maximumVersion, optional);
     }
 }

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
@@ -55,13 +55,24 @@ public final class ProductDependency implements Serializable {
             String productName,
             String minimumVersion,
             String maximumVersion,
-            String recommendedVersion) {
+            String recommendedVersion,
+            boolean optional) {
         this.productGroup = productGroup;
         this.productName = productName;
         this.minimumVersion = minimumVersion;
         this.maximumVersion = maximumVersion;
         this.recommendedVersion = recommendedVersion;
+        this.optional = optional;
         isValid();
+    }
+
+    public ProductDependency(
+            String productGroup,
+            String productName,
+            String minimumVersion,
+            String maximumVersion,
+            String recommendedVersion) {
+        this(productGroup, productName, minimumVersion, maximumVersion, recommendedVersion, false);
     }
 
     /**

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesExtension.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesExtension.java
@@ -41,6 +41,12 @@ public class RecommendedProductDependenciesExtension {
         recommendedProductDependencies.add(providerFactory.provider(() -> {
             ProductDependency dep = new ProductDependency();
             ConfigureUtil.configureUsing(closure).execute(dep);
+            if (dep.getOptional()) {
+                throw new IllegalArgumentException(String.format(
+                        "Optional dependencies are not supported for recommended product "
+                                + "dependencies. Please remove optional for dependency %s",
+                        dep));
+            }
             dep.isValid();
             return dep;
         }));

--- a/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
+++ b/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.dist
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.Iterables
 import java.util.jar.Manifest
@@ -104,6 +103,30 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         dep.productName == "name"
         dep.minimumVersion == "1.0.0"
         dep.maximumVersion == "1.x.x"
+    }
+
+    def 'does not allow you to add an optional dependency'() {
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.recommended-product-dependencies'
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'group'
+                    productName = 'name'
+                    minimumVersion = '1.0.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = '1.2.3'
+                    optional = true
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def executionResult = runTasksWithFailure(':jar')
+
+        then:
+        executionResult.failure.cause.cause.message.contains 'Optional dependencies are not supported'
     }
 
     def readRecommendedProductDeps(File jarFile) {

--- a/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
+++ b/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
@@ -17,6 +17,7 @@
 package com.palantir.gradle.dist
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.base.Throwables
 import com.google.common.collect.Iterables
 import java.util.jar.Manifest
 import java.util.zip.ZipFile
@@ -126,7 +127,8 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         def executionResult = runTasksWithFailure(':jar')
 
         then:
-        executionResult.failure.cause.cause.message.contains 'Optional dependencies are not supported'
+        def rootCause = Throwables.getRootCause(executionResult.failure)
+        rootCause.message.contains 'Optional dependencies are not supported'
     }
 
     def readRecommendedProductDeps(File jarFile) {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -53,6 +53,7 @@ public class BaseDistributionExtension {
     private final Property<String> podName;
     private final Property<ProductType> productType;
     private final ListProperty<ProductDependency> productDependencies;
+    private final SetProperty<ProductId> optionalProductDependencies;
     private final SetProperty<ProductId> ignoredProductDependencies;
     private final ProviderFactory providerFactory;
     private final MapProperty<String, Object> manifestExtensions;
@@ -67,6 +68,7 @@ public class BaseDistributionExtension {
         podName = project.getObjects().property(String.class);
         productType = project.getObjects().property(ProductType.class);
         productDependencies = project.getObjects().listProperty(ProductDependency.class);
+        optionalProductDependencies = project.getObjects().setProperty(ProductId.class);
         ignoredProductDependencies = project.getObjects().setProperty(ProductId.class);
 
         serviceGroup.set(project.provider(() -> project.getGroup().toString()));
@@ -206,6 +208,18 @@ public class BaseDistributionExtension {
             }
             return dep;
         }));
+    }
+
+    public final Provider<Set<ProductId>> getOptionalProductDependencies() {
+        return optionalProductDependencies;
+    }
+
+    public final void optionalProductDependency(String productGroup, String productName) {
+        this.optionalProductDependencies.add(new ProductId(productGroup, productName));
+    }
+
+    public final void optionalProductDependency(String ignoredProductId) {
+        this.optionalProductDependencies.add(new ProductId(ignoredProductId));
     }
 
     public final Provider<Set<ProductId>> getIgnoredProductDependencies() {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -218,8 +218,8 @@ public class BaseDistributionExtension {
         this.optionalProductDependencies.add(new ProductId(productGroup, productName));
     }
 
-    public final void optionalProductDependency(String ignoredProductId) {
-        this.optionalProductDependencies.add(new ProductId(ignoredProductId));
+    public final void optionalProductDependency(String optionalProductId) {
+        this.optionalProductDependencies.add(new ProductId(optionalProductId));
     }
 
     public final Provider<Set<ProductId>> getIgnoredProductDependencies() {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -98,6 +98,8 @@ public class CreateManifestTask extends DefaultTask {
 
     private final ListProperty<ProductDependency> productDependencies =
             getProject().getObjects().listProperty(ProductDependency.class);
+    private final SetProperty<ProductId> optionalProductIds =
+            getProject().getObjects().setProperty(ProductId.class);
     private final SetProperty<ProductId> ignoredProductIds =
             getProject().getObjects().setProperty(ProductId.class);
     private final Property<Configuration> productDependenciesConfig =
@@ -168,6 +170,11 @@ public class CreateManifestTask extends DefaultTask {
     }
 
     @Input
+    final SetProperty<ProductId> getOptionalProductIds() {
+        return optionalProductIds;
+    }
+
+    @Input
     final SetProperty<ProductId> getIgnoredProductIds() {
         return ignoredProductIds;
     }
@@ -227,6 +234,12 @@ public class CreateManifestTask extends DefaultTask {
                                 + "dependency or ignore",
                         productId));
             }
+            if (getOptionalProductIds().get().contains(productId)) {
+                throw new IllegalArgumentException(String.format(
+                        "Encountered product dependency declaration that was also declared as optional for '%s', "
+                                + "either remove the dependency or optional declaration",
+                        productId));
+            }
             allProductDependencies.merge(
                     productId, declaredDep, (dep1, dep2) -> mergeDependencies(productId, dep1, dep2));
         });
@@ -250,6 +263,10 @@ public class CreateManifestTask extends DefaultTask {
                                     productId,
                                     discoveredDependency,
                                     declaredDependency);
+                }
+                if (getOptionalProductIds().get().contains(productId)) {
+                    log.trace("Product dependency for '{}' set as optional", productId);
+                    mergedDependency.setOptional(true);
                 }
                 return mergedDependency;
             });
@@ -493,6 +510,7 @@ public class CreateManifestTask extends DefaultTask {
                     task.setManifestFile(new File(project.getBuildDir(), "/deployment/manifest.yml"));
                     task.getProductDependencies().set(ext.getAllProductDependencies());
                     task.setConfiguration(project.provider(ext::getProductDependenciesConfig));
+                    task.getOptionalProductIds().set(ext.getOptionalProductDependencies());
                     task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
                     task.getManifestExtensions().set(ext.getManifestExtensions());
                     task.getInRepoProductIds()

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -462,7 +462,8 @@ public class CreateManifestTask extends DefaultTask {
                                         recommendedDep.getProductName(),
                                         recommendedDep.getMinimumVersion(),
                                         recommendedDep.getMaximumVersion(),
-                                        recommendedDep.getRecommendedVersion()));
+                                        recommendedDep.getRecommendedVersion(),
+                                        recommendedDep.getOptional()));
                     } catch (IOException | IllegalArgumentException e) {
                         log.debug(
                                 "Failed to load product dependency for artifact '{}', file '{}', '{}'",

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -269,10 +269,6 @@ public class CreateManifestTask extends DefaultTask {
                                     discoveredDependency,
                                     declaredDependency);
                 }
-                if (getOptionalProductIds().get().contains(productId)) {
-                    log.trace("Product dependency for '{}' set as optional", productId);
-                    mergedDependency.setOptional(true);
-                }
                 return mergedDependency;
             });
         });

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -212,6 +212,7 @@ public class CreateManifestTask extends DefaultTask {
         this.manifestFile = manifestFile;
     }
 
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     @TaskAction
     final void createManifest() throws IOException {
         validateProjectVersion();
@@ -249,6 +250,10 @@ public class CreateManifestTask extends DefaultTask {
             if (getIgnoredProductIds().get().contains(productId)) {
                 log.trace("Ignored product dependency for '{}'", productId);
                 return;
+            }
+            if (getOptionalProductIds().get().contains(productId)) {
+                log.trace("Product dependency for '{}' set as optional", productId);
+                discoveredDependency.setOptional(true);
             }
             allProductDependencies.merge(productId, discoveredDependency, (declaredDependency, _newDependency) -> {
                 ProductDependency mergedDependency =

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -25,13 +25,13 @@ class ProductDependencyLockFileTest extends Specification {
         when:
         List<ProductDependency> sample = [
                 new ProductDependency("com.palantir.product", "foo", "1.20.0", "1.x.x", null),
-                new ProductDependency("com.palantir.other", "bar", "0.2.0", "0.x.x", null)
+                new ProductDependency("com.palantir.other", "bar", "0.2.0", "0.x.x", null, true)
         ]
 
         then:
         ProductDependencyLockFile.asString(sample, [] as Set<ProductId>, '0.0.0') == """\
         # Run ./gradlew --write-locks to regenerate this file
-        com.palantir.other:bar (0.2.0, 0.x.x)
+        com.palantir.other:bar (0.2.0, 0.x.x) optional
         com.palantir.product:foo (1.20.0, 1.x.x)
         """.stripIndent()
     }
@@ -54,13 +54,13 @@ class ProductDependencyLockFileTest extends Specification {
         List<ProductDependency> result = ProductDependencyLockFile.fromString("""\
         # Run ./gradlew --write-locks to regenerate this file
         com.palantir.other:bar (0.2.0, 0.x.x)
-        com.palantir.product:foo (1.20.0, 1.x.x)
+        com.palantir.product:foo (1.20.0, 1.x.x) optional
         """.stripIndent(), "0.0.0")
 
         then:
         result.size() == 2
         result[0] == new ProductDependency("com.palantir.other", "bar", "0.2.0", "0.x.x", null)
-        result[1] == new ProductDependency("com.palantir.product", "foo", "1.20.0", "1.x.x", null)
+        result[1] == new ProductDependency("com.palantir.product", "foo", "1.20.0", "1.x.x", null, true)
     }
 
     def 'round-trips without recommended version'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -203,15 +203,17 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                         "product-group"      : "group",
                         "product-name"       : "name",
                         "minimum-version"    : "1.0.0",
+                        "recommended-version": "1.2.0",
                         "maximum-version"    : "1.x.x",
-                        "recommended-version": "1.2.0"
+                        "optional"           : false
                 ],
                 [
                         "product-group"      : "group",
                         "product-name"       : "name2",
                         "minimum-version"    : "2.0.0",
+                        "recommended-version": "2.2.0",
                         "maximum-version"    : "2.x.x",
-                        "recommended-version": "2.2.0"
+                        "optional"           : false
                 ]
         ]
     }
@@ -247,15 +249,18 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                         "product-group"      : "group",
                         "product-name"       : "name",
                         "minimum-version"    : "1.1.0",
+                        "recommended-version": "1.2.0",
                         "maximum-version"    : "1.x.x",
-                        "recommended-version": "1.2.0"
+                        "optional"           : false
+
                 ],
                 [
                         "product-group"      : "group",
                         "product-name"       : "name2",
                         "minimum-version"    : "2.0.0",
+                        "recommended-version": "2.2.0",
                         "maximum-version"    : "2.x.x",
-                        "recommended-version": "2.2.0"
+                        "optional"           : false
                 ]
         ]
     }
@@ -309,8 +314,9 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                         "product-group"      : "group",
                         "product-name"       : "name2",
                         "minimum-version"    : "2.0.0",
+                        "recommended-version": "2.2.0",
                         "maximum-version"    : "2.x.x",
-                        "recommended-version": "2.2.0"
+                        "optional"           : false
                 ]
         ]
     }
@@ -338,8 +344,9 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                         "product-group"      : "group",
                         "product-name"       : "name2",
                         "minimum-version"    : "2.1.0",
+                        "recommended-version": "2.2.0",
                         "maximum-version"    : "2.6.x",
-                        "recommended-version": "2.2.0"
+                        "optional"           : false
                 ]
         ]
     }
@@ -663,6 +670,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                         "minimum-version"    : "0.0.0",
                         "recommended-version": "1.0.0",
                         "maximum-version"    : "1.x.x",
+                        "optional"           :  false
                 ],
         ]
     }
@@ -725,6 +733,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                         "minimum-version"    : "0.0.0",
                         "recommended-version": "1.0.0",
                         "maximum-version"    : "1.x.x",
+                        "optional"           : false
                 ],
         ]
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -326,8 +326,8 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
         """.stripIndent()
         file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
-        group:name (1.0.0, 1.x.x)
-        group:name2 (2.0.0, 2.x.x)
+        group:name (1.0.0, 1.x.x) optional
+        group:name2 (2.0.0, 2.x.x) optional
         """.stripIndent()
 
         when:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support `optional` field in the `ProductDependency` class.
It also allows discovered dependencies to be set optional through the `optionalProductDependency` declaration in the manifest.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

