### PR TITLE
Enable -XX:NativeMemoryTracking=summary

### DIFF
--- a/changelog/@unreleased/pr-1174.v2.yml
+++ b/changelog/@unreleased/pr-1174.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable `-XX:NativeMemoryTracking=summary` for all
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1174

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -69,7 +69,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
             "-XX:HeapDumpPath=var/log",
             // Set DNS cache TTL to 20s to account for systems such as RDS and other
             // AWS-managed systems that modify DNS records on failover.
-            "-Dsun.net.inetaddr.ttl=20");
+            "-Dsun.net.inetaddr.ttl=20",
+            "-XX:NativeMemoryTracking=summary");
 
     // Reduce memory usage for some versions of glibc.
     // Default value is 8 * CORES.

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -397,6 +397,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
+                '-XX:NativeMemoryTracking=summary',
                 '-XX:+UseParallelOldGC',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
@@ -420,6 +421,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
+                '-XX:NativeMemoryTracking=summary',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
             .env(LaunchConfigTask.defaultEnvironment)
@@ -457,6 +459,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
+                '-XX:NativeMemoryTracking=summary',
                 "-XX:+PrintGCDateStamps",
                 "-XX:+PrintGCDetails",
                 "-XX:-TraceClassUnloading",


### PR DESCRIPTION
## Before this PR

In WC 1.71.0, I added a bunch of metrics (~60) extracted from running `jcmd VM.native_memory`.  This only works if you have  `-XX:NativeMemoryTracking=summary` enabled.

I was initially quite cautious about the extra 'overhead' that so many blogs talked about, but after Carter's benchmarks and seeing timelock run with it on an early-adopter stack, we haven't been able to see any noticeable performance impact. The space overhead was also very small (~8MiB for timelock's 4g heap).

## After this PR
==COMMIT_MSG==
Enable `-XX:NativeMemoryTracking=summary` for all
==COMMIT_MSG==

`do not merge` until we've come to a decision about the DD $ cost of exposing lots more metrics.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

