### PR TITLE
Exclude AtlasDB schema from main class resolution

### DIFF
--- a/changelog/@unreleased/pr-1184.v2.yml
+++ b/changelog/@unreleased/pr-1184.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: AtlasDB schema classes are now ignored when resolving the main class.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1184

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/util/MainClassResolver.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/util/MainClassResolver.java
@@ -40,6 +40,8 @@ public final class MainClassResolver {
                 .map(File::toPath)
                 .flatMap(sourceDir -> allJavaFilesIn(sourceDir)
                         .filter(javaFile -> anyLinesInFileContain(javaFile, "public static void main("))
+                        .filter(javaFile ->
+                                !anyLinesInFileContain(javaFile, "com.palantir.atlasdb.table.description.Schema"))
                         .map(sourceDir::relativize))
                 .collect(Collectors.toSet());
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
@@ -45,9 +45,15 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
     def 'infers main class correctly'() {
         given:
         buildFile << """
+            dependencies {
+                implementation 'com.palantir.atlasdb:atlasdb-client:0.382.0'
+            }
+
             distribution {
                 serviceName 'service-name'
                 gc 'hybrid'
+
+                ignoredProductDependency('com.palantir.timelock', 'timelock-server')
             }
             
             // Force run to be realized eagerly
@@ -56,6 +62,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
             ${unTarTask('service-name')}
         """.stripIndent()
         file('src/main/java/test/Test.java') << mainClass('Test')
+        file('src/main/java/test/TestSchema.java') << schemaClass('TestSchema')
 
         when:
         runTasks(':untar')
@@ -129,4 +136,15 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
         """.stripIndent()
     }
 
+    static def schemaClass(String className) {
+        return """
+        package test;
+        import com.palantir.atlasdb.table.description.Schema;
+        public class ${className} {
+            public static void main(String[] args) {
+                while(true);
+            }
+        }
+        """.stripIndent()
+    }
 }


### PR DESCRIPTION
Attempting to use V2 of our internal AtlasDB Gradle plugin in some internal repos.

Unfortunately, because the schema files are part of the main source set, `MainClassResolver` finds both the schema class and the server class.

This PR updates `MainClassResolver` to ignore any files that import the AtlasDB `Schema` class. Server classes should never need to reference the `Schema` class directly - I've verified this is true in all internal repos.

I've verified this works as expected using `publishToMavenLocal` with an internal repo.