### PR TITLE
Read go-java-launcher version from properties

### DIFF
--- a/gradle-sls-packaging/src/main/resources/go-java-version.properties
+++ b/gradle-sls-packaging/src/main/resources/go-java-version.properties
@@ -1,0 +1,3 @@
+# Version of https://github.com/palantir/go-java-launcher to use. Kept up-to-date by excavator.
+# If you move this file, please make sure to update the respective excavator.
+go-java-version=1.17.0


### PR DESCRIPTION
## After this PR
Move the go-java-launcher version to a properties file. This will make it easier for us to automatically update this via excavator.

==COMMIT_MSG==
Read go-java-launcher version from properties
==COMMIT_MSG==