### PR TITLE
Use Async JVM Unified Logging on JDK 17+

### DIFF
--- a/changelog/@unreleased/pr-1374.v2.yml
+++ b/changelog/@unreleased/pr-1374.v2.yml
@@ -1,0 +1,13 @@
+type: improvement
+improvement:
+  description: |-
+    Use Async JVM Unified Logging on JDK 17+
+
+    Avoid fflush from Unified JVM Logging (e.g. GC logs), see:
+
+    https://aws.amazon.com/blogs/developer/asynchronous-logging-corretto-17/
+    https://bugs.openjdk.org/browse/JDK-8291898
+    https://bugs.openjdk.org/browse/JDK-8229517
+    https://github.com/openjdk/jdk/commit/41185d38f21e448370433f7e4f1633777cab6170
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1374

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -60,6 +60,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
             ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
     private static final ImmutableList<String> java15Options =
             ImmutableList.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+ExpandSubTypeCheckAtParseTime");
+    private static final ImmutableList<String> java17PlusOptions = ImmutableList.of(
+            "-Xlog:async"); // remove if/when async is default, see https://bugs.openjdk.org/browse/JDK-8291898
     private static final ImmutableList<String> disableBiasedLocking = ImmutableList.of("-XX:-UseBiasedLocking");
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
@@ -207,6 +209,10 @@ public abstract class LaunchConfigTask extends DefaultTask {
                         .addAllJvmOpts(
                                 javaVersion.get().compareTo(JavaVersion.toVersion("15")) == 0
                                         ? java15Options
+                                        : ImmutableList.of())
+                        .addAllJvmOpts(
+                                javaVersion.get().compareTo(JavaVersion.toVersion("17")) >= 0
+                                        ? java17PlusOptions
                                         : ImmutableList.of())
                         // Biased locking is disabled on java 15+ https://openjdk.java.net/jeps/374
                         // We disable biased locking on all releases in order to reduce safepoint time,


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/sls-packaging/issues/1373

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use Async JVM Unified Logging on JDK 17+

Avoid fflush from Unified JVM Logging (e.g. GC logs), see:

https://aws.amazon.com/blogs/developer/asynchronous-logging-corretto-17/
https://bugs.openjdk.org/browse/JDK-8291898
https://bugs.openjdk.org/browse/JDK-8229517
https://github.com/openjdk/jdk/commit/41185d38f21e448370433f7e4f1633777cab6170
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

