### PR TITLE
Include dependency name when failing due to bad ProductDependency versions

### DIFF
--- a/changelog/@unreleased/pr-1472.v2.yml
+++ b/changelog/@unreleased/pr-1472.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: When failing to create a `ProductDependency` due to invalid versions,
+    specify in the error message which depended-on product is involved.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1472

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
@@ -100,7 +100,9 @@ public final class ProductDependency implements Serializable {
                     maximum.compare(minimum.get()) >= 0,
                     "Minimum version is greater than maximum version",
                     SafeArg.of("minimumVersion", minimumVersion),
-                    SafeArg.of("maximumVersion", maximumVersion));
+                    SafeArg.of("maximumVersion", maximumVersion),
+                    SafeArg.of("productGroup", productGroup),
+                    SafeArg.of("productName", productName));
         }
 
         // Minimum can be unset here if the minimumVersion is a non-orderable SLS version, e.g. "1.0.0.dirty"
@@ -109,7 +111,9 @@ public final class ProductDependency implements Serializable {
                     VersionComparator.INSTANCE.compare(recommended.get(), minimum.get()) >= 0,
                     "Recommended version is not greater than minimum version",
                     SafeArg.of("recommendedVersion", recommendedVersion),
-                    SafeArg.of("minimumVersion", minimumVersion));
+                    SafeArg.of("minimumVersion", minimumVersion),
+                    SafeArg.of("productGroup", productGroup),
+                    SafeArg.of("productName", productName));
         }
 
         if (recommended.isPresent()) {
@@ -117,7 +121,9 @@ public final class ProductDependency implements Serializable {
                     maximum.compare(recommended.get()) >= 0,
                     "Recommended version is greater than maximum version",
                     SafeArg.of("recommendedVersion", recommendedVersion),
-                    SafeArg.of("maximumVersion", maximumVersion));
+                    SafeArg.of("maximumVersion", maximumVersion),
+                    SafeArg.of("productGroup", productGroup),
+                    SafeArg.of("productName", productName));
         }
     }
 


### PR DESCRIPTION
This information makes interpreting and fixing the issue easier.

==COMMIT_MSG==
When failing to create a `ProductDependency` due to invalid versions, specify in the error message which depended-on product is involved.
==COMMIT_MSG==

