### PR TITLE
Increase G1 default pause target from 200ms to 500ms

### DIFF
--- a/changelog/@unreleased/pr-1505.v2.yml
+++ b/changelog/@unreleased/pr-1505.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increase G1 default pause target from 200ms to 500ms
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1505

--- a/changelog/@unreleased/pr-1505.v2.yml
+++ b/changelog/@unreleased/pr-1505.v2.yml
@@ -1,5 +1,13 @@
 type: improvement
 improvement:
-  description: Increase G1 default pause target from 200ms to 500ms
+  description: |-
+    Increase G1 default pause target from 200ms to 500ms
+
+    The G1 pause target can be modified thusly:
+    ```groovy
+    gc 'hybrid', {
+        maxGCPauseMillis 250
+    }
+    ```
   links:
   - https://github.com/palantir/sls-packaging/pull/1505

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -89,10 +89,24 @@ public interface GcProfile extends Serializable {
         }
     }
 
+    // Match the MaxGCPauseMillis case
+    @SuppressWarnings("AbbreviationAsWordInName")
     class Hybrid implements GcProfile {
+        // We use 500ms by default, up from the JDK default value of 200ms. Using G1, eden space is dynamically
+        // chosen based on the amount of memory which can be collected within the pause time target.
+        // Higher pause target values allow for more eden space, resulting in more stable old generation
+        // in high-garbage or low-gc-thread scenarios. In the happy case, increasing the pause target increases
+        // both throughput and latency. In degenerate cases, a low target can cause the garbage collector to
+        // thrash and reduce throughput while increasing latency.
+        private int maxGCPauseMillis = 500;
+
         @Override
         public final List<String> gcJvmOpts(JavaVersion _javaVersion) {
-            return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseNUMA");
+            return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseNUMA", "-XX:MaxGCPauseMillis=" + maxGCPauseMillis);
+        }
+
+        public final void maxGCPauseMillis(int value) {
+            this.maxGCPauseMillis = value;
         }
     }
 


### PR DESCRIPTION
We use 500ms by default, up from the JDK default value of 200ms. Using G1, eden space is dynamically chosen based on the amount of memory which can be collected within the pause time target. Higher pause target values allow for more eden space, resulting in more stable old generation in high-garbage or low-gc-thread scenarios. In the happy case, increasing the pause target increases both throughput and latency. In degenerate cases, a low target can cause the garbage collector to thrash and reduce throughput while increasing latency.

==COMMIT_MSG==
Increase G1 default pause target from 200ms to 500ms
==COMMIT_MSG==

The G1 pause target can be modified thusly:
```groovy
gc 'hybrid', {
    maxGCPauseMillis 250
}
```

## Possible downsides?
I considered making two PRs, one to make `MaxGCPauseMillis` configurable, and a second to increase the default value.
Increasing this value may increase latency in latency-sensitive apps. Those which are particularly latency-sensitive are already using the `response-time` profile, so there shouldn't be a great deal of risk.
