### PR TITLE
fix check for duplicated product dependencies

### DIFF
--- a/changelog/@unreleased/pr-1167.v2.yml
+++ b/changelog/@unreleased/pr-1167.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: logs message only if a declared and a recommended overlap
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1167

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesTask.java
@@ -121,6 +121,16 @@ public abstract class ResolveProductDependenciesTask extends DefaultTask {
                 log.trace("Product dependency for '{}' declared as optional", productId);
                 allOptionalDependencies.add(productId);
             }
+            if (discoveredDependencies.containsKey(productId)) {
+                log.error(
+                        "Please remove your declared product dependency on '{}' because it is"
+                                + " already provided by a jar dependency:\n\n"
+                                + "\tProvided:     {}\n"
+                                + "\tYou declared: {}",
+                        productId,
+                        discoveredDependencies.get(productId),
+                        declaredDep);
+            }
         });
 
         discoveredDependencies.forEach((productId, discoveredDependency) -> {
@@ -135,16 +145,6 @@ public abstract class ResolveProductDependenciesTask extends DefaultTask {
             allProductDependencies.merge(productId, discoveredDependency, (declaredDependency, _newDependency) -> {
                 ProductDependency mergedDependency =
                         mergeDependencies(productId, declaredDependency, discoveredDependency);
-                if (mergedDependency.equals(discoveredDependency)) {
-                    log.error(
-                            "Please remove your declared product dependency on '{}' because it is"
-                                    + " already provided by a jar dependency:\n\n"
-                                    + "\tProvided:     {}\n"
-                                    + "\tYou declared: {}",
-                            productId,
-                            discoveredDependency,
-                            declaredDependency);
-                }
                 return mergedDependency;
             });
         });


### PR DESCRIPTION
## Before this PR
would log error message if more than one version of the same recommended dep

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
logs message only if a declared and a recommended overlap
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

