### PR TITLE
improvement: use mavenCentral in tests

### DIFF
--- a/changelog/@unreleased/pr-1118.v2.yml
+++ b/changelog/@unreleased/pr-1118.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: use mavenCentral in tests
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1118

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
@@ -37,7 +37,7 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
             }
             
             repositories {
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
 
             project.version = '1.0.0'

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -173,7 +173,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
 
             version '0.0.1'
@@ -213,7 +213,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
 
             class MyVersion {
@@ -576,7 +576,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
             distribution {
                 serviceName "my-service"
@@ -610,7 +610,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
             version '0.0.1'
             distribution {
@@ -655,7 +655,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
             version '0.0.1'
             distribution {
@@ -790,7 +790,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
             dependencies {
                 implementation project(':child')
@@ -806,7 +806,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
             dependencies {
                 api "com.google.guava:guava:19.0"
@@ -922,7 +922,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
             dependencies {
                 implementation project(':child')
@@ -938,7 +938,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
             dependencies {
                 api "com.google.guava:guava:19.0"
@@ -1021,7 +1021,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
 
             version '0.0.1'
@@ -1056,7 +1056,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
 
             version '0.0.1'
@@ -1133,7 +1133,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
 
             version '0.0.1'

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
@@ -35,7 +35,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
             
             repositories {
                 jcenter()
-                maven { url "https://palantir.bintray.com/releases" }
+                mavenCentral()
             }
 
             version '0.0.1'


### PR DESCRIPTION
## Before this PR
we're using bintray in all the tests, which is currently regularly browning out before the decommission

this is blocked on getting the go-init package (https://github.com/palantir/go-java-launcher) published to maven central

## After this PR
==COMMIT_MSG==
use mavenCentral in tests
==COMMIT_MSG==


