### PR TITLE
Annotate ConfigureProductDependenciesTask inputs

### DIFF
--- a/changelog/@unreleased/pr-1417.v2.yml
+++ b/changelog/@unreleased/pr-1417.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Annotate ConfigureProductDependenciesTask inputs to ensure task dependencies
+    are set as expected
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1417

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ConfigureProductDependenciesTask.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ConfigureProductDependenciesTask.java
@@ -27,6 +27,7 @@ import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.bundling.Jar;
 
@@ -52,12 +53,19 @@ public class ConfigureProductDependenciesTask extends DefaultTask {
                 .configure(jar -> {
                     Preconditions.checkState(
                             !jar.getState().getExecuted(), "Attempted to configure jar task after it was executed");
-                    jar.getManifest().from(createManifest(getProject(), productDependencies.get()));
+                    jar.getManifest()
+                            .from(createManifest(
+                                    getProject(), getProductDependencies().get()));
                 });
     }
 
     public final void setProductDependencies(Provider<Set<ProductDependency>> productDependencies) {
-        this.productDependencies.set(productDependencies);
+        getProductDependencies().set(productDependencies);
+    }
+
+    @Input
+    final SetProperty<ProductDependency> getProductDependencies() {
+        return productDependencies;
     }
 
     /** Eagerly creates a manifest containing <b>only</b> the recommended product dependencies. */


### PR DESCRIPTION
==COMMIT_MSG==
Annotate ConfigureProductDependenciesTask inputs to ensure task dependencies are set as expected
==COMMIT_MSG==

