### PR TITLE
Improvement: Add workaround to JDK-8253566 for java 15 runtimes

### DIFF
--- a/changelog/@unreleased/pr-1095.v2.yml
+++ b/changelog/@unreleased/pr-1095.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add workaround for JDK-8253566 by default when target runtime is java 15
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1095

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -57,6 +57,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
             "-Xloggc:var/log/gc-%t-%p.log",
             "-verbose:gc");
     private static List<String> java14Options = ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
+    private static List<String> java15Options =
+            ImmutableList.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+ExpandSubTypeCheckAtParseTime");
 
     private static final List<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
@@ -176,6 +178,10 @@ public abstract class LaunchConfigTask extends DefaultTask {
                         .addAllJvmOpts(
                                 javaVersion.get().compareTo(JavaVersion.toVersion("14")) >= 0
                                         ? java14Options
+                                        : ImmutableList.of())
+                        .addAllJvmOpts(
+                                javaVersion.get().compareTo(JavaVersion.toVersion("15")) == 0
+                                        ? java15Options
                                         : ImmutableList.of())
                         .addAllJvmOpts(gcJvmOptions.get())
                         .addAllJvmOpts(defaultJvmOpts.get())


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add workaround for JDK-8253566 by default when target runtime is java 15
==COMMIT_MSG==

even though this has been fixed in java 15.0.2 we can't guarantee that we aren't running with 15.0.0 or 15.0.1

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

