### PR TITLE
Module export discovery handles jars with no manifest gracefully

### DIFF
--- a/changelog/@unreleased/pr-1221.v2.yml
+++ b/changelog/@unreleased/pr-1221.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Module export discovery handles jars with no manifest gracefully
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1221

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleExports.java
@@ -57,9 +57,13 @@ final class ModuleExports {
                             try {
                                 if (file.getName().endsWith(".jar") && file.isFile()) {
                                     try (JarFile jar = new JarFile(file)) {
-                                        String value = jar.getManifest()
-                                                .getMainAttributes()
-                                                .getValue(ADD_EXPORTS_ATTRIBUTE);
+                                        java.util.jar.Manifest jarManifest = jar.getManifest();
+                                        if (jarManifest == null) {
+                                            project.getLogger().debug("Jar '{}' has no manifest", file);
+                                            return Stream.empty();
+                                        }
+                                        String value =
+                                                jarManifest.getMainAttributes().getValue(ADD_EXPORTS_ATTRIBUTE);
                                         if (Strings.isNullOrEmpty(value)) {
                                             return Stream.empty();
                                         }


### PR DESCRIPTION
## Before this PR
NPE!

## After this PR
==COMMIT_MSG==
Module export discovery handles jars with no manifest gracefully
==COMMIT_MSG==

