### PR TITLE
Fix: Add missing task dependencies to configtar task

### DIFF
--- a/changelog/@unreleased/pr-1201.v2.yml
+++ b/changelog/@unreleased/pr-1201.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Declare missing task dependencies of configTar task
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1201

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -242,7 +242,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.from(launchConfigTask.flatMap(LaunchConfigTask::getStaticLauncher), copySpec -> {
                 copySpec.into(DistTarTask.SCRIPTS_DIST_LOCATION);
             });
-            task.dependsOn(manifest);
+            task.dependsOn(manifest, launchConfigTask, startScripts, copyLauncherBinaries);
         });
 
         TaskProvider<JavaExec> runTask = project.getTasks().register("run", JavaExec.class, task -> {


### PR DESCRIPTION
## Before this PR
Gradle would complain that we are using deprecated behaviour of using outputs without declaring task ordering

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Declare missing task dependencies of configTar task
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

