### PR TITLE
Update go-java-launcher to 1.17.0 (was 1.15.0)

### DIFF
--- a/changelog/@unreleased/pr-1289.v2.yml
+++ b/changelog/@unreleased/pr-1289.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update go-java-launcher to 1.17.0 (was 1.15.0)
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1289

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -55,7 +55,7 @@ import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.util.GradleVersion;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
-    private static final String GO_JAVA_VERSION = "1.15.0";
+    private static final String GO_JAVA_VERSION = "1.17.0";
     private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher:" + GO_JAVA_VERSION;
     private static final String GO_INIT = "com.palantir.launching:go-init:" + GO_JAVA_VERSION;
     public static final String GROUP_NAME = "Distribution";


### PR DESCRIPTION
## After this PR

Update go-java-launcher to 1.17.0, especially to pick up the updated go version added in https://github.com/palantir/go-java-launcher/pull/186 which contains fixes for multiple CVEs (e.g. CVE-2022-23772, CVE-2022-23806).

==COMMIT_MSG==
Update go-java-launcher to 1.17.0 (was 1.15.0)
==COMMIT_MSG==
