### PR TITLE
Fix the Throughput GC on java 14+: use `-XX:+UseParallelGC` rather than `-XX:+UseParallelOldGC`

### DIFF
--- a/changelog/@unreleased/pr-1220.v2.yml
+++ b/changelog/@unreleased/pr-1220.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'Fix the Throughput GC on java 14+: use `-XX:+UseParallelGC` rather
+    than `-XX:+UseParallelOldGC`'
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1220

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -39,7 +39,7 @@ public interface GcProfile extends Serializable {
     class Throughput implements GcProfile {
         @Override
         public final List<String> gcJvmOpts(JavaVersion _javaVersion) {
-            return ImmutableList.of("-XX:+UseParallelOldGC");
+            return ImmutableList.of("-XX:+UseParallelGC");
         }
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -402,7 +402,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
                 '-XX:NativeMemoryTracking=summary',
-                '-XX:+UseParallelOldGC',
+                '-XX:+UseParallelGC',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
             .env(LaunchConfigTask.defaultEnvironment + [
@@ -473,7 +473,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "-Xloggc:var/log/gc-%t-%p.log",
                 "-verbose:gc",
                 "-XX:-UseBiasedLocking",
-                '-XX:+UseParallelOldGC',
+                '-XX:+UseParallelGC',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
             .dirs(["var/data/tmp"])


### PR DESCRIPTION
Java 14 and 15 ignore the `UseParallelOldGC` option entirely (using the g1gc defaults)

Java 16+ _fails to start_ when `-XX:+UseParallelOldGC` is provided.

Using java 8, the new value is equivalent to the old:
```
[~]$ ~/.tools/jdk/jdk-8/bin/java -XX:+UseParallelOldGC -XX:+PrintFlagsFinal -version > UseParallelOldGC.out
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (Zulu 8.52.0.23-CA-linux64) (build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (Zulu 8.52.0.23-CA-linux64) (build 25.282-b08, mixed mode)
[~]$ ~/.tools/jdk/jdk-8/bin/java -XX:+UseParallelGC -XX:+PrintFlagsFinal -version > UseParallelGC.out
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (Zulu 8.52.0.23-CA-linux64) (build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (Zulu 8.52.0.23-CA-linux64) (build 25.282-b08, mixed mode)
[~]$ diff UseParallelOldGC.out UseParallelGC.out
697,698c697,698
<      bool UseParallelGC                             = true                                {product}
<      bool UseParallelOldGC                         := true                                {product}
---
>      bool UseParallelGC                            := true                                {product}
>      bool UseParallelOldGC                          = true                                {product}
```

## Before this PR
java 16 and 17 fail to launch. Java 14 and 15 use unexpected and incorrect GCs

## After this PR
==COMMIT_MSG==
Fix the Throughput GC on java 14+: use `-XX:+UseParallelGC` rather than `-XX:+UseParallelOldGC`
==COMMIT_MSG==

## Possible downsides?
It's a change, I opted to apply the new option across the board because it appears safe, not to apply it only to java 14+.

