### PR TITLE
Explicitly declare variant for resolving product dependencies

### DIFF
--- a/changelog/@unreleased/pr-1272.v2.yml
+++ b/changelog/@unreleased/pr-1272.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Explicitly declare variant for resolving product dependencies
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1272

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist.artifacts;
 
+import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
@@ -49,7 +50,12 @@ public final class DependencyDiscovery {
             conf.setVisible(false);
         });
 
-        project.getDependencies().add(consumable.getName(), project);
+        // Explicitly declare the configuration to depend on to avoid resolution failures due to ambiguous variants.
+        Map<String, String> projectDependency =
+                Map.of("path", project.getPath(), "configuration", consumable.getName());
+        project.getDependencies()
+                .add(consumable.getName(), project.getDependencies().project(projectDependency));
+
         return consumable;
     }
 


### PR DESCRIPTION
## Before this PR
When used in combination with other internal Gradle plugins, we would run into the issue of resolving the product dependencies configuration due to Gradle failing to choose between variants.

This would manifest in the task `resolveProductDependencies` failing with:

```
Could not determine the dependencies of task ':my-project:resolveProductDependencies'.
> Could not resolve all task dependencies for configuration ':my-project:assetBundleForProductDependencies'.
   > Could not resolve project :my-project.
     Required by:
         project :my-project
      > Cannot choose between the following variants of project :my-project:
          - apiElements
          - consistentVersionsPlaceholder
          - depsForPdeps
          - runtimeElements
          - sls
          - [...]
        All of them match the consumer attributes:
          - Variant 'apiElements' capability <project dep coordinate>:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.dependency.bundling 'external' but the consumer didn't ask for it
                  - Provides org.gradle.jvm.version '11' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-api' but the consumer didn't ask for it
          - Variant 'consistentVersionsPlaceholder' capability <project dep coordinate>:
              - Unmatched attributes:
                  - Provides com.palantir.consistent-versions.usage 'GCV_SOURCE' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'consistent-versions-usage' but the consumer didn't ask for it
          - Variant 'depsForPdeps' capability <project dep coordinate>:
              - Unmatched attributes:
                  - Provides artifactType 'module' but the consumer didn't ask for it
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'typescript-api' but the consumer didn't ask for it
          - [...]
```

## After this PR

I think the issue we are seeing is that the consumer (the `resolveProductDependencies` task), can't distinguish between the provided variants of the copied pdeps configuration. To help Gradle pick a variant in these situations, we can explicitly declare the variant to resolve as part of the dependency constraint.

==COMMIT_MSG==
Explicitly declare variant for resolving product dependencies
==COMMIT_MSG==

## Possible downsides

Hard to reproduce the error in the context of this repo. Manually tested compatibility with an internal service and will add an integration test to the other internal Gradle plugin to verify that both are now compatible after this change.
