### PR TITLE
Disable C2 compiler for Java 11

### DIFF
--- a/changelog/@unreleased/pr-1370.v2.yml
+++ b/changelog/@unreleased/pr-1370.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Disable C2 compiler for Java 11
+
+    Disable the C2 compiler using the -XX:TieredStopAtLevel=1 flag. This prevents a potential memory leak issue https://bugs.openjdk.org/browse/JDK-8291665
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1370

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -61,6 +61,7 @@ public abstract class LaunchConfigTask extends DefaultTask {
     private static final ImmutableList<String> java15Options =
             ImmutableList.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+ExpandSubTypeCheckAtParseTime");
     private static final ImmutableList<String> disableBiasedLocking = ImmutableList.of("-XX:-UseBiasedLocking");
+    private static final ImmutableList<String> disableC2 = ImmutableList.of("-XX:TieredStopAtLevel=1");
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
@@ -191,6 +192,12 @@ public abstract class LaunchConfigTask extends DefaultTask {
                         .addAllJvmOpts(javaAgentArgs())
                         .addAllJvmOpts(alwaysOnJvmOptions)
                         .addAllJvmOpts(addJava8GcLogging.get() ? java8gcLoggingOptions : ImmutableList.of())
+                        // Java 11u6 and later have potential memory leak issues when using the C2
+                        // compiler
+                        .addAllJvmOpts(
+                                javaVersion.get().compareTo(JavaVersion.toVersion("11")) == 0
+                                        ? disableC2
+                                        : ImmutableList.of())
                         .addAllJvmOpts(
                                 javaVersion.get().compareTo(JavaVersion.toVersion("14")) >= 0
                                         ? java14PlusOptions

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -192,7 +192,7 @@ public abstract class LaunchConfigTask extends DefaultTask {
                         .addAllJvmOpts(javaAgentArgs())
                         .addAllJvmOpts(alwaysOnJvmOptions)
                         .addAllJvmOpts(addJava8GcLogging.get() ? java8gcLoggingOptions : ImmutableList.of())
-                        // Java 11u6 and later have potential memory leak issues when using the C2
+                        // Java 11.0.16 introduced a potential memory leak issues when using the C2
                         // compiler
                         .addAllJvmOpts(
                                 javaVersion.get().compareTo(JavaVersion.toVersion("11")) == 0


### PR DESCRIPTION
Disable the C2 compiler using the -XX:TieredStopAtLevel=1 flag. This prevents a potential memory leak issue https://bugs.openjdk.org/browse/JDK-8291665