### PR TITLE
JDK-21+ response-time gc profile uses generational zgc

### DIFF
--- a/changelog/@unreleased/pr-1520.v2.yml
+++ b/changelog/@unreleased/pr-1520.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: JDK-21+ response-time gc profile uses generational zgc
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1520

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -49,6 +49,16 @@ public interface GcProfile extends Serializable {
 
         @Override
         public final List<String> gcJvmOpts(JavaVersion javaVersion) {
+            // JDK-21+ uses generational ZGC as the response-time optimized garbage collector.
+            if (javaVersion.compareTo(JavaVersion.toVersion("21")) >= 0) {
+                return ImmutableList.of(
+                        "-XX:+UseZGC",
+                        // https://openjdk.org/jeps/439
+                        "-XX:+ZGenerational",
+                        // "forces concurrent cycle instead of Full GC on System.gc()"
+                        "-XX:+ExplicitGCInvokesConcurrent");
+            }
+
             // The CMS garbage collector was removed in Java 14: https://openjdk.java.net/jeps/363. Users are free to
             // use it up until this release.
             if (javaVersion.compareTo(JavaVersion.toVersion("14")) >= 0) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -610,6 +610,29 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         ])
     }
 
+    def 'Uses generational zgc for jdk-21'() {
+        createUntarBuildFile(buildFile)
+        buildFile << """
+            dependencies { implementation files("${EXTERNAL_JAR}") }
+            tasks.jar.archiveBaseName = "internal"
+            distribution {
+                javaVersion 21
+                gc 'response-time'
+            }""".stripIndent()
+        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+
+        when:
+        runTasks(':build', ':distTar', ':untar')
+
+        then:
+        def actualStaticConfig = OBJECT_MAPPER.readValue(
+                file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
+        actualStaticConfig.jvmOpts().containsAll([
+                "-XX:+UseZGC",
+                "-XX:+ZGenerational",
+                "-XX:+ExplicitGCInvokesConcurrent",
+        ])
+    }
 
     def 'produce distribution bundle that populates check.sh'() {
         given:


### PR DESCRIPTION
==COMMIT_MSG==
JDK-21+ response-time gc profile uses generational zgc
==COMMIT_MSG==

