### PR TITLE
Unset the JDK-11 CompileCommand override for bundled JDKS

### DIFF
--- a/changelog/@unreleased/pr-1519.v2.yml
+++ b/changelog/@unreleased/pr-1519.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Unset the JDK-11 CompileCommand override for bundled JDKS
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1519

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -168,9 +168,10 @@ public final class LaunchConfig {
                         .addAllJvmOpts(avxOptions)
                         .addAllJvmOpts(params.getAddJava8GcLogging().get() ? java8gcLoggingOptions : ImmutableList.of())
                         // Java 11.0.16 introduced a potential memory leak issues when using the C2
-                        // compiler
+                        // compiler, resolved in 11.0.16.1
                         .addAllJvmOpts(
                                 javaVersion.compareTo(JavaVersion.toVersion("11")) == 0
+                                                && !params.getBundledJdks().get()
                                         ? jdk11DisableC2Compile
                                         : ImmutableList.of())
                         .addAllJvmOpts(

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -491,7 +491,6 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                         '-XX:+IgnoreUnrecognizedVMOptions',
                         '-XX:NativeMemoryTracking=summary',
                         '-XX:FlightRecorderOptions=stackdepth=256',
-                        '-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord',
                         '-XX:-UseBiasedLocking',
                         '-XX:+IgnoreUnrecognizedVMOptions',
                         '-XX:+UseContainerCpuShares',


### PR DESCRIPTION
The config option is only necessary for outdated JDKs with a known bug, thus does not impact products which are shipped with bundled JDKs.

==COMMIT_MSG==
Unset the JDK-11 CompileCommand override for bundled JDKS
==COMMIT_MSG==
