### PR TITLE
Bump go-java-launcher to 1.19.0 due to CVE in 1.18.0

### DIFF
--- a/changelog/@unreleased/pr-1328.v2.yml
+++ b/changelog/@unreleased/pr-1328.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump go-java-launcher to 1.19.0 due to CVE in 1.18.0
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1328

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -57,7 +57,7 @@ import org.gradle.util.GradleVersion;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     // Used as fallback version if no higher version is specified in 'versions.props'.
-    private static final String FALLBACK_GO_JAVA_VERSION = "1.18.0";
+    private static final String FALLBACK_GO_JAVA_VERSION = "1.19.0";
     private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher";
     private static final String GO_INIT = "com.palantir.launching:go-init";
     public static final String GROUP_NAME = "Distribution";


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

