### PR TITLE
Step 2.5: misc tweaks for cleanup and add tests for resolve task

### DIFF
--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependencies.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependencies.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.dist;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
 import java.util.Set;
 import org.immutables.value.Value;
 
@@ -36,5 +37,11 @@ public interface RecommendedProductDependencies {
 
     static Builder builder() {
         return new Builder();
+    }
+
+    static RecommendedProductDependencies of(List<ProductDependency> productDependencies) {
+        return builder()
+                .addAllRecommendedProductDependencies(productDependencies)
+                .build();
     }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -111,7 +111,7 @@ public final class ProductDependencyIntrospectionPlugin implements Plugin<Projec
             Project project, List<ProductDependency> dependencies, Map<ProductId, Project> inRepoProductIds) {
         return dependencies.stream()
                 .map(dependency -> {
-                    ProductId productId = new ProductId(dependency.getProductGroup(), dependency.getProductName());
+                    ProductId productId = ProductId.of(dependency);
                     if (inRepoProductIds.containsKey(productId)) {
                         String projectPath = inRepoProductIds.get(productId).getPath();
                         return project.getDependencies()

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -72,7 +72,7 @@ public final class ProductDependencyLockFile {
      * To avoid this, we replace the minimum version of such dependencies with a placeholder, {@code $projectVersion}.
      */
     private static String renderDepMinimumVersion(Set<ProductId> servicesDeclaredInProject, ProductDependency dep) {
-        ProductId productId = new ProductId(dep.getProductGroup(), dep.getProductName());
+        ProductId productId = ProductId.of(dep);
         if (servicesDeclaredInProject.contains(productId)) {
             return PROJECT_VERSION;
         } else {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/Serializations.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/Serializations.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.palantir.gradle.dist.pdeps.ProductDependencyManifest;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.gradle.api.GradleException;
+
+public final class Serializations {
+    public static final ObjectMapper jsonMapper = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .registerModule(new GuavaModule());
+
+    public static void writeSlsManifest(SlsManifest slsManifest, File outputFile) {
+        try {
+            Files.createDirectories(outputFile.toPath().getParent());
+            jsonMapper.writeValue(outputFile, slsManifest);
+        } catch (IOException e) {
+            throw new GradleException("Unable to write SlsManifest file", e);
+        }
+    }
+
+    public static SlsManifest readSlsManifest(File file) {
+        try {
+            return jsonMapper.readValue(file, SlsManifest.class);
+        } catch (IOException e) {
+            throw new GradleException("Unable to read SlsManifest: " + file, e);
+        }
+    }
+
+    public static void writeProductDependencyManifest(ProductDependencyManifest pdm, File outputFile) {
+        try {
+            Files.createDirectories(outputFile.toPath().getParent());
+            jsonMapper.writeValue(outputFile, pdm);
+        } catch (IOException e) {
+            throw new GradleException("Unable to write ProductDependencyManifest file", e);
+        }
+    }
+
+    public static ProductDependencyManifest readProductDependencyManifest(File file) {
+        try {
+            return jsonMapper.readValue(file, ProductDependencyManifest.class);
+        } catch (IOException e) {
+            throw new GradleException("Unable to read ProductDependencyManifest: " + file, e);
+        }
+    }
+
+    public static void writeRecommendedProductDependencies(RecommendedProductDependencies rdp, File outputFile) {
+        try {
+            Files.createDirectories(outputFile.toPath().getParent());
+            jsonMapper.writeValue(outputFile, rdp);
+        } catch (IOException e) {
+            throw new GradleException("Unable to write RecommendedProductDependencies file", e);
+        }
+    }
+
+    public static RecommendedProductDependencies readRecommendedProductDependencies(File file) {
+        try {
+            return jsonMapper.readValue(file, RecommendedProductDependencies.class);
+        } catch (IOException e) {
+            throw new GradleException("Unable to read RecommendedProductDependencies: " + file, e);
+        }
+    }
+
+    private Serializations() {}
+}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/Diagnostics.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/Diagnostics.java
@@ -18,7 +18,7 @@ package com.palantir.gradle.dist.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.palantir.gradle.dist.tasks.CreateManifestTask;
+import com.palantir.gradle.dist.Serializations;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,7 +41,7 @@ public final class Diagnostics {
         try {
             string = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8).trim();
             List<ObjectNode> value =
-                    CreateManifestTask.jsonMapper.readValue(string, new TypeReference<List<ObjectNode>>() {});
+                    Serializations.jsonMapper.readValue(string, new TypeReference<List<ObjectNode>>() {});
             log.info("Deserialized '{}': '{}'", relativePath, value);
             return value;
         } catch (IOException e) {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/MergeDiagnosticsJsonTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/MergeDiagnosticsJsonTask.java
@@ -17,7 +17,7 @@
 package com.palantir.gradle.dist.service;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.palantir.gradle.dist.tasks.CreateManifestTask;
+import com.palantir.gradle.dist.Serializations;
 import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
@@ -54,7 +54,7 @@ public abstract class MergeDiagnosticsJsonTask extends DefaultTask {
 
         File out = getOutputJsonFile().getAsFile().get();
         try {
-            CreateManifestTask.jsonMapper.writeValue(out, aggregated);
+            Serializations.jsonMapper.writeValue(out, aggregated);
         } catch (IOException e) {
             throw new GradleException("Failed to write " + out, e);
         }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.dist.tasks;
 
 import com.palantir.gradle.dist.BaseDistributionExtension;
+import com.palantir.gradle.dist.Serializations;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import java.io.File;
 import java.io.IOException;
@@ -44,7 +45,7 @@ public final class ConfigTarTask {
                     .set(project.provider(() -> project.getVersion().toString()));
             task.getArchiveExtension().set(ext.getProductType().map(productType -> {
                 try {
-                    String productTypeString = CreateManifestTask.jsonMapper.writeValueAsString(productType);
+                    String productTypeString = Serializations.jsonMapper.writeValueAsString(productType);
                     return productTypeString
                             .substring(1, productTypeString.lastIndexOf('.'))
                             .concat(".config.tgz");

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -37,6 +37,7 @@ import com.palantir.gradle.dist.ProductType;
 import com.palantir.gradle.dist.RecommendedProductDependencies;
 import com.palantir.gradle.dist.RecommendedProductDependenciesPlugin;
 import com.palantir.gradle.dist.SlsManifest;
+import com.palantir.gradle.dist.pdeps.ProductDependencies;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.sls.versions.SlsVersion;
 import java.io.ByteArrayOutputStream;
@@ -519,6 +520,10 @@ public class CreateManifestTask extends DefaultTask {
     }
 
     public static TaskProvider<CreateManifestTask> createManifestTask(Project project, BaseDistributionExtension ext) {
+        // This is simply to get the task wired up with the plugin.  It's output is not used by the createManifest task
+        // yet.
+        ProductDependencies.registerProductDependencyTasks(project, "runtimeElements", ext);
+
         TaskProvider<CreateManifestTask> createManifest = project.getTasks()
                 .register("createManifest", CreateManifestTask.class, task -> {
                     task.getServiceName().set(ext.getDistributionServiceName());

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ProductDependencyTestFixture.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ProductDependencyTestFixture.groovy
@@ -1,0 +1,102 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.pdeps
+
+import nebula.test.dependencies.DependencyGraph
+import nebula.test.dependencies.GradleDependencyGenerator
+
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+class ProductDependencyTestFixture {
+    static final String STANDARD_PRODUCT_DEPENDENCY = '''
+        productDependency {
+            productGroup = 'group'
+            productName = 'name'
+            minimumVersion = '1.0.0'
+            maximumVersion = '1.x.x'
+            recommendedVersion = '1.2.0'
+        }
+        '''
+
+    File mavenRepo
+    File projectDir
+    File buildFile
+
+    ProductDependencyTestFixture(File projectDir, File buildFile) {
+        this.projectDir = projectDir
+        this.buildFile = buildFile
+    }
+
+    def setup() {
+        generateDependencies()
+        buildFile << """
+            plugins {
+                id 'com.palantir.sls-java-service-distribution'
+            }
+
+            repositories {
+                maven {url "file:///${mavenRepo.getAbsolutePath()}"}
+            }
+
+            project.version = '1.0.0'
+            distribution {
+                serviceName 'serviceName'
+                serviceGroup 'serviceGroup'
+            }
+        """.stripIndent()
+    }
+
+    void generateDependencies() {
+        DependencyGraph dependencyGraph = new DependencyGraph(
+                "a:a:1.0 -> b:b:1.0|c:c:1.0", "b:b:1.0", "c:c:1.0", "d:d:1.0", "e:e:1.0",
+                "pdep:pdep:1.0")
+        GradleDependencyGenerator generator = new GradleDependencyGenerator(
+                dependencyGraph, new File(projectDir, "build/testrepogen").toString())
+        mavenRepo = generator.generateTestMavenRepo()
+
+
+        // depends on group:name:[1.0.0, 1.x.x]:1.2.0
+        Files.copy(
+                ProductDependencyTestFixture.class.getResourceAsStream("/a-1.0.jar"),
+                new File(mavenRepo, "a/a/1.0/a-1.0.jar").toPath(),
+                StandardCopyOption.REPLACE_EXISTING)
+        // depends on group:name2:[2.0.0, 2.x.x]:2.2.0
+        Files.copy(
+                ProductDependencyTestFixture.class.getResourceAsStream("/b-1.0.jar"),
+                new File(mavenRepo, "b/b/1.0/b-1.0.jar").toPath(),
+                StandardCopyOption.REPLACE_EXISTING)
+        // Make d.jar a duplicate of b.jar
+        Files.copy(
+                ProductDependencyTestFixture.class.getResourceAsStream("/b-1.0.jar"),
+                new File(mavenRepo, "d/d/1.0/d-1.0.jar").toPath(),
+                StandardCopyOption.REPLACE_EXISTING)
+        // e-1.0.jar declares group:name2:[2.1.0, 2.6.x]:2.2.0
+        Files.copy(
+                ProductDependencyTestFixture.class.getResourceAsStream("/b-duplicate-different-versions-1.0.jar"),
+                new File(mavenRepo, "e/e/1.0/e-1.0.jar").toPath(),
+                StandardCopyOption.REPLACE_EXISTING)
+    }
+
+    void addStandardProductDependency() {
+        buildFile << """
+            distribution {
+                $STANDARD_PRODUCT_DEPENDENCY
+            }
+            """.stripIndent()
+    }
+}

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
@@ -16,50 +16,42 @@
 
 package com.palantir.gradle.dist.pdeps
 
-import com.palantir.gradle.dist.BaseDistributionExtension
-import com.palantir.gradle.dist.tasks.CreateManifestTask
+import com.palantir.gradle.dist.GradleIntegrationSpec
+import com.palantir.gradle.dist.ProductDependency
+import com.palantir.gradle.dist.RecommendedProductDependencies
+import com.palantir.gradle.dist.Serializations
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
+
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import nebula.test.IntegrationSpec
 import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.GradleDependencyGenerator
 
-class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
-    private static String PDEP = """
-    productDependency {
-        productGroup = "group1"
-        productName = "name1"
-        minimumVersion = "1.0.0"
-        maximumVersion = "1.3.x"
-        recommendedVersion = "1.2.1"
-    }
-    """.stripIndent()
+class ResolveProductDependenciesIntegrationSpec extends GradleIntegrationSpec {
+
+    public static final String MANIFEST_FILE_PATH = 'build/product-dependencies/pdeps-manifest.json'
+
+    ProductDependencyTestFixture pdtf
+    File manifestFile
 
     def setup() {
-        buildFile << """
-        apply plugin: 'java'
-        import ${ProductDependencies.class.getCanonicalName()}
-        import ${BaseDistributionExtension.class.getCanonicalName()}
-        
-        def ext = project.extensions.create("base", BaseDistributionExtension, project)
-        ProductDependencies.registerProductDependencyTasks(project,"runtimeElements", ext);
-        """.stripIndent()
+        debug = true
+        manifestFile = new File(projectDir, MANIFEST_FILE_PATH)
+        pdtf = new ProductDependencyTestFixture(projectDir, buildFile)
+        pdtf.setup()
     }
 
     def 'consumes declared product dependencies'() {
         setup:
-        buildFile << """
-            base {
-                ${PDEP}
-            }
-        """.stripIndent()
+        pdtf.addStandardProductDependency()
 
         when:
         def buildResult = runTasks(':resolveProductDependencies')
 
         then:
-        def manifest = loadManifest(file('build/product-dependencies/pdeps-manifest.json'))
-        !manifest.productDependencies().isEmpty()
+        def productDependencies = readPDepManifest()
+        !productDependencies.isEmpty()
     }
 
     def 'discovers project dependencies without compilation'() {
@@ -69,7 +61,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         apply plugin: 'com.palantir.recommended-product-dependencies'
         
         recommendedProductDependencies {
-            ${PDEP}
+            ${ProductDependencyTestFixture.STANDARD_PRODUCT_DEPENDENCY}
         }
         """.stripIndent())
         buildFile << """
@@ -82,9 +74,9 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def result = runTasks(':resolveProductDependencies')
 
         then:
-        !result.wasExecuted(':child:jar')
-        def manifest = loadManifest(file('build/product-dependencies/pdeps-manifest.json'))
-        !manifest.productDependencies().isEmpty()
+        !result.tasks.contains(':child:jar')
+        def productDependencies = readPDepManifest()
+        !productDependencies.isEmpty()
     }
 
     def 'discovers external dependencies'() {
@@ -113,12 +105,531 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def result = runTasks(':resolveProductDependencies')
 
         then:
-        def manifest = loadManifest(file('build/product-dependencies/pdeps-manifest.json'))
-        !manifest.productDependencies().isEmpty()
+        def productDependencies = readPDepManifest()
+        !productDependencies.isEmpty()
     }
 
-    def loadManifest(File file) {
-        return CreateManifestTask.jsonMapper.readValue(file, ProductDependencyManifest)
+    def 'merges declared product dependencies'() {
+        setup:
+        buildFile << """
+            distribution {
+                $ProductDependencyTestFixture.STANDARD_PRODUCT_DEPENDENCY
+                //add same with a different minimum version
+                productDependency {
+                    productGroup = 'group'
+                    productName = 'name'
+                    minimumVersion = '1.1.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = '1.2.0'
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def buildResult = runTasks('resolveProductDependencies')
+
+        then:
+        buildResult.task(':resolveProductDependencies').outcome == TaskOutcome.SUCCESS
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 1
+        prodDeps.find{it.productName == 'name'} == new ProductDependency('group', 'name', '1.1.0', '1.x.x', '1.2.0')
     }
 
+    def 'throws if declared dependency is also ignored'() {
+        setup:
+        pdtf.addStandardProductDependency()
+        buildFile << """
+            distribution {
+                ignoredProductDependency('group:name')
+            }
+        """.stripIndent()
+
+        when:
+        def buildResult = runTasksAndFail(':resolveProductDependencies')
+
+        then:
+        buildResult.output.contains('Encountered product dependency declaration that was also ignored')
+    }
+
+    def 'throws if declared dependency is also optional'() {
+        setup:
+        pdtf.addStandardProductDependency()
+        buildFile << """
+            distribution {
+                optionalProductDependency('group:name')
+            }
+        """.stripIndent()
+
+        when:
+        def buildResult = runTasksAndFail(':resolveProductDependencies')
+
+        then:
+        buildResult.output.contains('Encountered product dependency declaration that was also declared as optional')
+    }
+
+    def "throws if declared dependency on the same product"() {
+        buildFile << """
+            distribution {
+                productDependency {
+                    productGroup = 'serviceGroup'
+                    productName = 'serviceName'
+                    minimumVersion = '1.1.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = '1.2.0'
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def buildResult = runTasksAndFail(':resolveProductDependencies')
+
+        then:
+        buildResult.output.contains('Invalid for product to declare an explicit dependency on itself')
+    }
+
+    def 'Resolve unspecified productDependencies'() {
+        setup:
+        buildFile << """
+            dependencies {
+                runtime 'a:a:1.0'
+            }
+        """.stripIndent()
+
+        when:
+        runTasks(':resolveProductDependencies')
+
+        then:
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 2
+        prodDeps.find{it.productName == 'name'} == new ProductDependency('group', 'name', '1.0.0', '1.x.x', '1.2.0')
+        prodDeps.find{it.productName == 'name2'} == new ProductDependency('group', 'name2', '2.0.0', '2.x.x', '2.2.0')
+    }
+
+    def 'Merges declared productDependencies with discovered dependencies'() {
+        setup:
+        buildFile << """
+            dependencies {
+                runtime 'a:a:1.0'
+            }
+            distribution {
+                //add same with a different minimum version and optional
+                productDependency {
+                    productGroup = 'group'
+                    productName = 'name'
+                    minimumVersion = '1.1.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = '1.2.0'
+                    optional = true
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasks(':resolveProductDependencies')
+
+        then:
+        !result.output.contains(
+                "Please remove your declared product dependency on 'group:name' because it is already provided by a jar dependency")
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 2
+        def pd = prodDeps.find { it.productName == 'name' }
+        pd.minimumVersion == '1.1.0'
+        pd.optional
+    }
+
+    def 'Can ignore recommended product dependencies'() {
+        setup:
+        buildFile << """
+            dependencies {
+                runtime 'a:a:1.0'
+            }
+            distribution {
+                ignoredProductDependency('group:name')
+                ignoredProductDependency('group:name2')
+            }
+        """.stripIndent()
+
+        when:
+        runTasks(':resolveProductDependencies')
+
+        then:
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.isEmpty()
+    }
+
+    def 'Mark as optional product dependencies'() {
+        setup:
+        buildFile << """
+            dependencies {
+                runtime 'a:a:1.0'
+            }
+            distribution {
+                optionalProductDependency('group:name')
+                optionalProductDependency('group:name2')
+            }
+        """.stripIndent()
+
+        when:
+        runTasks(':resolveProductDependencies')
+
+        then:
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.find{it.productName == 'name'}.optional
+        prodDeps.find{it.productName == 'name2'}.optional
+    }
+
+    def "Merges duplicate discovered dependencies with same version"() {
+        setup:
+        buildFile << """
+            dependencies {
+                runtime 'b:b:1.0'
+                runtime 'd:d:1.0'
+            }
+        """.stripIndent()
+
+        when:
+        runTasks(':resolveProductDependencies')
+
+        then:
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 1
+    }
+
+    def "Merges duplicate discovered dependencies with different mergeable versions"() {
+        setup:
+        buildFile << """
+            dependencies {
+                runtime 'b:b:1.0'
+                runtime 'e:e:1.0'
+            }
+        """.stripIndent()
+
+        when:
+        runTasks(':resolveProductDependencies')
+
+        then:
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 1
+        prodDeps[0].minimumVersion == '2.1.0'
+        prodDeps[0].maximumVersion == '2.6.x'
+    }
+
+    def "Does not include self dependency"() {
+        buildFile << """
+            dependencies {
+                runtime 'b:b:1.0'
+            }
+            // Configure this service to have the same coordinates as the (sole) dependency coming from b:b:1.0
+            distribution {
+                serviceGroup = "group"
+                serviceName = "name2"
+            }
+        """.stripIndent()
+
+        when:
+        runTasks(':resolveProductDependencies')
+
+        then:
+        readPDepManifest().isEmpty()
+    }
+
+    @Unroll
+    def 'filters out recommended product dependency on self (version: #projectVersion)'() {
+        setup:
+        buildFile << """
+        allprojects {
+            project.version = '$projectVersion'
+        }
+        """
+        helper.addSubproject("foo-api", """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+            
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'my-service'
+                    minimumVersion = rootProject.version
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        """.stripIndent())
+        def fooServerDir = helper.addSubproject("foo-server", """
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            dependencies {
+                compile project(':foo-api')
+            }
+            distribution {
+                serviceGroup 'com.palantir.group'
+                serviceName 'my-service'
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+                args 'server', 'var/conf/my-service.yml'
+            }
+        """.stripIndent())
+        //set report file to that in the sub-project dir
+        manifestFile = new File(fooServerDir, MANIFEST_FILE_PATH)
+
+        when:
+        runTasks(':foo-server:resolveProductDependencies', '-i')
+
+        then: 'foo-server does not include transitively discovered self dependency'
+        readPDepManifest().isEmpty()
+
+        where:
+        projectVersion << ['1.0.0-rc1.dirty', '1.0.0']
+    }
+
+    def 'merging two dirty product dependencies is not acceptable'() {
+        buildFile << """
+        allprojects {
+            project.version = '1.0.0-rc1.dirty'
+        }
+        """
+        helper.addSubproject("foo-api", """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+            
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'foo-service'
+                    minimumVersion = '0.0.0.dirty'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        """.stripIndent())
+
+        helper.addSubproject("other-server", """
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            dependencies {
+                compile project(':foo-api')
+            }
+            distribution {
+                serviceGroup 'com.palantir.group'
+                serviceName 'other-service'
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+                args 'server', 'var/conf/my-service.yml'
+                
+                // Incompatible with the 0.0.0.dirty from the classpath
+                productDependency('com.palantir.group', 'foo-service', '1.0.0.dirty', '1.x.x')
+            }
+        """.stripIndent())
+
+        when:
+        def result = runTasksAndFail('resolveProductDependencies')
+
+        then:
+        result.output.contains('Could not determine minimum version among two non-orderable minimum versions')
+    }
+
+    def "resolveProductDependencies discovers in repo product dependencies"() {
+        setup:
+        buildFile << """
+        allprojects {
+            project.version = '1.0.0'
+            group "com.palantir.group"
+        }
+        """
+        helper.addSubproject("bar-api", """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'bar-service'
+                    minimumVersion = '0.0.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        """.stripIndent())
+        def fooServerDir = helper.addSubproject("foo-server", """
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            
+            dependencies {
+                compile project(':bar-api')
+            }
+
+            distribution {
+                serviceGroup 'com.palantir.group'
+                serviceName 'foo-service'
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+                args 'server', 'var/conf/my-service.yml'
+            }
+        """.stripIndent())
+        //set report file to that in the sub-project dir
+        manifestFile = new File(fooServerDir, MANIFEST_FILE_PATH)
+
+        when:
+        def result = runTasks('foo-server:resolveProductDependencies')
+
+        then:
+        result.task(":foo-server:resolveProductDependencies").outcome == TaskOutcome.SUCCESS
+        result.task(':bar-api:jar') == null
+
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 1
+        prodDeps[0] == new ProductDependency('com.palantir.group', 'bar-service', '0.0.0', '1.x.x', '1.0.0')
+    }
+
+    def "resolveProductDependencies discovers transitive in repo dependencies"() {
+        setup:
+        buildFile << """
+        allprojects {
+            project.version = '1.0.0'
+            group "com.palantir.group"
+        }
+        """
+        helper.addSubproject("bar-api", """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'bar-service'
+                    minimumVersion = '0.0.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        """.stripIndent())
+        helper.addSubproject("bar-lib", """
+            apply plugin: 'java'
+            dependencies {
+                compile project(':bar-api')
+            }
+        """.stripIndent())
+        def fooServerDir = helper.addSubproject("foo-server", """
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            
+            dependencies {
+                compile project(':bar-lib')
+            }
+
+            distribution {
+                serviceGroup 'com.palantir.group'
+                serviceName 'foo-service'
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+                args 'server', 'var/conf/my-service.yml'
+            }
+        """.stripIndent())
+        manifestFile = new File(fooServerDir, MANIFEST_FILE_PATH)
+
+        when:
+        def result = runTasks('foo-server:resolveProductDependencies')
+
+        then:
+        result.task(":foo-server:resolveProductDependencies").outcome == TaskOutcome.SUCCESS
+        result.task(':bar-api:jar') == null
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 1
+        prodDeps[0] == new ProductDependency('com.palantir.group', 'bar-service', '0.0.0', '1.x.x', '1.0.0')
+    }
+
+    def 'use provided discovered dependencies'() {
+        setup:
+        pdtf.addStandardProductDependency()
+        def overrideDepsFile = new File(projectDir, 'override-deps.json')
+        def pd = new ProductDependency('com.palantir.group', 'other-service', '0.5.0', '2.x.x', '1.0.0')
+        Serializations.writeRecommendedProductDependencies(RecommendedProductDependencies.of([pd]), overrideDepsFile)
+        buildFile << """
+            dependencies {
+                runtime 'a:a:1.0'
+            }
+            resolveProductDependencies {
+                productDependenciesFiles.setFrom(file('override-deps.json'))
+            }
+        """
+
+        when:
+        def result = runTasks('resolveProductDependencies')
+
+        then:
+        result.task(":resolveProductDependencies").outcome == TaskOutcome.SUCCESS
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 2
+        prodDeps[0] == new ProductDependency('com.palantir.group', 'other-service', '0.5.0', '2.x.x', '1.0.0')
+        prodDeps[1] == new ProductDependency('group', 'name', '1.0.0', '1.x.x', '1.2.0')
+    }
+
+    def 'handles multiple product dependencies when project version is dirty'() {
+        setup:
+        // Set project version to be non orderable sls version
+        buildFile << """
+        allprojects {
+            project.version = '1.0.0.dirty'
+            group "com.palantir.group"
+        }
+        """
+        helper.addSubproject('bar-service', '''
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            
+            dependencies {
+                compile project(':bar-api')
+            }
+
+            distribution {
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+            }
+        '''.stripIndent())
+        helper.addSubproject('bar-lib', '''
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'bar-service'
+                    minimumVersion = project.version
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        '''.stripIndent())
+        helper.addSubproject("bar-api", """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'com.palantir.group'
+                    productName = 'bar-service'
+                    minimumVersion = '0.5.0'
+                    maximumVersion = '1.x.x'
+                    recommendedVersion = rootProject.version
+                }
+            }
+        """.stripIndent())
+        def fooServerDir = helper.addSubproject("foo-server", """
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            
+            dependencies {
+                compile project(':bar-api')
+                compile project(':bar-lib')
+            }
+
+            distribution {
+                mainClass 'com.palantir.foo.bar.MyServiceMainClass'
+            }
+        """.stripIndent())
+        manifestFile = new File(fooServerDir, MANIFEST_FILE_PATH)
+
+        when:
+        def result = runTasks('foo-server:resolveProductDependencies')
+
+        then:
+        result.task(":foo-server:resolveProductDependencies").outcome == TaskOutcome.SUCCESS
+        List<ProductDependency> prodDeps = readPDepManifest()
+        prodDeps.size() == 1
+        prodDeps[0] == new ProductDependency('com.palantir.group', 'bar-service', '1.0.0.dirty', '1.x.x', null)
+    }
+
+    private List<ProductDependency> readPDepManifest() {
+        assert manifestFile.exists()
+        return Serializations.readProductDependencyManifest(manifestFile).productDependencies();
+    }
 }


### PR DESCRIPTION
Also fix one bug in resolve - it was allowing self dependencies

The tests for the resolve task are taken straight from the createManifest spec.
Once we wire the two tasks together, will delete the duplicate ones from the manifest spec.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
misc tweaks for cleanup and add tests for resolve task
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

