### PR TITLE
Enable 'UseContainerCpuShares' for java distributions

### DIFF
--- a/changelog/@unreleased/pr-1414.v2.yml
+++ b/changelog/@unreleased/pr-1414.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Enable 'UseContainerCpuShares' for java distributions
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1414

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -225,10 +225,10 @@ public abstract class LaunchConfigTask extends DefaultTask {
                                         : ImmutableList.of())
                         // https://bugs.openjdk.org/browse/JDK-8281181 stopped respecting cpu.shares for
                         // processor count. UseContainerCpuShares can be enabled for the time being, however it
-                        // is deprecated in jdk19 and expired in jdk21: https://bugs.openjdk.org/browse/JDK-8282684
+                        // is deprecated in jdk19 and obsoleted in jdk20: https://bugs.openjdk.org/browse/JDK-8282684
                         .addAllJvmOpts(
                                 javaVersion.get().compareTo(JavaVersion.toVersion("11")) >= 0
-                                                && javaVersion.get().compareTo(JavaVersion.toVersion("20")) <= 0
+                                                && javaVersion.get().compareTo(JavaVersion.toVersion("19")) <= 0
                                         ? forceUseContainerCpuShares
                                         : ImmutableList.of())
                         .addAllJvmOpts(

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -64,8 +64,10 @@ public abstract class LaunchConfigTask extends DefaultTask {
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
             ImmutableList.of("-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord");
+    // UseContainerCpuShares was added in a patch release, thus IgnoreUnrecognizedVMOptions is required to avoid
+    // breaking distributions running with older JDKs.
     private static final ImmutableList<String> forceUseContainerCpuShares =
-            ImmutableList.of("-XX:+UseContainerCpuShares");
+            ImmutableList.of("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseContainerCpuShares");
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -464,35 +464,35 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         def expectedStaticConfig = LaunchConfigTask.LaunchConfig.builder()
-            .mainClass("test.Test")
-            .serviceName("service-name")
-            .javaHome("foo")
-            .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
-            .jvmOpts([
-                '-XX:+CrashOnOutOfMemoryError',
-                '-Djava.io.tmpdir=var/data/tmp',
-                '-XX:ErrorFile=var/log/hs_err_pid%p.log',
-                '-XX:HeapDumpPath=var/log',
-                '-Dsun.net.inetaddr.ttl=20',
-                '-XX:+UnlockDiagnosticVMOptions',
-                '-XX:-UseAESCTRIntrinsics',
-                '-XX:NativeMemoryTracking=summary',
-                '-XX:FlightRecorderOptions=stackdepth=256',
-                "-XX:+PrintGCDateStamps",
-                "-XX:+PrintGCDetails",
-                "-XX:-TraceClassUnloading",
-                "-XX:+UseGCLogFileRotation",
-                "-XX:GCLogFileSize=10M",
-                "-XX:NumberOfGCLogFiles=10",
-                "-Xloggc:var/log/gc-%t-%p.log",
-                "-verbose:gc",
-                "-XX:-UseBiasedLocking",
-                '-XX:+UseParallelGC',
-                '-Xmx4M',
-                '-Djavax.net.ssl.trustStore=truststore.jks'])
-            .dirs(["var/data/tmp"])
-            .env(["MALLOC_ARENA_MAX": '4'])
-            .build()
+                .mainClass("test.Test")
+                .serviceName("service-name")
+                .javaHome("foo")
+                .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
+                .jvmOpts([
+                        '-XX:+CrashOnOutOfMemoryError',
+                        '-Djava.io.tmpdir=var/data/tmp',
+                        '-XX:ErrorFile=var/log/hs_err_pid%p.log',
+                        '-XX:HeapDumpPath=var/log',
+                        '-Dsun.net.inetaddr.ttl=20',
+                        '-XX:+UnlockDiagnosticVMOptions',
+                        '-XX:-UseAESCTRIntrinsics',
+                        '-XX:NativeMemoryTracking=summary',
+                        '-XX:FlightRecorderOptions=stackdepth=256',
+                        "-XX:+PrintGCDateStamps",
+                        "-XX:+PrintGCDetails",
+                        "-XX:-TraceClassUnloading",
+                        "-XX:+UseGCLogFileRotation",
+                        "-XX:GCLogFileSize=10M",
+                        "-XX:NumberOfGCLogFiles=10",
+                        "-Xloggc:var/log/gc-%t-%p.log",
+                        "-verbose:gc",
+                        "-XX:-UseBiasedLocking",
+                        '-XX:+UseParallelGC',
+                        '-Xmx4M',
+                        '-Djavax.net.ssl.trustStore=truststore.jks'])
+                .dirs(["var/data/tmp"])
+                .env(["MALLOC_ARENA_MAX": '4'])
+                .build()
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
         expectedStaticConfig == actualStaticConfig
@@ -518,7 +518,8 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         actualStaticConfig.jvmOpts().containsAll([
                 "-XX:+UseShenandoahGC",
                 "-XX:+ExplicitGCInvokesConcurrent",
-                "-XX:+ClassUnloadingWithConcurrentMark"
+                "-XX:+ClassUnloadingWithConcurrentMark",
+                "-XX:+UseContainerCpuShares",
         ])
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -464,35 +464,35 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         def expectedStaticConfig = LaunchConfigTask.LaunchConfig.builder()
-                .mainClass("test.Test")
-                .serviceName("service-name")
-                .javaHome("foo")
-                .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
-                .jvmOpts([
-                        '-XX:+CrashOnOutOfMemoryError',
-                        '-Djava.io.tmpdir=var/data/tmp',
-                        '-XX:ErrorFile=var/log/hs_err_pid%p.log',
-                        '-XX:HeapDumpPath=var/log',
-                        '-Dsun.net.inetaddr.ttl=20',
-                        '-XX:+UnlockDiagnosticVMOptions',
-                        '-XX:-UseAESCTRIntrinsics',
-                        '-XX:NativeMemoryTracking=summary',
-                        '-XX:FlightRecorderOptions=stackdepth=256',
-                        "-XX:+PrintGCDateStamps",
-                        "-XX:+PrintGCDetails",
-                        "-XX:-TraceClassUnloading",
-                        "-XX:+UseGCLogFileRotation",
-                        "-XX:GCLogFileSize=10M",
-                        "-XX:NumberOfGCLogFiles=10",
-                        "-Xloggc:var/log/gc-%t-%p.log",
-                        "-verbose:gc",
-                        "-XX:-UseBiasedLocking",
-                        '-XX:+UseParallelGC',
-                        '-Xmx4M',
-                        '-Djavax.net.ssl.trustStore=truststore.jks'])
-                .dirs(["var/data/tmp"])
-                .env(["MALLOC_ARENA_MAX": '4'])
-                .build()
+            .mainClass("test.Test")
+            .serviceName("service-name")
+            .javaHome("foo")
+            .classpath(['service/lib/internal-0.0.1.jar', 'service/lib/external.jar'])
+            .jvmOpts([
+                '-XX:+CrashOnOutOfMemoryError',
+                '-Djava.io.tmpdir=var/data/tmp',
+                '-XX:ErrorFile=var/log/hs_err_pid%p.log',
+                '-XX:HeapDumpPath=var/log',
+                '-Dsun.net.inetaddr.ttl=20',
+                '-XX:+UnlockDiagnosticVMOptions',
+                '-XX:-UseAESCTRIntrinsics',
+                '-XX:NativeMemoryTracking=summary',
+                '-XX:FlightRecorderOptions=stackdepth=256',
+                "-XX:+PrintGCDateStamps",
+                "-XX:+PrintGCDetails",
+                "-XX:-TraceClassUnloading",
+                "-XX:+UseGCLogFileRotation",
+                "-XX:GCLogFileSize=10M",
+                "-XX:NumberOfGCLogFiles=10",
+                "-Xloggc:var/log/gc-%t-%p.log",
+                "-verbose:gc",
+                "-XX:-UseBiasedLocking",
+                '-XX:+UseParallelGC',
+                '-Xmx4M',
+                '-Djavax.net.ssl.trustStore=truststore.jks'])
+            .dirs(["var/data/tmp"])
+            .env(["MALLOC_ARENA_MAX": '4'])
+            .build()
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfigTask.LaunchConfig)
         expectedStaticConfig == actualStaticConfig


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8281181 was introduced in the October patch.
==COMMIT_MSG==
Enable 'UseContainerCpuShares' for java distributions
==COMMIT_MSG==

