### PR TITLE
resolve race condition with jar manifest manipulation

### DIFF
--- a/changelog/@unreleased/pr-1150.v2.yml
+++ b/changelog/@unreleased/pr-1150.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: resolve race condition with jar manifest manipulation
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1150

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependencies.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependencies.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.Attributes.Name;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -28,6 +30,8 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableRecommendedProductDependencies.class)
 public interface RecommendedProductDependencies {
     String SLS_RECOMMENDED_PRODUCT_DEPS_KEY = "Sls-Recommended-Product-Dependencies";
+    Attributes.Name SLS_RECOMMENDED_PRODUCT_DEPS_ATTRIBUTE =
+            new Name(RecommendedProductDependencies.SLS_RECOMMENDED_PRODUCT_DEPS_KEY);
 
     @JsonProperty("recommended-product-dependencies")
     Set<ProductDependency> recommendedProductDependencies();

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ResolveProductDependenciesTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ResolveProductDependenciesTaskIntegrationSpec.groovy
@@ -395,7 +395,6 @@ class ResolveProductDependenciesTaskIntegrationSpec extends GradleIntegrationSpe
 
         then:
         result.task(":foo-server:resolveProductDependencies").outcome == TaskOutcome.SUCCESS
-        result.task(':bar-api:jar') == null
 
         List<ProductDependency> prodDeps = readReport()
         prodDeps.size() == 1
@@ -451,7 +450,6 @@ class ResolveProductDependenciesTaskIntegrationSpec extends GradleIntegrationSpe
 
         then:
         result.task(":foo-server:resolveProductDependencies").outcome == TaskOutcome.SUCCESS
-        result.task(':bar-api:jar') == null
         List<ProductDependency> prodDeps = readReport()
         prodDeps.size() == 1
         prodDeps[0] == new ProductDependency('com.palantir.group', 'bar-service', '0.0.0', '1.x.x', '1.0.0')


### PR DESCRIPTION
The minimum required change is for the task to dependOn the configuration.  The rest of the
changes simplify the jar-scanning logic since we can now assume all jars are present, regardless
of whether the dependency is in the same project or external.

## Before this PR
The ResolveProductDependenciesTask can run before or during tasks that modify the contents of the Manifest produced by the Jar task of dependent projects.  This can lead to ConcurrentModificationExceptions.  This was a potential problem even when the logic was in the CreateManifest task.  It is unclear why it did not manifest.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
resolve race condition with jar manifest manipulation
==COMMIT_MSG==

## Possible downsides?
Adding the dependency on the configuration does mean that incoming dependencies will be resolved (i.e. the jars built).  That is true regardless of whether the logic to change how the artifact is scanned is changed or not.  This is normally not an issue since createManifest is generally triggered by the dist target and everything needs to be built anyway.  It is different when only --write-locks is run and there are no recommended product dependencies.  We may want to find an optimization for that case if it becomes significant.
