### PR TITLE
Allow product dependency to also be declared as optional

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesTask.java
@@ -109,12 +109,6 @@ public abstract class ResolveProductDependenciesTask extends DefaultTask {
                                 + "dependency or ignore",
                         productId));
             }
-            if (getOptionalProductIds().get().contains(productId)) {
-                throw new IllegalArgumentException(String.format(
-                        "Encountered product dependency declaration that was also declared as optional for '%s', "
-                                + "either remove the dependency or optional declaration",
-                        productId));
-            }
             allProductDependencies.merge(
                     productId, declaredDep, (dep1, dep2) -> mergeDependencies(productId, dep1, dep2));
             if (declaredDep.getOptional()) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesTaskSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesTaskSpec.groovy
@@ -65,16 +65,6 @@ class ResolveProductDependenciesTaskSpec extends ProjectSpec {
         e.message.contains("Encountered product dependency declaration that was also ignored")
     }
 
-    def 'throws if declared dependency is also optional'() {
-        when:
-        task.optionalProductIds.add(PRODUCT_ID)
-        task.computeDependencies(List.of(PDEP), ImmutableSetMultimap.of())
-
-        then:
-        def e = thrown IllegalArgumentException
-        e.message.contains("Encountered product dependency declaration that was also declared as optional")
-    }
-
     def "throws on declared self-dependency"() {
         when:
         task.serviceGroup.set("group")


### PR DESCRIPTION
## Before this PR
To declare an optional dependency that is not discovered, you have to do:
```
productDependency {
    productGroup = 'com.palantir.foo'
    productName = 'foo-service'
    minimumVersion = '1.2.3'
    optional = true
}
```

It would be much nicer if we could use the shorthand that looks similar to dependencies for these optional dependencies.

## After this PR
To declare an optional dependency that is not discovered, you can do:
```java
productDependency 'com.palantir.foo:foo-service:1.2.3'

optionalProductDependency 'com.palantir.foo:foo-service'
```

Alternatively we could allow something like:
```
optionalProductDependency 'com.palantir.foo:foo-service:1.2.3'
```

But this is trickier because it conflicts with the existing method.