### PR TITLE
Remove version from JDK path

### DIFF
--- a/changelog/@unreleased/pr-1516.v2.yml
+++ b/changelog/@unreleased/pr-1516.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove version from JDK path when JDKs are included in dists.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1516

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -273,11 +273,10 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         // and you end up with a report like so:
         //      Path: /opt/palantir/services/.24710105/service/jdk17
         // rather than more useful:
-        //      Path: /opt/palantir/services/.24710105/service/multipass-2.1.3-jdks/jdk17
+        //      Path: /opt/palantir/services/.24710105/service/multipass-jdks/jdk17
         // which is implemented below.
 
         return String.format(
-                "service/%s-%s-jdks/jdk%s",
-                getDistributionServiceName().get(), project.getVersion(), javaVersionValue.getMajorVersion());
+                "service/%s-jdks/jdk%s", getDistributionServiceName().get(), javaVersionValue.getMajorVersion());
     }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -265,7 +265,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         return new GcProfile.Throughput();
     }
 
-    final String jdkPathInDist(JavaVersion javaVersionValue) {
+    public final String jdkPathInDist(JavaVersion javaVersionValue) {
         // We put the JDK in a directory that contains the name and version of service. This is because in our cloud
         // environments (and some customer environments), there is a third party security scanning tool that will report
         // vulnerabilities in the JDK by printing a path, but does not display symlinks. This means it's hard to tell

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JdksInDistsIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JdksInDistsIntegrationSpec.groovy
@@ -73,7 +73,7 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
 
         then:
         def rootDir = extractDist()
-        def jdkDir = new File(rootDir, "service/myService-1.0.0-jdks/jdk17")
+        def jdkDir = new File(rootDir, "service/myService-jdks/jdk17")
         jdkDir.exists()
 
         def releaseFileText = new File(jdkDir, "release").text
@@ -81,8 +81,8 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
         releaseFileText.contains 'its a jdk trust me'
 
         def launcherStatic = new File(rootDir, "service/bin/launcher-static.yml").text
-        launcherStatic.contains 'javaHome: "service/myService-1.0.0-jdks/jdk17"'
-        launcherStatic.contains '  JAVA_17_HOME: "service/myService-1.0.0-jdks/jdk17"'
+        launcherStatic.contains 'javaHome: "service/myService-jdks/jdk17"'
+        launcherStatic.contains '  JAVA_17_HOME: "service/myService-jdks/jdk17"'
     }
 
     def 'multiple jdks can exist in the dist'() {
@@ -103,17 +103,17 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
         def rootDir = extractDist()
 
         def launcherStatic = new File(rootDir, "service/bin/launcher-static.yml").text
-        launcherStatic.contains 'javaHome: "service/myService-1.0.0-jdks/jdk17"'
+        launcherStatic.contains 'javaHome: "service/myService-jdks/jdk17"'
 
         for (version in [11, 13, 17]) {
-            def jdkDir = new File(rootDir, "service/myService-1.0.0-jdks/jdk" + version)
+            def jdkDir = new File(rootDir, "service/myService-jdks/jdk" + version)
             assert jdkDir.exists()
 
             def releaseFileText = new File(jdkDir, "release").text
 
             assert releaseFileText.contains('its a jdk trust me')
 
-            def envVarLine = "  JAVA_${version}_HOME: \"service/myService-1.0.0-jdks/jdk${version}\""
+            def envVarLine = "  JAVA_${version}_HOME: \"service/myService-jdks/jdk${version}\""
             assert launcherStatic.contains(envVarLine)
         }
     }
@@ -146,7 +146,7 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
 
         // A way of fixing this tests seems to open up the possibility of making extra unnecessary JDK repos - ensure
         // this does not happen.
-        !new File(rootDir, "service/myService-1.0.0-jdks/jdk11").exists()
+        !new File(rootDir, "service/myService-jdks/jdk11").exists()
     }
 
     def 'even a user clearing env does not get rid of JAVA_XX_HOME env vars'() {
@@ -169,8 +169,8 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
 
         def launcherStatic = new File(rootDir, "service/bin/launcher-static.yml").text
 
-        launcherStatic.contains 'JAVA_11_HOME: "service/myService-1.0.0-jdks/jdk11"'
-        launcherStatic.contains 'JAVA_17_HOME: "service/myService-1.0.0-jdks/jdk17"'
+        launcherStatic.contains 'JAVA_11_HOME: "service/myService-jdks/jdk11"'
+        launcherStatic.contains 'JAVA_17_HOME: "service/myService-jdks/jdk17"'
     }
 
     private File extractDist() {


### PR DESCRIPTION
## Before this PR
In #1510, we included the version in the path JDKs live in the dist to help people getting alerts from third party security scanners. However, adding a version here means that when container images are built, their layer caches are busted and docker images are recreated all the time.

## After this PR
==COMMIT_MSG==
Remove version from JDK path when JDKs are included in dists.
==COMMIT_MSG==

## Possible downsides?
Might be marginally harder to work out which exact service instance has the vuln (as in might need an extra step) - but the people who this would affect have agreed this is ok.
