### PR TITLE
Revert #1414: Stop adding -XX:+UseContainerCpuShares

### DIFF
--- a/changelog/@unreleased/pr-1416.v2.yml
+++ b/changelog/@unreleased/pr-1416.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Stop automatically adding `-XX:+UseContainerCpuShares` (introduced
+    in sls-packaging 7.25.0) to allow for a more conservative rollout.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1416

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfigTask.java
@@ -64,10 +64,6 @@ public abstract class LaunchConfigTask extends DefaultTask {
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
             ImmutableList.of("-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord");
-    // UseContainerCpuShares was added in a patch release, thus IgnoreUnrecognizedVMOptions is required to avoid
-    // breaking distributions running with older JDKs.
-    private static final ImmutableList<String> forceUseContainerCpuShares =
-            ImmutableList.of("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseContainerCpuShares");
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
@@ -222,14 +218,6 @@ public abstract class LaunchConfigTask extends DefaultTask {
                         .addAllJvmOpts(
                                 javaVersion.get().compareTo(JavaVersion.toVersion("15")) < 0
                                         ? disableBiasedLocking
-                                        : ImmutableList.of())
-                        // https://bugs.openjdk.org/browse/JDK-8281181 stopped respecting cpu.shares for
-                        // processor count. UseContainerCpuShares can be enabled for the time being, however it
-                        // is deprecated in jdk19 and obsoleted in jdk20: https://bugs.openjdk.org/browse/JDK-8282684
-                        .addAllJvmOpts(
-                                javaVersion.get().compareTo(JavaVersion.toVersion("11")) >= 0
-                                                && javaVersion.get().compareTo(JavaVersion.toVersion("19")) <= 0
-                                        ? forceUseContainerCpuShares
                                         : ImmutableList.of())
                         .addAllJvmOpts(
                                 ModuleArgs.collectClasspathArgs(getProject(), javaVersion.get(), getFullClasspath()))

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -518,8 +518,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         actualStaticConfig.jvmOpts().containsAll([
                 "-XX:+UseShenandoahGC",
                 "-XX:+ExplicitGCInvokesConcurrent",
-                "-XX:+ClassUnloadingWithConcurrentMark",
-                "-XX:+UseContainerCpuShares",
+                "-XX:+ClassUnloadingWithConcurrentMark"
         ])
     }
 


### PR DESCRIPTION
## Before this PR

sls-packaging 7.25.0 introduced this new option: https://github.com/palantir/sls-packaging/pull/1414. Rolling it out has is correlated with some significant performance changes (e.g. PDS-320010 for timelock, and another thread ing #dev-backend-infra), which makes me concerned this might introduce a wider risk of problems over the break.

## After this PR
==COMMIT_MSG==
Revert #1414: Stop adding -XX:+UseContainerCpuShares
==COMMIT_MSG==

## Possible downsides?
- i don't have conclusive proof that this JVM option was problematic for timelock

