### PR TITLE
Set enableManifestClasspath true by default

### DIFF
--- a/changelog/@unreleased/pr-1554.v2.yml
+++ b/changelog/@unreleased/pr-1554.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Set `enableManifestClasspath = true` by default for Java services.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1554

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -84,7 +84,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         }));
 
         addJava8GcLogging = objectFactory.property(Boolean.class).value(false);
-        enableManifestClasspath = objectFactory.property(Boolean.class).value(false);
+        enableManifestClasspath = objectFactory.property(Boolean.class).value(true);
 
         gc = objectFactory
                 .property(GcProfile.class)


### PR DESCRIPTION
==COMMIT_MSG==
We have a product that deploys SLS services on Windows machines, and these deploys break when the start command gets to be >8191 chars. That length is dominated by the classpath.

Having `enableManifestClasspath = true` by default will avoid these unexpected breakages and is believed to have no other effects.
==COMMIT_MSG==

