### PR TITLE
sls-packaging no longer sets `-XX:+UseContainerCpuShares`

### DIFF
--- a/changelog/@unreleased/pr-1543.v2.yml
+++ b/changelog/@unreleased/pr-1543.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: sls-packaging no longer sets `-XX:+UseContainerCpuShares`
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1543

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -64,10 +64,6 @@ public final class LaunchConfig {
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
             ImmutableList.of("-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord");
-    // UseContainerCpuShares was added in a patch release, thus IgnoreUnrecognizedVMOptions is required to avoid
-    // breaking distributions running with older JDKs.
-    private static final ImmutableList<String> forceUseContainerCpuShares =
-            ImmutableList.of("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseContainerCpuShares");
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
@@ -189,14 +185,6 @@ public final class LaunchConfig {
                         .addAllJvmOpts(
                                 javaVersion.compareTo(JavaVersion.toVersion("15")) < 0
                                         ? disableBiasedLocking
-                                        : ImmutableList.of())
-                        // https://bugs.openjdk.org/browse/JDK-8281181 stopped respecting cpu.shares for
-                        // processor count. UseContainerCpuShares can be enabled for the time being, however it
-                        // is deprecated in jdk19 and obsoleted in jdk20: https://bugs.openjdk.org/browse/JDK-8282684
-                        .addAllJvmOpts(
-                                javaVersion.compareTo(JavaVersion.toVersion("11")) >= 0
-                                                && javaVersion.compareTo(JavaVersion.toVersion("19")) <= 0
-                                        ? forceUseContainerCpuShares
                                         : ImmutableList.of())
                         .addAllJvmOpts(ModuleArgs.collectClasspathArgs(javaVersion, params.getFullClasspath()))
                         .addAllJvmOpts(params.getGcJvmOptions().get())

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -410,8 +410,6 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                         '-XX:UseAVX=2',
                         '-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord',
                         '-XX:-UseBiasedLocking',
-                        '-XX:+IgnoreUnrecognizedVMOptions',
-                        '-XX:+UseContainerCpuShares',
                         '-XX:+UseParallelGC',
                         '-Xmx4M',
                         '-Djavax.net.ssl.trustStore=truststore.jks'])
@@ -493,8 +491,6 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                         '-XX:FlightRecorderOptions=stackdepth=256',
                         '-XX:UseAVX=2',
                         '-XX:-UseBiasedLocking',
-                        '-XX:+IgnoreUnrecognizedVMOptions',
-                        '-XX:+UseContainerCpuShares',
                         '-XX:+UseParallelGC',
                         '-Xmx4M',
                         '-Djavax.net.ssl.trustStore=truststore.jks'])
@@ -608,7 +604,6 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "-XX:+UseShenandoahGC",
                 "-XX:+ExplicitGCInvokesConcurrent",
                 "-XX:+ClassUnloadingWithConcurrentMark",
-                "-XX:+UseContainerCpuShares",
         ])
     }
 


### PR DESCRIPTION
## Before this PR
all jdk-11 through jdk-19 services set `-XX:+UseContainerCpuShares` unnecessarily. See the [container support](https://github.com/palantir/go-java-launcher#java-heap-and-container-support) section of the go-java-launcher readme:
> 1. If -XX:ActiveProcessorCount is unset, it will be set based on the discovered cgroup configurations and host information to a value between 2 and the number of processors reported by the runtime. You can read more about the reasoning behind this [here](https://github.com/palantir/go-java-launcher/issues/313).

## After this PR
This is part of a deprecation campaign to allow jvms in containers to use ergonomics profiles based on the host system as opposed to requests-based overrides.
==COMMIT_MSG==
sls-packaging no longer sets `-XX:+UseContainerCpuShares`
==COMMIT_MSG==

## Possible downsides?
Removing `UseContainerCpuShares` will have no impact in the short term because go-java-launcher overrides the
`ActiveProcessorCount` property based on requests by default, unless [container support is
disabled](https://github.com/palantir/go-java-launcher#disabling-container-support). An audit of uses of that flag shows primarily tests will be impacted, relatively low risk that this will impact services. In the off-chance it does make a change for services, the result will be the behavior that we ultimately want, without the slow rollout we intend for most products.

### Alternatives

Originally I put together an implementation using a feature flag, but decided the additional complexity around configuration would do more harm than good. You can find the diff [here](https://github.com/palantir/sls-packaging/compare/ckozak/disableContainerCpuSharesWorkaround_flag?expand=1).

> If you aren't sure which way to do something, do it both ways and see which works better
> &mdash; <cite>John Carmack</cite>
