### PR TITLE
Add jvm args to jdk16+ to support safepoint metrics

### DIFF
--- a/changelog/@unreleased/pr-1176.v2.yml
+++ b/changelog/@unreleased/pr-1176.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add jvm args to jdk16+ to support safepoint metrics
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1176


### PR DESCRIPTION
They're some of our most actionable metrics which would be painful
to lose.

Not seeing progress here:
https://mail.openjdk.java.net/pipermail/serviceability-dev/2021-June/038164.html

## After this PR
==COMMIT_MSG==
Add jvm args to jdk16+ to support safepoint metrics
==COMMIT_MSG==

## Possible downsides?
Ideally we wouldn't rely on `--add-exports`

