### PR TITLE
[JDK-8291665] Disable Hotspot C2 split if blocks

### DIFF
--- a/changelog/@unreleased/pr-1381.v2.yml
+++ b/changelog/@unreleased/pr-1381.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    [JDK-8291665] Disable Hotspot C2 split if blocks
+
+    See https://bugs.openjdk.org/browse/JDK-8291665?focusedCommentId=14517134&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14517134
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1381

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -62,8 +62,8 @@ public abstract class LaunchConfigTask extends DefaultTask {
             ImmutableList.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+ExpandSubTypeCheckAtParseTime");
     private static final ImmutableList<String> disableBiasedLocking = ImmutableList.of("-XX:-UseBiasedLocking");
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
-    private static final ImmutableList<String> jdk11DisableC2Compile =
-            ImmutableList.of("-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord");
+    private static final ImmutableList<String> jdk11DisableC2Compile = ImmutableList.of(
+            "-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord", "-XX:-SplitIfBlocks");
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",


### PR DESCRIPTION
## Before this PR
OpenJDK 11.0.16 encounters C2 memory exhaustion due to [JDK-8291665](https://bugs.openjdk.org/browse/JDK-8291665)

## After this PR
==COMMIT_MSG==
[JDK-8291665] Disable Hotspot C2 split if blocks

See https://bugs.openjdk.org/browse/JDK-8291665?focusedCommentId=14517134&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14517134
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

