### PR TITLE
The new `javaAgent` configuration is no longer non-transitive

### DIFF
--- a/changelog/@unreleased/pr-1084.v2.yml
+++ b/changelog/@unreleased/pr-1084.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: The new `javaAgent` configuration is no longer non-transitive
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1084

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -92,16 +92,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         });
 
         Configuration runtimeClasspath = project.getConfigurations().getByName("runtimeClasspath");
-        Configuration javaAgentConfiguration = project.getConfigurations()
-                .create("javaAgent", new Action<Configuration>() {
-                    @Override
-                    public void execute(Configuration javaAgent) {
-                        // Each javaAgent is applied via a '-javaagent:path/to/agent.jar' argument
-                        // Agents should have no dependencies, but this allows us to avoid adding
-                        // non-agent jars as agents if any are listed.
-                        javaAgent.setTransitive(false);
-                    }
-                });
+        Configuration javaAgentConfiguration = project.getConfigurations().create("javaAgent");
 
         // Set default configuration to look for product dependencies to be runtimeClasspath
         distributionExtension.setProductDependenciesConfig(runtimeClasspath);


### PR DESCRIPTION
This works around a GCV bug which fails to apply constraints to
non-transitive configurations.
See https://github.com/palantir/gradle-consistent-versions/issues/677

==COMMIT_MSG==
The new `javaAgent` configuration is no longer non-transitive
==COMMIT_MSG==

## Possible downsides?
Agents shouldn't ever have dependencies, however it's somewhat fragile to rely on that being the case. We may end up with more `-javaagent:<path/to/*.jar>` lines args than we want, preventing the JVM from starting. I've added validation to prevent this scenario from shipping.
