### PR TITLE
Allow AVX-512 instructions when jdks are bundled with distributions

### DIFF
--- a/changelog/@unreleased/pr-1517.v2.yml
+++ b/changelog/@unreleased/pr-1517.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow AVX-512 instructions when jdks are bundled with distributions
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1517

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -227,8 +227,9 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getBundledJdks()
                             .set(distributionExtension
                                     .getJdks()
-                                    .map(javaVersionObjectMap ->
-                                            javaVersionObjectMap.containsKey(distributionExtension.getJavaVersion())));
+                                    .map(javaVersionObjectMap -> javaVersionObjectMap.containsKey(distributionExtension
+                                            .getJavaVersion()
+                                            .get())));
                     task.getEnv().set(userConfiguredEnvWithJdkEnvVars(distributionExtension));
                 });
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -224,7 +224,11 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getAddJava8GcLogging().set(distributionExtension.getAddJava8GcLogging());
                     task.getJavaHome().set(distributionExtension.getJavaHome());
                     task.getJavaVersion().set(distributionExtension.getJavaVersion());
-                    task.getJdks().set(distributionExtension.getJdks());
+                    task.getBundledJdks()
+                            .set(distributionExtension
+                                    .getJdks()
+                                    .map(javaVersionObjectMap ->
+                                            javaVersionObjectMap.containsKey(distributionExtension.getJavaVersion())));
                     task.getEnv().set(userConfiguredEnvWithJdkEnvVars(distributionExtension));
                 });
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -224,6 +224,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.getAddJava8GcLogging().set(distributionExtension.getAddJava8GcLogging());
                     task.getJavaHome().set(distributionExtension.getJavaHome());
                     task.getJavaVersion().set(distributionExtension.getJavaVersion());
+                    task.getJdks().set(distributionExtension.getJdks());
                     task.getEnv().set(userConfiguredEnvWithJdkEnvVars(distributionExtension));
                 });
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -116,7 +116,7 @@ public final class LaunchConfig {
         Property<JavaVersion> getJavaVersion();
 
         @Input
-        MapProperty<JavaVersion, Object> getJdks();
+        Property<Boolean> getBundledJdks();
 
         @Input
         ListProperty<String> getArgs();
@@ -199,7 +199,7 @@ public final class LaunchConfig {
                                 // When a specific jdk is provided, we can assume a modern versions including the
                                 // bugfix for JDK-8292158. Only Java versions 11-19 were impacted by this bug, so
                                 // we don't need to worry about newer releases.
-                                !params.getJdks().getting(javaVersion).isPresent()
+                                !params.getBundledJdks().get()
                                                 && javaVersion.compareTo(JavaVersion.toVersion("11")) >= 0
                                                 && javaVersion.compareTo(JavaVersion.toVersion("19")) <= 0
                                         ? disableAvx512

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -154,15 +154,7 @@ public final class LaunchConfig {
 
     static void action(Params params) {
         JavaVersion javaVersion = params.getJavaVersion().get();
-
-        // When a specific jdk is provided, we can assume a modern versions including the
-        // bugfix for JDK-8292158. Only Java versions 11-19 were impacted by this bug, so
-        // we don't need to worry about newer releases.
-        List<String> avxOptions = !params.getBundledJdks().get()
-                        && javaVersion.compareTo(JavaVersion.toVersion("11")) >= 0
-                        && javaVersion.compareTo(JavaVersion.toVersion("19")) <= 0
-                ? disableAvx512
-                : ImmutableList.of();
+        List<String> avxOptions = getAvxOptions(params);
 
         writeConfig(
                 LaunchConfigInfo.builder()
@@ -227,6 +219,18 @@ public final class LaunchConfig {
                         .env(defaultEnvironment)
                         .build(),
                 params.getCheckLauncher().get().getAsFile());
+    }
+
+    // When a specific jdk is provided, we can assume a modern versions including the
+    // bugfix for JDK-8292158. Only Java versions 11-19 were impacted by this bug, so
+    // we don't need to worry about newer releases.
+    private static List<String> getAvxOptions(Params params) {
+        JavaVersion javaVersion = params.getJavaVersion().get();
+        return !params.getBundledJdks().get()
+                        && javaVersion.compareTo(JavaVersion.toVersion("11")) >= 0
+                        && javaVersion.compareTo(JavaVersion.toVersion("19")) <= 0
+                ? disableAvx512
+                : ImmutableList.of();
     }
 
     private static void writeConfig(LaunchConfigInfo config, File scriptFile) {


### PR DESCRIPTION
## Before this PR
No avx512 anywhere.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow AVX-512 instructions when jdks are bundled with distributions
==COMMIT_MSG==
This builds upon #1510, relying on usage of the feature flag to drop arguments for compatibility with older jdk builds.

