### PR TITLE
allow discovered dependencies to be set

### DIFF
--- a/changelog/@unreleased/pr-1144.v2.yml
+++ b/changelog/@unreleased/pr-1144.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: allow discovered dependencies to be set rather than processed in CreateManifestTask
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1144

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -53,6 +53,7 @@ public class BaseDistributionExtension {
     private final Property<String> podName;
     private final Property<ProductType> productType;
     private final ListProperty<ProductDependency> productDependencies;
+    private final ListProperty<ProductDependency> discoveredDependencies;
     private final SetProperty<ProductId> optionalProductDependencies;
     private final SetProperty<ProductId> ignoredProductDependencies;
     private final ProviderFactory providerFactory;
@@ -68,6 +69,7 @@ public class BaseDistributionExtension {
         podName = project.getObjects().property(String.class);
         productType = project.getObjects().property(ProductType.class);
         productDependencies = project.getObjects().listProperty(ProductDependency.class);
+        discoveredDependencies = project.getObjects().listProperty(ProductDependency.class);
         optionalProductDependencies = project.getObjects().setProperty(ProductId.class);
         ignoredProductDependencies = project.getObjects().setProperty(ProductId.class);
 
@@ -208,6 +210,14 @@ public class BaseDistributionExtension {
             }
             return dep;
         }));
+    }
+
+    public final void discoveredProductDependency(ProductDependency productDependency) {
+        discoveredDependencies.add(productDependency);
+    }
+
+    public final ListProperty<ProductDependency> getDiscoveredProductDependencies() {
+        return discoveredDependencies;
     }
 
     public final Provider<Set<ProductId>> getOptionalProductDependencies() {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductId.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductId.java
@@ -45,6 +45,10 @@ public final class ProductId implements Serializable {
         this.productName = productName;
     }
 
+    public static ProductId of(ProductDependency pd) {
+        return new ProductId(pd.getProductGroup(), pd.getProductName());
+    }
+
     @Override
     public String toString() {
         return productGroup + ":" + productName;


### PR DESCRIPTION
if none are set then the default mechanism of scanning jars kicks in.

## Before this PR
We have an external tool that can modify the list of discovered (recommended) dependencies.  There was no way to override that process in the CreateManifest task

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
allow discovered dependencies to be set rather than processed in CreateManifestTask
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

