### PR TITLE
the conjure-gradle plugin needs to be able to set the inputs.

### DIFF
--- a/changelog/@unreleased/pr-1165.v2.yml
+++ b/changelog/@unreleased/pr-1165.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: the conjure-gradle plugin needs to be able to set the inputs
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1165

--- a/changelog/@unreleased/pr-1165.v2.yml
+++ b/changelog/@unreleased/pr-1165.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: the conjure-gradle plugin needs to be able to set the inputs
+  description: Make CompileRecommendedProductDependencies input public
   links:
   - https://github.com/palantir/sls-packaging/pull/1165

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/CompileRecommendedProductDependencies.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/CompileRecommendedProductDependencies.java
@@ -30,10 +30,10 @@ public abstract class CompileRecommendedProductDependencies extends DefaultTask 
     static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Input
-    abstract SetProperty<ProductDependency> getRecommendedProductDependencies();
+    public abstract SetProperty<ProductDependency> getRecommendedProductDependencies();
 
     @OutputFile
-    abstract RegularFileProperty getOutputFile();
+    public abstract RegularFileProperty getOutputFile();
 
     @TaskAction
     final void action() throws IOException {


### PR DESCRIPTION
making the output also public for completeness.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
the conjure-gradle plugin needs to be able to set the inputs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

