### PR TITLE
Reduce level of noisy log

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -214,7 +214,7 @@ public abstract class CreateManifestTask extends DefaultTask {
         if (!OrderableSlsVersion.check(stringVersion)) {
             getProject()
                     .getLogger()
-                    .warn(
+                    .info(
                             "Version string in project {} is not orderable as per SLS specification: {}",
                             getProject().getName(),
                             stringVersion);


### PR DESCRIPTION
This log is emitted anytime your repo is in a dirty state.

This PR reduces the level from warn to info so it is not logged by default.