### PR TITLE
bump go-java-launcher to 1.11.0 (was 1.10.0)

### DIFF
--- a/changelog/@unreleased/pr-1086.v2.yml
+++ b/changelog/@unreleased/pr-1086.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: bump go-java-launcher to 1.11.0 (was 1.10.0)
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1086

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -56,8 +56,8 @@ import org.gradle.util.GFileUtils;
 import org.gradle.util.GradleVersion;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.10.0";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.10.0";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.11.0";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.11.0";
     public static final String GROUP_NAME = "Distribution";
 
     @Override


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
go-java-launcher is not the latest version

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
bump go-java-launcher to 1.11.0 (was 1.10.0)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
none
