### PR TITLE
Include launcher-static.yml in config tars

### DIFF
--- a/changelog/@unreleased/pr-1191.v2.yml
+++ b/changelog/@unreleased/pr-1191.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include `service/bin/launcher-static.yml` in java config tars.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1191

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -99,7 +99,7 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
                     }));
         }));
 
-        TaskProvider<Tar> configTar = ConfigTarTask.createConfigTarTask(project, distributionExtension);
+        TaskProvider<ConfigTarTask> configTar = ConfigTarTask.createConfigTarTask(project, distributionExtension);
         configTar.configure(task -> task.dependsOn(manifest));
 
         project.getArtifacts().add(SlsBaseDistPlugin.SLS_CONFIGURATION_NAME, distTar);

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -25,6 +25,8 @@ import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Tar;
 
 final class DistTarTask {
+    static final String SCRIPTS_DIST_LOCATION = "service/bin";
+
     static void configure(
             Project project,
             Tar distTarTask,
@@ -66,7 +68,7 @@ final class DistTarTask {
                 t.from(project.getConfigurations().named("javaAgent"));
             });
 
-            root.into("service/bin", t -> {
+            root.into(SCRIPTS_DIST_LOCATION, t -> {
                 t.from(project.getLayout().getBuildDirectory().dir("scripts"));
                 t.setFileMode(0755);
             });

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -243,7 +243,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         TaskProvider<ConfigTarTask> configTar = ConfigTarTask.createConfigTarTask(project, distributionExtension);
         configTar.configure(task -> {
             task.from(launchConfigTask.flatMap(LaunchConfigTask::getStaticLauncher), copySpec -> {
-                copySpec.into("service/bin");
+                copySpec.into(DistTarTask.SCRIPTS_DIST_LOCATION);
             });
             task.dependsOn(manifest);
         });

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -240,8 +240,13 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         TaskProvider<CreateManifestTask> manifest =
                 CreateManifestTask.createManifestTask(project, distributionExtension);
 
-        TaskProvider<Tar> configTar = ConfigTarTask.createConfigTarTask(project, distributionExtension);
-        configTar.configure(task -> task.dependsOn(manifest));
+        TaskProvider<ConfigTarTask> configTar = ConfigTarTask.createConfigTarTask(project, distributionExtension);
+        configTar.configure(task -> {
+            task.from(launchConfigTask.flatMap(LaunchConfigTask::getStaticLauncher), copySpec -> {
+                copySpec.into("service/bin");
+            });
+            task.dependsOn(manifest);
+        });
 
         TaskProvider<JavaExec> runTask = project.getTasks().register("run", JavaExec.class, task -> {
             task.setGroup(JavaServiceDistributionPlugin.GROUP_NAME);

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -46,6 +46,11 @@ public class ConfigTarTask extends Tar {
     @Override
     public final AbstractCopyTask from(Object sourcePath, Action<? super CopySpec> configureAction) {
         return super.from(sourcePath, copySpec -> {
+            // These from tasks are overriden so we can set a default `into` on each from copyspec. Originally, the
+            // task level `into` was set to `deployment`, which forced all files into the `deployment` directory.
+            // However, with launcher-static.yml, we want to keep it at the same path as the dist, in service/bin/,
+            // for consistency. However, other plugins (like hyperion) add their own custom `from`s, so to maintain
+            // backcompat we override all the froms and set the default per from into to be `deployment`.
             copySpec.into("deployment");
             configureAction.execute(copySpec);
         });

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -46,7 +46,7 @@ public class ConfigTarTask extends Tar {
     @Override
     public final AbstractCopyTask from(Object sourcePath, Action<? super CopySpec> configureAction) {
         return super.from(sourcePath, copySpec -> {
-            // These from tasks are overriden so we can set a default `into` on each from copyspec. Originally, the
+            // These from methods are overriden so we can set a default `into` on each from copyspec. Originally, the
             // task level `into` was set to `deployment`, which forced all files into the `deployment` directory.
             // However, with launcher-static.yml, we want to keep it at the same path as the dist, in service/bin/,
             // for consistency. However, other plugins (like hyperion) add their own custom `from`s, so to maintain

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
@@ -16,16 +16,17 @@
 
 package com.palantir.gradle.dist.tasks
 
-import com.palantir.gradle.dist.GradleIntegrationSpec
 
-class ConfigTarTaskIntegrationSpec extends GradleIntegrationSpec {
+import nebula.test.IntegrationSpec
+
+class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
 
     def 'configTar task exists for services'() {
         setup:
         createUntarBuildFile(buildFile, "java-service", "service", "foo-service")
 
         when:
-        runTasks(':configTar')
+        runTasksSuccessfully(':configTar')
 
         then:
         fileExists('build/distributions/foo-service-0.0.1.service.config.tgz')
@@ -36,7 +37,7 @@ class ConfigTarTaskIntegrationSpec extends GradleIntegrationSpec {
         createUntarBuildFile(buildFile, "asset", "asset", "foo-asset")
 
         when:
-        runTasks(':configTar')
+        runTasksSuccessfully(':configTar')
 
         then:
         fileExists('build/distributions/foo-asset-0.0.1.asset.config.tgz')
@@ -47,14 +48,15 @@ class ConfigTarTaskIntegrationSpec extends GradleIntegrationSpec {
         createUntarBuildFile(buildFile, "java-service", "service", "foo-service")
 
         when:
-        runTasks(':configTar', ':untar')
+        runTasksSuccessfully(':configTar', ':untar')
 
         then:
         def files = directory('dist/foo-service-0.0.1/', projectDir).list()
-        files.length == 1
+        files.length == 2
         files.contains('deployment')
         def manifest = file('dist/foo-service-0.0.1/deployment/manifest.yml', projectDir).text
         manifest.contains('service.v1')
+        file('dist/foo-service-0.0.1/service/bin/launcher-static.yml')
     }
 
     def 'configTar task contains the necessary deployment files for assets'() {
@@ -62,7 +64,7 @@ class ConfigTarTaskIntegrationSpec extends GradleIntegrationSpec {
         createUntarBuildFile(buildFile, "asset", "asset", "foo-asset")
 
         when:
-        runTasks(':configTar', ':untar')
+        runTasksSuccessfully(':configTar', ':untar')
 
         then:
         def files = directory('dist/foo-asset-0.0.1/', projectDir).list()
@@ -74,12 +76,13 @@ class ConfigTarTaskIntegrationSpec extends GradleIntegrationSpec {
 
     private static createUntarBuildFile(buildFile, pluginType, artifactType, name) {
         buildFile << """
-            plugins {
-                id 'com.palantir.sls-${pluginType}-distribution'
-            }
+            apply plugin: 'com.palantir.sls-${pluginType}-distribution'
             
             distribution {
                 serviceName '${name}'
+                if ('${artifactType}' == 'service') {
+                    mainClass 'main.Main'
+                }
             }
 
             version "0.0.1"

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
@@ -51,12 +51,12 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
         runTasksSuccessfully(':configTar', ':untar')
 
         then:
-        def files = directory('dist/foo-service-0.0.1/', projectDir).list()
+        def files = new File(projectDir, 'dist/foo-service-0.0.1/').list()
         files.length == 2
         files.contains('deployment')
-        def manifest = file('dist/foo-service-0.0.1/deployment/manifest.yml', projectDir).text
+        def manifest = new File(projectDir, 'dist/foo-service-0.0.1/deployment/manifest.yml').text
         manifest.contains('service.v1')
-        file('dist/foo-service-0.0.1/service/bin/launcher-static.yml')
+        fileExists('dist/foo-service-0.0.1/service/bin/launcher-static.yml')
     }
 
     def 'configTar task contains the necessary deployment files for assets'() {
@@ -67,10 +67,10 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
         runTasksSuccessfully(':configTar', ':untar')
 
         then:
-        def files = directory('dist/foo-asset-0.0.1/', projectDir).list()
+        def files = new File(projectDir, 'dist/foo-asset-0.0.1/').list()
         files.length == 1
         files.contains('deployment')
-        def manifest = file('dist/foo-asset-0.0.1/deployment/manifest.yml', projectDir).text
+        def manifest = new File(projectDir, 'dist/foo-asset-0.0.1/deployment/manifest.yml').text
         manifest.contains('asset.v1')
     }
 


### PR DESCRIPTION
## Before this PR
`launcher-static.yml` is not included in config tgzs, meaning in dev-env we must use artifcatory paths like `/internal-dist/group/name/version/big-dist.tgz!service/bin/launcher-static.yml`. This means we put a lot of cpu load on artifactory and it can take a long time to download.

## After this PR
==COMMIT_MSG==
Include `service/bin/launcher-static.yml` in java config tars.
==COMMIT_MSG==

This will allow dev-env to download a much smaller config tgz instead, which should be pretty much instant.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

