### PR TITLE
[WIP] Enable container support.

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -41,6 +41,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     private final Property<JavaVersion> javaVersion;
     private final Property<String> mainClass;
     private final Property<String> javaHome;
+    private final Property<Boolean> enableContainerSupport;
     private final Property<Boolean> addJava8GcLogging;
     private final Property<Boolean> enableManifestClasspath;
     private final Property<GcProfile> gc;
@@ -69,6 +70,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
 
             return "$JAVA_" + javaVersionValue.getMajorVersion() + "_HOME";
         }));
+        enableContainerSupport = objectFactory.property(Boolean.class).value(false);
 
         addJava8GcLogging = objectFactory.property(Boolean.class).value(false);
         enableManifestClasspath = objectFactory.property(Boolean.class).value(false);
@@ -113,6 +115,14 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
 
     public final void javaHome(String newJavaHome) {
         this.javaHome.set(newJavaHome);
+    }
+
+    public final Provider<Boolean> getEnableContainerSupport() {
+        return enableContainerSupport;
+    }
+
+    public final void enableContainerSupport(boolean newEnableContainerSupport) {
+        this.enableContainerSupport.set(newEnableContainerSupport);
     }
 
     public final Provider<Boolean> getAddJava8GcLogging() {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -54,8 +54,8 @@ import org.gradle.util.GFileUtils;
 import org.gradle.util.GradleVersion;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
-    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.11.0";
-    private static final String GO_INIT = "com.palantir.launching:go-init:1.11.0";
+    private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:1.12.0-rc1";
+    private static final String GO_INIT = "com.palantir.launching:go-init:1.12.0-rc1";
     public static final String GROUP_NAME = "Distribution";
 
     @Override

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -222,6 +222,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getDefaultJvmOpts().set(distributionExtension.getDefaultJvmOpts());
                     task.getAddJava8GcLogging().set(distributionExtension.getAddJava8GcLogging());
                     task.getJavaHome().set(distributionExtension.getJavaHome());
+                    task.getEnableContainerSupport().set(distributionExtension.getEnableContainerSupport());
                     task.getJavaVersion().set(distributionExtension.getJavaVersion());
                     task.getEnv().set(distributionExtension.getEnv());
                 });

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -84,7 +84,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
             getProject().getObjects().property(Boolean.class);
     private final Property<String> javaHome = getProject().getObjects().property(String.class);
     private final Property<JavaVersion> javaVersion = getProject().getObjects().property(JavaVersion.class);
-    private final Property<Boolean> containerSupport = getProject().getObjects().property(Boolean.class);
+    private final Property<Boolean> enableContainerSupport =
+            getProject().getObjects().property(Boolean.class);
     private final ListProperty<String> args = getProject().getObjects().listProperty(String.class);
     private final ListProperty<String> checkArgs = getProject().getObjects().listProperty(String.class);
     private final ListProperty<String> defaultJvmOpts =
@@ -128,8 +129,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
 
     @Input
     @Optional
-    public final Property<Boolean> getContainerSupport() {
-        return containerSupport;
+    public final Property<Boolean> getEnableContainerSupport() {
+        return enableContainerSupport;
     }
 
     @Input
@@ -182,8 +183,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
                         .javaHome(javaHome.getOrElse(""))
                         .args(args.get())
                         .classpath(relativizeToServiceLibDirectory(getClasspath()))
-                        .containerSupport(
-                                containerSupport.get() && javaVersion.get().compareTo(JAVA_11) >= 0)
+                        .containerSupport(enableContainerSupport.get()
+                                && javaVersion.get().compareTo(JAVA_11) >= 0)
                         .addAllJvmOpts(javaAgentArgs())
                         .addAllJvmOpts(alwaysOnJvmOptions)
                         .addAllJvmOpts(addJava8GcLogging.get() ? java8gcLoggingOptions : ImmutableList.of())

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -277,7 +277,10 @@ public abstract class LaunchConfigTask extends DefaultTask {
 
         Map<String, String> env();
 
-        boolean containerSupport();
+        @Value.Default
+        default boolean containerSupport() {
+            return false;
+        }
 
         static Builder builder() {
             return new Builder();

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -183,7 +183,7 @@ public abstract class LaunchConfigTask extends DefaultTask {
                         .args(args.get())
                         .classpath(relativizeToServiceLibDirectory(getClasspath()))
                         .containerSupport(
-                                containerSupport.get() && javaVersion.get().compareTo(JAVA_11) >= 1)
+                                containerSupport.get() && javaVersion.get().compareTo(JAVA_11) >= 0)
                         .addAllJvmOpts(javaAgentArgs())
                         .addAllJvmOpts(alwaysOnJvmOptions)
                         .addAllJvmOpts(addJava8GcLogging.get() ? java8gcLoggingOptions : ImmutableList.of())

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -500,6 +500,63 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         ])
     }
 
+    def 'enables container support if enabled and >= JAVA 11'() {
+        createUntarBuildFile(buildFile)
+        buildFile << """
+            dependencies { compile files("${EXTERNAL_JAR}") }
+            tasks.jar.archiveBaseName = "internal"
+            distribution {
+                javaVersion 14
+                enableContainerSupport true
+            }""".stripIndent()
+        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+
+        when:
+        runTasks(':build', ':distTar', ':untar')
+
+        then:
+        def actualStaticConfig = OBJECT_MAPPER.readValue(
+                file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
+        actualStaticConfig.containerSupport().is(true)
+    }
+
+//    def 'does not enable container support by default'() {
+//        createUntarBuildFile(buildFile)
+//        buildFile << """
+//            dependencies { compile files("${EXTERNAL_JAR}") }
+//            tasks.jar.archiveBaseName = "internal"
+//            distribution {
+//                javaVersion 11
+//            }""".stripIndent()
+//        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+//
+//        when:
+//        runTasks(':build', ':distTar', ':untar')
+//
+//        then:
+//        def actualStaticConfig = OBJECT_MAPPER.readValue(
+//                file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
+//        actualStaticConfig.containerSupport().is(false)
+//    }
+//
+//    def 'does not enable container support by default'() {
+//        createUntarBuildFile(buildFile)
+//        buildFile << """
+//            dependencies { compile files("${EXTERNAL_JAR}") }
+//            tasks.jar.archiveBaseName = "internal"
+//            distribution {
+//                javaVersion 11
+//            }""".stripIndent()
+//        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+//
+//        when:
+//        runTasks(':build', ':distTar', ':untar')
+//
+//        then:
+//        def actualStaticConfig = OBJECT_MAPPER.readValue(
+//                file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
+//        actualStaticConfig.containerSupport().is(false)
+//    }
 
     def 'produce distribution bundle that populates check.sh'() {
         given:


### PR DESCRIPTION
## Before this PR

Developers have to manually specify heap size when running in containers.

## After this PR
==COMMIT_MSG==
If containerSupport: true AND running inside container, java heap is configured automatically.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

