### PR TITLE
Update README for optional in recommendedProductDependencies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -380,12 +380,13 @@ recommendedProductDependencies {
         minimumVersion = rootProject.version
         maximumVersion = "${rootProject.version.tokenize('.')[0].toInteger()}.x.x"
         recommendedVersion = rootProject.version
-        optional = false
     }
 }
 ```
 
 The recommended product dependencies will be serialized into the jar manifest of the jar that the project produces. The SLS distribution and asset plugins will inspect the manifest of all jars in the server or asset and extract the recommended product dependencies.
+
+Marking a product dependency as optional in recommendedProductDependencies [is not currently supported](https://github.com/palantir/sls-packaging/issues/1208).
 
 ## License
 


### PR DESCRIPTION
## Before this PR
The README example for recommendedProductDependencies includes an optional field on the productDependency.  Although that field exists on the object, it has no effect until https://github.com/palantir/sls-packaging/issues/1208 is implemented.

## After this PR
==COMMIT_MSG==
Update README for optional in recommendedProductDependencies
==COMMIT_MSG==

This PR aims to reduce confusion about the supported status of optional deps in library dependencies.

## Possible downsides?
None known -- no code change