### PR TITLE
Make ModuleArgs expand manifest classpath JARs for exports and opens

### DIFF
--- a/changelog/@unreleased/pr-1349.v2.yml
+++ b/changelog/@unreleased/pr-1349.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Make ModuleArgs expand manifest classpath JARs for exports and opens
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1349

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -306,6 +306,11 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
 
         project.afterEvaluate(_p -> launchConfigTask.configure(task -> {
             task.getJavaAgents().setFrom(javaAgentConfiguration);
+            task.getFullClasspath()
+                    .from(jarTask.get()
+                            .getOutputs()
+                            .getFiles()
+                            .plus(distributionExtension.getProductDependenciesConfig()));
             task.getClasspath()
                     .from(
                             distributionExtension.getEnableManifestClasspath().get()

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -306,19 +306,14 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
 
         project.afterEvaluate(_p -> launchConfigTask.configure(task -> {
             task.getJavaAgents().setFrom(javaAgentConfiguration);
-            task.getFullClasspath()
-                    .from(jarTask.get()
-                            .getOutputs()
-                            .getFiles()
-                            .plus(distributionExtension.getProductDependenciesConfig()));
+            FileCollection fullClasspath =
+                    jarTask.get().getOutputs().getFiles().plus(distributionExtension.getProductDependenciesConfig());
+            task.getFullClasspath().from(fullClasspath);
             task.getClasspath()
                     .from(
                             distributionExtension.getEnableManifestClasspath().get()
                                     ? manifestClassPathTask.get().getOutputs().getFiles()
-                                    : jarTask.get()
-                                            .getOutputs()
-                                            .getFiles()
-                                            .plus(distributionExtension.getProductDependenciesConfig()));
+                                    : fullClasspath);
         }));
 
         project.afterEvaluate(_proj -> distTar.configure(task -> {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -157,6 +157,15 @@ public abstract class LaunchConfigTask extends DefaultTask {
     @InputFiles
     public abstract ConfigurableFileCollection getClasspath();
 
+    /**
+     * The difference between fullClasspath and classpath is that classpath is what is written
+     * to the launcher-static.yml file, this <i>might</i> in some cases be the manifest classpath
+     * JAR. Full Classpath on the other hand is always going to be the full set of JARs which may
+     * be the same as classpath if manifest classpath JARs are not used.
+     */
+    @InputFiles
+    public abstract ConfigurableFileCollection getFullClasspath();
+
     @InputFiles
     public abstract ConfigurableFileCollection getJavaAgents();
 
@@ -198,7 +207,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
                                 javaVersion.get().compareTo(JavaVersion.toVersion("15")) < 0
                                         ? disableBiasedLocking
                                         : ImmutableList.of())
-                        .addAllJvmOpts(ModuleArgs.collectClasspathArgs(getProject(), javaVersion.get(), getClasspath()))
+                        .addAllJvmOpts(
+                                ModuleArgs.collectClasspathArgs(getProject(), javaVersion.get(), getFullClasspath()))
                         .addAllJvmOpts(gcJvmOptions.get())
                         .addAllJvmOpts(defaultJvmOpts.get())
                         .putAllEnv(defaultEnvironment)

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleArgs.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleArgs.java
@@ -19,15 +19,11 @@ package com.palantir.gradle.dist.service.tasks;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.jar.Attributes;
 import java.util.jar.JarFile;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.gradle.api.JavaVersion;
@@ -64,9 +60,7 @@ final class ModuleArgs {
             return ImmutableList.of();
         }
 
-        Set<File> classpathFiles = loadAllClasspathFiles(project, classpath);
-
-        ImmutableList<JarManifestModuleInfo> classpathInfo = classpathFiles.stream()
+        ImmutableList<JarManifestModuleInfo> classpathInfo = classpath.getFiles().stream()
                 .map(file -> {
                     try {
                         if (file.getName().endsWith(".jar") && file.isFile()) {
@@ -77,6 +71,8 @@ final class ModuleArgs {
                                         .debug("Jar '{}' produced manifest info: {}", file, parsedModuleInfo);
                                 return parsedModuleInfo.orElse(null);
                             }
+                        } else {
+                            project.getLogger().info("File {} wasn't a JAR or file", file);
                         }
                         return null;
                     } catch (IOException e) {
@@ -97,33 +93,6 @@ final class ModuleArgs {
                 .sorted()
                 .flatMap(ModuleArgs::addOpensArg);
         return Stream.concat(exports, opens).collect(ImmutableList.toImmutableList());
-    }
-
-    private static Set<File> loadAllClasspathFiles(Project project, FileCollection classpath) {
-        return classpath.getFiles().stream()
-                .filter(f -> f.isFile() && f.getName().endsWith(".jar"))
-                .flatMap(f -> {
-                    try (JarFile jar = new JarFile(f)) {
-                        java.util.jar.Manifest jarManifest = jar.getManifest();
-                        if (jarManifest == null) {
-                            return Stream.empty();
-                        }
-
-                        List<String> classpathEntries =
-                                readManifestAttribute(jarManifest, Attributes.Name.CLASS_PATH.toString());
-
-                        if (classpathEntries.isEmpty()) {
-                            return Stream.of(f);
-                        }
-
-                        return Stream.concat(
-                                Stream.of(f), classpathEntries.stream().map(e -> new File(f.getParentFile(), e)));
-                    } catch (IOException e) {
-                        project.getLogger().warn("Failed to load manifest entry for jar {}", f, e);
-                        return Stream.empty();
-                    }
-                })
-                .collect(Collectors.toSet());
     }
 
     private static Optional<JarManifestModuleInfo> parseModuleInfo(@Nullable java.util.jar.Manifest jarManifest) {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleArgs.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/ModuleArgs.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.dist.service.tasks;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -117,12 +116,14 @@ final class ModuleArgs {
                             return Stream.of(f);
                         }
 
-                        return Stream.concat(Stream.of(f), classpathEntries.stream().map(e -> new File(f.getParentFile(), e)));
+                        return Stream.concat(
+                                Stream.of(f), classpathEntries.stream().map(e -> new File(f.getParentFile(), e)));
                     } catch (IOException e) {
                         project.getLogger().warn("Failed to load manifest entry for jar {}", f, e);
                         return Stream.empty();
                     }
-                }).collect(Collectors.toSet());
+                })
+                .collect(Collectors.toSet());
     }
 
     private static Optional<JarManifestModuleInfo> parseModuleInfo(@Nullable java.util.jar.Manifest jarManifest) {


### PR DESCRIPTION



## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We only read the JARs on the classpath. This was
fine if we didn't use manifest classpath JARs.

After this PR: We now read the JARs in the manifest classpath JAR
and then include those in our search for opens and exports.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make ModuleArgs expand manifest classpath JARs for exports and opens
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

