### PR TITLE
Copy pdeps config lazily

### DIFF
--- a/changelog/@unreleased/pr-1183.v2.yml
+++ b/changelog/@unreleased/pr-1183.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Copy pdeps config lazily
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1183

--- a/changelog/@unreleased/pr-1183.v2.yml
+++ b/changelog/@unreleased/pr-1183.v2.yml
@@ -1,5 +1,5 @@
-type: fix
-fix:
-  description: Copy pdeps config lazily
+type: break
+break:
+  description: Copy pdeps config lazily. Increase minimum Gradle version to 6.1.
   links:
   - https://github.com/palantir/sls-packaging/pull/1183

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/SlsBaseDistPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/SlsBaseDistPlugin.java
@@ -35,7 +35,7 @@ public class SlsBaseDistPlugin implements Plugin<Project> {
 
     public static final String SLS_DIST_USAGE = "sls-dist";
 
-    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("5.6");
+    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("6.1");
 
     @Override
     public final void apply(Project project) {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist.artifacts;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactView;
@@ -40,17 +41,20 @@ public final class DependencyDiscovery {
     }
 
     public static Configuration copyConfiguration(Project project, String configurationName, String name) {
-        Configuration consumable = project.getConfigurations()
-                .create(GUtil.toLowerCamelCase(configurationName + " for " + name), conf -> {
-                    conf.extendsFrom(project.getConfigurations().getByName(configurationName));
-                    conf.setDescription("DiagnosticsManifestPlugin uses this configuration to extract single file");
-                    conf.setCanBeConsumed(true);
-                    conf.setCanBeResolved(true);
-                    conf.setVisible(false);
-                });
+        String newConfigName = GUtil.toLowerCamelCase(GUtil.toLowerCamelCase(configurationName + " for " + name));
+        return Optional.ofNullable(project.getConfigurations().findByName(newConfigName))
+                .orElseGet(() -> {
+                    Configuration consumable = project.getConfigurations().create(newConfigName, conf -> {
+                        conf.extendsFrom(project.getConfigurations().getByName(configurationName));
+                        conf.setDescription("DiagnosticsManifestPlugin uses this configuration to extract single file");
+                        conf.setCanBeConsumed(true);
+                        conf.setCanBeResolved(true);
+                        conf.setVisible(false);
+                    });
 
-        project.getDependencies().add(consumable.getName(), project);
-        return consumable;
+                    project.getDependencies().add(consumable.getName(), project);
+                    return consumable;
+                });
     }
 
     public static <T extends TransformAction<P>, P extends TransformParameters> void configureJarTransform(

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.dist.artifacts;
 
-import java.util.Optional;
 import java.util.function.Consumer;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactView;
@@ -41,20 +40,17 @@ public final class DependencyDiscovery {
     }
 
     public static Configuration copyConfiguration(Project project, String configurationName, String name) {
-        String newConfigName = GUtil.toLowerCamelCase(GUtil.toLowerCamelCase(configurationName + " for " + name));
-        return Optional.ofNullable(project.getConfigurations().findByName(newConfigName))
-                .orElseGet(() -> {
-                    Configuration consumable = project.getConfigurations().create(newConfigName, conf -> {
-                        conf.extendsFrom(project.getConfigurations().getByName(configurationName));
-                        conf.setDescription("DiagnosticsManifestPlugin uses this configuration to extract single file");
-                        conf.setCanBeConsumed(true);
-                        conf.setCanBeResolved(true);
-                        conf.setVisible(false);
-                    });
-
-                    project.getDependencies().add(consumable.getName(), project);
-                    return consumable;
+        Configuration consumable = project.getConfigurations()
+                .create(GUtil.toLowerCamelCase(configurationName + " for " + name), conf -> {
+                    conf.extendsFrom(project.getConfigurations().getByName(configurationName));
+                    conf.setDescription("DiagnosticsManifestPlugin uses this configuration to extract single file");
+                    conf.setCanBeConsumed(true);
+                    conf.setCanBeResolved(true);
+                    conf.setVisible(false);
                 });
+
+        project.getDependencies().add(consumable.getName(), project);
+        return consumable;
     }
 
     public static <T extends TransformAction<P>, P extends TransformParameters> void configureJarTransform(

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -370,7 +370,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         createUntarBuildFile(buildFile)
 
         buildFile << """
-            dependencies { compile files("${EXTERNAL_JAR}") }
+            dependencies { implementation files("${EXTERNAL_JAR}") }
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaHome 'foo'
@@ -436,7 +436,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
     def 'produce distribution with java 8 gc logging'() {
         createUntarBuildFile(buildFile)
         buildFile << """
-            dependencies { compile files("${EXTERNAL_JAR}") }
+            dependencies { implementation files("${EXTERNAL_JAR}") }
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaHome 'foo'
@@ -483,7 +483,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
     def 'respects java version'() {
         createUntarBuildFile(buildFile)
         buildFile << """
-            dependencies { compile files("${EXTERNAL_JAR}") }
+            dependencies { implementation files("${EXTERNAL_JAR}") }
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 14
@@ -533,7 +533,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 enableManifestClasspath true
             }
             dependencies {
-              compile "com.google.guava:guava:19.0"
+              implementation "com.google.guava:guava:19.0"
             }
         '''.stripIndent()
 
@@ -782,7 +782,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
             dependencies {
                 implementation project(':child')
-                compile 'org.mockito:mockito-core:2.7.22'
+                implementation 'org.mockito:mockito-core:2.7.22'
             }
         ''')
 
@@ -845,10 +845,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             buildscript {
                 repositories {
                     mavenCentral()
-                    jcenter()
                 }
                 dependencies {
-                    classpath 'com.palantir.gradle.docker:gradle-docker:0.25.0'
+                    classpath 'com.palantir.gradle.docker:gradle-docker:0.27.0'
                 }
             }
             apply plugin: 'com.palantir.docker-compose'
@@ -914,7 +913,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
             dependencies {
                 implementation project(':child')
-                compile 'org.mockito:mockito-core:2.7.22'
+                implementation 'org.mockito:mockito-core:2.7.22'
             }
         ''')
 
@@ -1071,7 +1070,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies {
-                compile files("${EXTERNAL_JAR}")
+                implementation files("${EXTERNAL_JAR}")
                 javaAgent "net.bytebuddy:byte-buddy-agent:1.10.21"
             }
             tasks.jar.archiveBaseName = "internal"
@@ -1094,7 +1093,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies {
-                compile files("${EXTERNAL_JAR}")
+                implementation files("${EXTERNAL_JAR}")
                 javaAgent files("${EXTERNAL_JAR}")
             }
             tasks.jar.archiveBaseName = "internal"
@@ -1113,7 +1112,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
     def 'exports management packages on new javas'() {
         createUntarBuildFile(buildFile)
         buildFile << """
-            dependencies { compile files("${EXTERNAL_JAR}") }
+            dependencies { implementation files("${EXTERNAL_JAR}") }
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 17


### PR DESCRIPTION
## Before this PR
We have an internal project that tries to explicitly overwrite the minimum version of a product dependency by doing the following:

```gradle
apply plugin: 'com.palantir.sls-asset-distribution'

configurations {
    overriddenProductDependencies {
        extendsFrom assetBundle
        // Brings in a pdep with a higher version of 'com.palantir.my-service'
        exclude group: project.group, module: 'my-api-conjure-objects'
        exclude group: project.group, module: 'my-api-conjure-jersey'
    }
}

distribution {
    // We don't want to pick up the higher pdep from my-api-conjure-objects or -jersey
    // but instead hardcode the min version to 1.0.0.
    productDependenciesConfig = configurations.overriddenProductDependencies
    productDependency {
        productGroup = 'com.palantir'
        productName = 'my-service'
        minimumVersion = '1.0.0'
    }
}

```

However the problem is that sls-packaging copies the `productDependencyConfig` ([ref](https://github.com/palantir/sls-packaging/blob/4870f4363c886e304401a78c3662db8f3d4732dc/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java#L41-L42)) *before* the project build file is configured and the `overriddenProductDependencies` configuration got created.
Based on that, the default `assetBundle` configuration is used for resolving product dependencies ([ref](https://github.com/palantir/sls-packaging/blob/4ec8b15b65c1e02f3c4faeb86079a5f6497bfbce/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java#L58)) and the `overriddenProductDependencies` with its exclude rules are ignored.
As a result, the minimum version coming from `my-api-conjure-jersey` is picked up and written into the manifest.

## After this PR

FLUP on https://github.com/palantir/sls-packaging/pull/1164.

Copy and wire up the `productDependencyConfig` lazily, allowing consumers to configure the extension at any point during configuration.

Note that this increases the minimum Gradle version to 6.1.

==COMMIT_MSG==
Copy pdeps config lazily
==COMMIT_MSG==