### PR TITLE
Simplify .config.tgz extension

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -17,11 +17,9 @@
 package com.palantir.gradle.dist.tasks;
 
 import com.palantir.gradle.dist.BaseDistributionExtension;
-import com.palantir.gradle.dist.ObjectMappers;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import groovy.lang.Closure;
 import java.io.File;
-import java.io.IOException;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
@@ -70,16 +68,7 @@ public class ConfigTarTask extends Tar {
             task.getArchiveBaseName().set(ext.getDistributionServiceName());
             task.getArchiveVersion()
                     .set(project.provider(() -> project.getVersion().toString()));
-            task.getArchiveExtension().set(ext.getProductType().map(productType -> {
-                try {
-                    String productTypeString = ObjectMappers.jsonMapper.writeValueAsString(productType);
-                    return productTypeString
-                            .substring(1, productTypeString.lastIndexOf('.'))
-                            .concat(".config.tgz");
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }));
+            task.getArchiveExtension().set("config.tgz");
         });
 
         // TODO(forozco): make this lazy since into does not support providers, but does support callable

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
         runTasksSuccessfully(':configTar')
 
         then:
-        fileExists('build/distributions/foo-service-0.0.1.service.config.tgz')
+        fileExists('build/distributions/foo-service-0.0.1.config.tgz')
     }
 
     def 'configTar task exists for assets'() {
@@ -40,7 +40,7 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
         runTasksSuccessfully(':configTar')
 
         then:
-        fileExists('build/distributions/foo-asset-0.0.1.asset.config.tgz')
+        fileExists('build/distributions/foo-asset-0.0.1.config.tgz')
     }
 
     def 'configTar task contains the necessary deployment files for services'() {
@@ -92,7 +92,7 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
 
             // most convenient way to untar the dist is to use gradle
             task untar (type: Copy) {
-                from tarTree(resources.gzip("\${buildDir}/distributions/${name}-0.0.1.${artifactType}.config.tgz"))
+                from tarTree(resources.gzip("\${buildDir}/distributions/${name}-0.0.1.config.tgz"))
                 into "\${projectDir}/dist"
                 dependsOn configTar
             }


### PR DESCRIPTION
## Before this PR
We've got a PR to update the sls-spec and change the extension we publish this to.

## After this PR
==COMMIT_MSG==
The `configTar` task now publishes with an extension of `.config.tgz` instead of `{type}.config.tgz`
==COMMIT_MSG==

Just adding `do not merge` until the internal sls-spec PR _actually_ merges.

Also open question - do we want to call this a `break`??

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

