### PR TITLE
Disable biased locking

### DIFF
--- a/changelog/@unreleased/pr-1160.v2.yml
+++ b/changelog/@unreleased/pr-1160.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Disable biased locking by providing `-XX:-UseBiasedLocking` to jvm
+    args for java versions prior to jdk15.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1160

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -465,6 +465,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "-XX:NumberOfGCLogFiles=10",
                 "-Xloggc:var/log/gc-%t-%p.log",
                 "-verbose:gc",
+                "-XX:-UseBiasedLocking",
                 '-XX:+UseParallelOldGC',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])


### PR DESCRIPTION
==COMMIT_MSG==
Disable biased locking by providing `-XX:-UseBiasedLocking` to jvm args for java versions prior to jdk15.
==COMMIT_MSG==

Biased locking is disabled on java 15+ https://openjdk.java.net/jeps/374

We've found a lot of safepoints due to `RevokeBias`, and several projects have observed a performance improvement by disabling biased locking. We're not aware of any cases in which disabling biased locks reduces performance because our applications tend to be multi-threaded, and modern CPUs handle the CAS elegantly.
biased locking can result in non-obvious safepoints when `System.identityHashCode` is called because the identity hashcode and lock bias are stored in the same portion of the object header.