### PR TITLE
Apply `--add-exports` to Java 16+ services based on manifest entries

### DIFF
--- a/changelog/@unreleased/pr-1215.v2.yml
+++ b/changelog/@unreleased/pr-1215.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Apply `--add-exports` to Java 16+ services based on manifest entries
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1215

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -60,11 +60,6 @@ public abstract class LaunchConfigTask extends DefaultTask {
             ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
     private static final ImmutableList<String> java15Options =
             ImmutableList.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+ExpandSubTypeCheckAtParseTime");
-    // Support safepoint metrics from the internal sun.management package in production. We prefer not
-    // to use '--illegal-access=permit' so that we can avoid unintentional and unbounded illegal access
-    // that we aren't aware of.
-    private static final ImmutableList<String> java16PlusOptions =
-            ImmutableList.of("--add-exports", "java.management/sun.management=ALL-UNNAMED");
     private static final ImmutableList<String> disableBiasedLocking = ImmutableList.of("-XX:-UseBiasedLocking");
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
@@ -199,10 +194,7 @@ public abstract class LaunchConfigTask extends DefaultTask {
                                 javaVersion.get().compareTo(JavaVersion.toVersion("15")) < 0
                                         ? disableBiasedLocking
                                         : ImmutableList.of())
-                        .addAllJvmOpts(
-                                javaVersion.get().compareTo(JavaVersion.toVersion("16")) >= 0
-                                        ? java16PlusOptions
-                                        : ImmutableList.of())
+                        .addAllJvmOpts(ModuleExports.getExports(getProject(), javaVersion.get(), getClasspath()))
                         .addAllJvmOpts(gcJvmOptions.get())
                         .addAllJvmOpts(defaultJvmOpts.get())
                         .putAllEnv(defaultEnvironment)

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
@@ -27,7 +27,11 @@ import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 
 /**
- * Utility functionality which mirrors {@code Add-Exports} plumbing from
+ * This utility class reuses the {@code Add-Exports} manifest entry defined in
+ * <a href="https://openjdk.java.net/jeps/261">JEP-261</a> to collect required exports
+ * from the runtime classpath so they may be applied to the static configuration.
+ *
+ * Note that this mirrors {@code Add-Exports} plumbing from
  * <a href="https://github.com/palantir/gradle-baseline/pull/1944">gradle-baseline#1944</a>.
  */
 final class ModuleExports {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
@@ -44,7 +44,7 @@ final class ModuleExports {
 
     static ImmutableList<String> getExports(Project project, JavaVersion javaVersion, FileCollection classpath) {
         // --add-exports is unnecessary prior to java 16
-        if (javaVersion.compareTo(JavaVersion.VERSION_16) < 0) {
+        if (javaVersion.compareTo(JavaVersion.toVersion("16")) < 0) {
             return ImmutableList.of();
         }
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.service.tasks;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+
+/**
+ * Utility functionality which mirrors {@code Add-Exports} plumbing from
+ * <a href="https://github.com/palantir/gradle-baseline/pull/1944">gradle-baseline#1944</a>.
+ */
+final class ModuleExports {
+
+    private static final String ADD_EXPORTS_ATTRIBUTE = "Add-Exports";
+    private static final Splitter EXPORT_SPLITTER =
+            Splitter.on(' ').trimResults().omitEmptyStrings();
+
+    // Exists for backcompat until infrastructure has rolled out with Add-Exports manifest values.
+    // Support safepoint metrics from the internal sun.management package in production. We prefer not
+    // to use '--illegal-access=permit' so that we can avoid unintentional and unbounded illegal access
+    // that we aren't aware of.
+    private static final ImmutableList<String> DEFAULT_EXPORTS = ImmutableList.of("java.management/sun.management");
+
+    static ImmutableList<String> getExports(Project project, JavaVersion javaVersion, FileCollection classpath) {
+        // --add-exports is unnecessary prior to java 16
+        if (javaVersion.compareTo(JavaVersion.VERSION_16) < 0) {
+            return ImmutableList.of();
+        }
+
+        return Stream.concat(
+                        classpath.getFiles().stream().flatMap(file -> {
+                            try {
+                                if (file.getName().endsWith(".jar") && file.isFile()) {
+                                    JarFile jar = new JarFile(file);
+                                    String value = jar.getManifest()
+                                            .getMainAttributes()
+                                            .getValue(ADD_EXPORTS_ATTRIBUTE);
+                                    if (Strings.isNullOrEmpty(value)) {
+                                        return Stream.empty();
+                                    }
+                                    project.getLogger()
+                                            .debug(
+                                                    "Found manifest entry {}: {} in jar {}",
+                                                    ADD_EXPORTS_ATTRIBUTE,
+                                                    value,
+                                                    file);
+                                    return EXPORT_SPLITTER.splitToStream(value);
+                                }
+                                return Stream.empty();
+                            } catch (IOException e) {
+                                project.getLogger().warn("Failed to check jar {} for manifest attributes", file, e);
+                                return Stream.empty();
+                            }
+                        }),
+                        DEFAULT_EXPORTS.stream())
+                .distinct()
+                .sorted()
+                .flatMap(modulePackagePair -> Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED"))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    private ModuleExports() {}
+}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
@@ -56,20 +56,21 @@ final class ModuleExports {
                         classpath.getFiles().stream().flatMap(file -> {
                             try {
                                 if (file.getName().endsWith(".jar") && file.isFile()) {
-                                    JarFile jar = new JarFile(file);
-                                    String value = jar.getManifest()
-                                            .getMainAttributes()
-                                            .getValue(ADD_EXPORTS_ATTRIBUTE);
-                                    if (Strings.isNullOrEmpty(value)) {
-                                        return Stream.empty();
+                                    try (JarFile jar = new JarFile(file)) {
+                                        String value = jar.getManifest()
+                                                .getMainAttributes()
+                                                .getValue(ADD_EXPORTS_ATTRIBUTE);
+                                        if (Strings.isNullOrEmpty(value)) {
+                                            return Stream.empty();
+                                        }
+                                        project.getLogger()
+                                                .debug(
+                                                        "Found manifest entry {}: {} in jar {}",
+                                                        ADD_EXPORTS_ATTRIBUTE,
+                                                        value,
+                                                        file);
+                                        return EXPORT_SPLITTER.splitToStream(value);
                                     }
-                                    project.getLogger()
-                                            .debug(
-                                                    "Found manifest entry {}: {} in jar {}",
-                                                    ADD_EXPORTS_ATTRIBUTE,
-                                                    value,
-                                                    file);
-                                    return EXPORT_SPLITTER.splitToStream(value);
                                 }
                                 return Stream.empty();
                             } catch (IOException e) {


### PR DESCRIPTION
This provides the same functionality as
https://github.com/palantir/gradle-baseline/pull/1944/

We're piggy-backing off the `Add-Exports` manifest property to collect exports required for any given application based on the libraries it uses.

==COMMIT_MSG==
Apply `--add-exports` to Java 16+ services based on manifest entries
==COMMIT_MSG==

