### PR TITLE
MergeDiagnosticJson should not be build cacheable

### DIFF
--- a/changelog/@unreleased/pr-1436.v2.yml
+++ b/changelog/@unreleased/pr-1436.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`mergeDiagnosticJson` is no longer build cacheable, as it spends 100x
+    more time accessing the cache than just running the task'
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1436

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/MergeDiagnosticsJsonTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/MergeDiagnosticsJsonTask.java
@@ -16,7 +16,4 @@
 
 package com.palantir.gradle.dist.service;
 
-import org.gradle.api.tasks.CacheableTask;
-
-@CacheableTask
 public abstract class MergeDiagnosticsJsonTask extends MergeDiagnosticsJsonTaskImpl {}

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
@@ -16,30 +16,12 @@
 
 package com.palantir.gradle.dist.service
 
-
 import nebula.test.IntegrationSpec
-
-import java.nio.file.Files
-import java.nio.file.Path
 
 class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
 
-    private void enableLocalBuildCache() {
-        Path localBuildCache = Files.createDirectories(projectDir.toPath().resolve("local-build-cache"))
-        file("gradle.properties") << "org.gradle.caching=true"
-        settingsFile << """
-        buildCache {
-            local {
-                directory = file("${localBuildCache}")
-                enabled = true
-            }
-        }
-        """.stripIndent()
-    }
-
     def 'detects stuff defined in current project'() {
         given:
-        enableLocalBuildCache()
         buildFile << """
         apply plugin: 'java-library'
         ${applyPlugin(DiagnosticsManifestPlugin.class)}
@@ -68,13 +50,6 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         result2.wasUpToDate(":mergeDiagnosticsJson")
-
-        when:
-        outFile.delete()
-        def result3 = runTasksSuccessfully("mergeDiagnosticsJson", '-is')
-
-        then:
-        result3.getStandardOutput().contains("Task :mergeDiagnosticsJson FROM-CACHE")
     }
 
     def 'detects stuff defined in sibling projects'() {


### PR DESCRIPTION
## Before this PR
`mergeDiagnosticJson` is cacheable, meaning that Gradle will spend 5 seconds looking for a cache entry to save doing ~10-20 milliseconds of actual work (given the jars it's scanning through is the runtime classpath, which is always needed and already cached). This is quite a common sight:

<img width="1728" alt="Screenshot 2023-02-13 at 17 50 52" src="https://user-images.githubusercontent.com/397795/218535926-ce54160d-e1b9-4299-a738-1ff5a2150b9a.png">

## After this PR
==COMMIT_MSG==
`mergeDiagnosticJson` is no longer build cacheable, as it spends 100x more time accessing the cache than just running the task
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

