### PR TITLE
Revert "Enable String Deduplication on JDK 17+ (#1380)"

### DIFF
--- a/changelog/@unreleased/pr-1452.v2.yml
+++ b/changelog/@unreleased/pr-1452.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: This reverts commit 902de8d0c0d68098fc7fb5f5932c9cbc0a3a8e6a.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1452

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -60,10 +60,6 @@ public final class LaunchConfig {
             ImmutableList.of("-XX:+ShowCodeDetailsInExceptionMessages");
     private static final ImmutableList<String> java15Options =
             ImmutableList.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+ExpandSubTypeCheckAtParseTime");
-
-    private static final ImmutableList<String> java17PlusOptions = ImmutableList.of(
-            "-XX:+UseStringDeduplication"); // only enable on JDK 17+ due to https://bugs.openjdk.org/browse/JDK-8277981
-
     private static final ImmutableList<String> disableBiasedLocking = ImmutableList.of("-XX:-UseBiasedLocking");
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
@@ -178,10 +174,6 @@ public final class LaunchConfig {
                         .addAllJvmOpts(
                                 javaVersion.compareTo(JavaVersion.toVersion("15")) == 0
                                         ? java15Options
-                                        : ImmutableList.of())
-                        .addAllJvmOpts(
-                                javaVersion.compareTo(JavaVersion.toVersion("17")) >= 0
-                                        ? java17PlusOptions
                                         : ImmutableList.of())
                         // Biased locking is disabled on java 15+ https://openjdk.java.net/jeps/374
                         // We disable biased locking on all releases in order to reduce safepoint time,


### PR DESCRIPTION
## Before this PR
#1380 enabled string deduplication on JDK 17+; however, seeing a bit too much increase in GC cycles on some services, so reverting for now 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
This reverts commit 902de8d0c0d68098fc7fb5f5932c9cbc0a3a8e6a.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

