### PR TITLE
correctly merge optional and non-optional dependencies

### DIFF
--- a/changelog/@unreleased/pr-1078.v2.yml
+++ b/changelog/@unreleased/pr-1078.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: If a dependency is discovered (non-optional) but declared explicitly as optional, it will be recognized as `optional`.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1078

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyMerger.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyMerger.java
@@ -82,12 +82,18 @@ public final class ProductDependencyMerger {
                 .filter(version -> satisfiesMaxVersion(maximumVersion, version))
                 .max(VersionComparator.INSTANCE);
 
+        // Since recommended--and thus, discovered--product dependencies cannot be optional, if we are merging
+        // optional and non-optional dependencies, then the one with `optional = true` must be an explicit product
+        // dependency and should always take precedence.
+        boolean optional = dep1.getOptional() || dep2.getOptional();
+
         ProductDependency result = new ProductDependency();
         result.setMinimumVersion(minimumVersion.toString());
         result.setMaximumVersion(maximumVersion.toString());
         recommendedVersion.map(Objects::toString).ifPresent(result::setRecommendedVersion);
         result.setProductGroup(dep1.getProductGroup());
         result.setProductName(dep1.getProductName());
+        result.setOptional(optional);
         result.isValid();
         return result;
     }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyMerger.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyMerger.java
@@ -82,10 +82,8 @@ public final class ProductDependencyMerger {
                 .filter(version -> satisfiesMaxVersion(maximumVersion, version))
                 .max(VersionComparator.INSTANCE);
 
-        // Since recommended--and thus, discovered--product dependencies cannot be optional, if we are merging
-        // optional and non-optional dependencies, then the one with `optional = true` must be an explicit product
-        // dependency and should always take precedence.
-        boolean optional = dep1.getOptional() || dep2.getOptional();
+        // Optional iff both inputs are optional; otherwise, we want to conservatively propagate the strict requirement.
+        boolean optional = dep1.getOptional() && dep2.getOptional();
 
         ProductDependency result = new ProductDependency();
         result.setMinimumVersion(minimumVersion.toString());

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -45,6 +45,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -222,6 +223,8 @@ public class CreateManifestTask extends DefaultTask {
         }
 
         Map<ProductId, ProductDependency> allProductDependencies = new HashMap<>();
+        Set<ProductId> allOptionalDependencies =
+                new HashSet<>(getOptionalProductIds().get());
         getProductDependencies().get().forEach(declaredDep -> {
             ProductId productId = new ProductId(declaredDep.getProductGroup(), declaredDep.getProductName());
             Preconditions.checkArgument(
@@ -243,6 +246,10 @@ public class CreateManifestTask extends DefaultTask {
             }
             allProductDependencies.merge(
                     productId, declaredDep, (dep1, dep2) -> mergeDependencies(productId, dep1, dep2));
+            if (declaredDep.getOptional()) {
+                log.trace("Product dependency for '{}' declared as optional", productId);
+                allOptionalDependencies.add(productId);
+            }
         });
 
         // Merge all discovered and declared product dependencies
@@ -269,10 +276,9 @@ public class CreateManifestTask extends DefaultTask {
             });
         });
 
-        // Ensure explicitly optional product dependencies are marked as such.
-        getOptionalProductIds()
-                .get()
-                .forEach(productId -> allProductDependencies.computeIfPresent(productId, (_productId, existingDep) -> {
+        // Ensure optional product dependencies are marked as such.
+        allOptionalDependencies.forEach(
+                productId -> allProductDependencies.computeIfPresent(productId, (_productId, existingDep) -> {
                     log.trace("Product dependency for '{}' set as optional", productId);
                     existingDep.setOptional(true);
                     return existingDep;

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyMergerTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyMergerTest.groovy
@@ -67,9 +67,11 @@ class ProductDependencyMergerTest extends Specification {
 
         when:
         def merged = ProductDependencyMerger.merge(dep1, dep2)
+        def merged2 = ProductDependencyMerger.merge(dep2, dep2)
 
         then:
-        merged.optional
+        !merged.optional
+        merged2.optional
     }
 
     private ProductDependency newRecommendation(String min, String max, String recommended = null) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyMergerTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyMergerTest.groovy
@@ -60,7 +60,20 @@ class ProductDependencyMergerTest extends Specification {
         e.message.contains("minimumVersion and maximumVersion must be different")
     }
 
+    def "merges optional and non-optional"() {
+        given:
+        def dep1 = newRecommendation("2.0.0", "2.x.x")
+        def dep2 = new ProductDependency("group", "name", "2.0.0", "2.x.x", null, true)
+
+        when:
+        def merged = ProductDependencyMerger.merge(dep1, dep2)
+
+        then:
+        merged.optional
+    }
+
     private ProductDependency newRecommendation(String min, String max, String recommended = null) {
         return new ProductDependency("group", "name", min, max, recommended)
     }
+
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyMergerTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyMergerTest.groovy
@@ -75,5 +75,4 @@ class ProductDependencyMergerTest extends Specification {
     private ProductDependency newRecommendation(String min, String max, String recommended = null) {
         return new ProductDependency("group", "name", min, max, recommended)
     }
-
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -271,7 +271,7 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
                         "minimum-version"    : "1.1.0",
                         "recommended-version": "1.2.0",
                         "maximum-version"    : "1.x.x",
-                        "optional"           : false
+                        "optional"           : true
 
                 ],
                 [

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -247,13 +247,13 @@ class CreateManifestTaskIntegrationSpec extends GradleIntegrationSpec {
             
             createManifest {
                 productDependencies = [
-                    new com.palantir.gradle.dist.ProductDependency("group", "name", "1.1.0", "1.x.x", "1.2.0"), 
+                    new com.palantir.gradle.dist.ProductDependency("group", "name", "1.1.0", "1.x.x", "1.2.0", true), 
                 ]
             }
         """.stripIndent()
         file('product-dependencies.lock').text = """\
         # Run ./gradlew --write-locks to regenerate this file
-        group:name (1.1.0, 1.x.x)
+        group:name (1.1.0, 1.x.x) optional
         group:name2 (2.0.0, 2.x.x)
         """.stripIndent()
 


### PR DESCRIPTION
## Before this PR
If a dependency is discovered (non-optional) but declared explicitly as optional, the resulting merged dependency will always be non-optional, since the merge logic ignored the value of the `optional` field (and the default is `false`).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
If a dependency is discovered (non-optional) but created explicitly as optional, it will correctly be categorized as `optional`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

