### PR TITLE
Fix #1230 Increase default JFR stack depth to 256 frames (from 64)

### DIFF
--- a/changelog/@unreleased/pr-1282.v2.yml
+++ b/changelog/@unreleased/pr-1282.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increase default JFR stack depth to 256 frames (from 64)
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1282

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -70,7 +70,11 @@ public abstract class LaunchConfigTask extends DefaultTask {
             // Set DNS cache TTL to 20s to account for systems such as RDS and other
             // AWS-managed systems that modify DNS records on failover.
             "-Dsun.net.inetaddr.ttl=20",
-            "-XX:NativeMemoryTracking=summary");
+            "-XX:NativeMemoryTracking=summary",
+            // Increase default JFR stack depth beyond the default (conservative) 64 frames.
+            // This can be overridden by user-provided options.
+            // See sls-packaging#1230
+            "-XX:FlightRecorderOptions=stackdepth=256");
 
     // Reduce memory usage for some versions of glibc.
     // Default value is 8 * CORES.

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -407,6 +407,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
                 '-XX:NativeMemoryTracking=summary',
+                '-XX:FlightRecorderOptions=stackdepth=256',
                 '-XX:+UseParallelGC',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
@@ -431,6 +432,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
                 '-XX:NativeMemoryTracking=summary',
+                '-XX:FlightRecorderOptions=stackdepth=256',
                 '-Xmx4M',
                 '-Djavax.net.ssl.trustStore=truststore.jks'])
             .env(LaunchConfigTask.defaultEnvironment)
@@ -469,6 +471,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=20',
                 '-XX:NativeMemoryTracking=summary',
+                '-XX:FlightRecorderOptions=stackdepth=256',
                 "-XX:+PrintGCDateStamps",
                 "-XX:+PrintGCDetails",
                 "-XX:-TraceClassUnloading",


### PR DESCRIPTION
Fix #1230
==COMMIT_MSG==
Increase default JFR stack depth to 256 frames (from 64)
==COMMIT_MSG==

