### PR TITLE
Enable String Deduplication on JDK 17+

### DIFF
--- a/changelog/@unreleased/pr-1380.v2.yml
+++ b/changelog/@unreleased/pr-1380.v2.yml
@@ -1,0 +1,19 @@
+type: improvement
+improvement:
+  description: |-
+    Enable String Deduplication on JDK 17+
+
+    G1 and Shenandoah GC support string deduplication as of JDK 17
+    * https://openjdk.java.net/jeps/192
+    * https://bugs.openjdk.org/browse/JDK-8264718
+
+    Only enable on JDK 17+ due to fix
+    https://bugs.openjdk.org/browse/JDK-8277981
+
+    JDK 18+ enable string deduplication for SerialGC, ParallalGC, and ZGC.
+    https://malloc.se/blog/zgc-jdk18
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1380
+  - https://openjdk.java.net/jeps/192
+  - https://bugs.openjdk.org/browse/JDK-8264718
+  - https://malloc.se/blog/zgc-jdk18

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -60,6 +60,9 @@ public final class LaunchConfig {
             ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
     private static final ImmutableList<String> java15Options =
             ImmutableList.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+ExpandSubTypeCheckAtParseTime");
+
+    private static final ImmutableList<String> java17PlusOptions = ImmutableList.of(
+            "-XX:+UseStringDeduplication"); // only enable on JDK 17+ due to https://bugs.openjdk.org/browse/JDK-8277981
     private static final ImmutableList<String> disableBiasedLocking = ImmutableList.of("-XX:-UseBiasedLocking");
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
@@ -174,6 +177,10 @@ public final class LaunchConfig {
                         .addAllJvmOpts(
                                 javaVersion.compareTo(JavaVersion.toVersion("15")) == 0
                                         ? java15Options
+                                        : ImmutableList.of())
+                        .addAllJvmOpts(
+                                javaVersion.compareTo(JavaVersion.toVersion("17")) >= 0
+                                        ? java17PlusOptions
                                         : ImmutableList.of())
                         // Biased locking is disabled on java 15+ https://openjdk.java.net/jeps/374
                         // We disable biased locking on all releases in order to reduce safepoint time,

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -63,6 +63,7 @@ public final class LaunchConfig {
 
     private static final ImmutableList<String> java17PlusOptions = ImmutableList.of(
             "-XX:+UseStringDeduplication"); // only enable on JDK 17+ due to https://bugs.openjdk.org/browse/JDK-8277981
+
     private static final ImmutableList<String> disableBiasedLocking = ImmutableList.of("-XX:-UseBiasedLocking");
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =


### PR DESCRIPTION
## Before this PR
JVM string deduplication was not enabled

## After this PR
Reduce heap size by allowing JVM garbage collectors to deduplicate strings.
==COMMIT_MSG==
Enable String Deduplication on JDK 17+

G1 and Shenandoah GC support string deduplication as of JDK 17
* https://openjdk.java.net/jeps/192
* https://bugs.openjdk.org/browse/JDK-8264718

Only enable on JDK 17+ due to fix
https://bugs.openjdk.org/browse/JDK-8277981

JDK 18+ enable string deduplication for SerialGC, ParallalGC, and ZGC.
https://malloc.se/blog/zgc-jdk18
==COMMIT_MSG==

Closes https://github.com/palantir/sls-packaging/issues/1378

## Possible downsides?
Enabling this by default may trigger some unknown JDK bug(s).