### PR TITLE
Discover all diagnostic manifests

### DIFF
--- a/changelog/@unreleased/pr-1443.v2.yml
+++ b/changelog/@unreleased/pr-1443.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The diagnostic manifest plugin now correctly discovers diagnostic manifest
+    generates from places other than the resource directory.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1443


### PR DESCRIPTION
Our internal diagnostic annotation processor generates the diagnostic manifest in the class directory, not the resource directory.

I've confirmed that this works on one of our internal projects.