### PR TITLE
More specific command in lock file headers

### DIFF
--- a/changelog/@unreleased/pr-1585.v2.yml
+++ b/changelog/@unreleased/pr-1585.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: More specific command in lock file headers
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1585

--- a/gradle-sls-packaging-api/src/main/java/com/palantir/gradle/dist/SchemaVersionLockFile.java
+++ b/gradle-sls-packaging-api/src/main/java/com/palantir/gradle/dist/SchemaVersionLockFile.java
@@ -29,7 +29,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableSchemaVersionLockFile.class)
 public interface SchemaVersionLockFile {
 
-    String COMMENT = "Run ./gradlew --write-locks to regenerate this file";
+    String COMMENT = "Run ./gradlew writeSchemaVersionLocks to regenerate this file";
     String LOCK_FILE = "schema-versions.lock";
     int VERSION = 1;
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 
 public final class ProductDependencyLockFile {
 
-    private static final String HEADER = "# Run ./gradlew --write-locks to regenerate this file\n";
+    private static final String HEADER = "# Run ./gradlew writeProductDependenciesLocks to regenerate this file\n";
     public static final String PROJECT_VERSION = "$projectVersion";
     private static final Pattern LOCK_PATTERN = Pattern.compile(
             "^(?<group>[^:]+):(?<name>[^ ]+) \\((?<min>[^,]+), (?<max>[^\\)]+)\\)(?<optional> optional)?$");

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
@@ -25,7 +25,7 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
         buildFile << 'apply plugin: com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin'
 
         file("product-dependencies.lock").text = '''\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeProductDependenciesLocks to regenerate this file
             com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent()
         def mavenRepo = generateMavenRepo('com.palantir.product:test:1.0.0')
@@ -52,12 +52,12 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
 
     def "merges product dependency constraints from different projects"() {
         file("a/product-dependencies.lock").text = '''\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeProductDependenciesLocks to regenerate this file
             com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent()
 
         file("b/product-dependencies.lock").text = '''\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeProductDependenciesLocks to regenerate this file
             com.palantir.product:test (1.2.0, 1.6.x)
         '''.stripIndent()
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginTest.groovy
@@ -27,7 +27,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
 
     def "get version from lock file"() {
         project.file("product-dependencies.lock").text = '''\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent()
 
@@ -41,7 +41,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
     def "resolves project versions into concrete version"() {
         project.version = "1.1.0"
         project.file("product-dependencies.lock").text = '''\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:test ($projectVersion, 1.x.x)
         '''.stripIndent()
 
@@ -63,7 +63,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
 
     def "fails if dependency does not exist in lock file"() {
         project.file("product-dependencies.lock").text = '''\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent()
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -30,7 +30,7 @@ class ProductDependencyLockFileTest extends Specification {
 
         then:
         ProductDependencyLockFile.asString(sample, [] as Set<ProductId>) == """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.other:bar (0.2.0, 0.x.x) optional
         com.palantir.product:foo (1.20.0, 1.x.x)
         """.stripIndent()
@@ -44,7 +44,7 @@ class ProductDependencyLockFileTest extends Specification {
         )
         then:
         result == '''\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:foo ($projectVersion, 1.x.x)
         '''.stripIndent()
     }
@@ -52,7 +52,7 @@ class ProductDependencyLockFileTest extends Specification {
     def 'deserialize'() {
         when:
         List<ProductDependency> result = ProductDependencyLockFile.fromString("""\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.other:bar (0.2.0, 0.x.x)
         com.palantir.product:foo (1.20.0, 1.x.x) optional
         """.stripIndent(), "0.0.0")

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -111,7 +111,7 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
             }
         """.stripIndent()
         file('product-dependencies.lock').text = """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 2.0.0)
         group2:name2 (1.0.0, 2.x.x)
         """.stripIndent()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -291,7 +291,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
         """.stripIndent()
         file('product-dependencies.lock').text = """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
         group2:name2 (1.0.0, 1.x.x)
         """.stripIndent()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -46,7 +46,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         file('product-dependencies.lock').text = """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group:name2 (2.0.0, 2.x.x)
         """.stripIndent()
 
@@ -78,7 +78,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         file('product-dependencies.lock').text = """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
         """.stripIndent()
 
@@ -100,7 +100,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         file('product-dependencies.lock').text = """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
         """.stripIndent()
 
@@ -159,7 +159,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent())
 
         file('product-dependencies.lock', barDir).text = """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.group:foo-service (\$projectVersion, 1.x.x)
         """.stripIndent()
 
@@ -194,7 +194,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         then:
         buildResult.wasExecuted(':createManifest')
         file('product-dependencies.lock').text == """\
-        # Run ./gradlew --write-locks to regenerate this file
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
         """.stripIndent()
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
@@ -53,7 +53,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
 
         file('schema-versions.lock').text = """\
         ---
-        comment: "Run ./gradlew --write-locks to regenerate this file"
+        comment: "Run ./gradlew writeSchemaVersionLocks to regenerate this file"
         schemaMigrations:
         - type: "offline"
           from: 52
@@ -89,7 +89,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
 
         file('schema-versions.lock').text = """\
         ---
-        comment: "Run ./gradlew --write-locks to regenerate this file"
+        comment: "Run ./gradlew writeSchemaVersionLocks to regenerate this file"
         schemaMigrations:
         - type: "offline"
           from: 53
@@ -115,7 +115,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
 
         file('schema-versions.lock').text = """\
         ---
-        comment: "Run ./gradlew --write-locks to regenerate this file"
+        comment: "Run ./gradlew writeSchemaVersionLocks to regenerate this file"
         schemaMigrations:
         - type: "offline"
           from: 53
@@ -147,7 +147,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         buildResult.wasExecuted(':createManifest')
         file('schema-versions.lock').text == """\
         ---
-        comment: "Run ./gradlew --write-locks to regenerate this file"
+        comment: "Run ./gradlew writeSchemaVersionLocks to regenerate this file"
         schemaMigrations:
         - type: "offline"
           from: 53

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ distribution {
 sls-packaging also maintains a lockfile, `product-dependencies.lock`, which should be checked in to Git.  This file is an accurate reflection of all the inferred and explicitly defined product dependencies. Run **`./gradlew --write-locks`** or **`./gradlew writeProductDependenciesLocks`** to update it. e.g.
 
 ```
-# Run ./gradlew --write-locks to regenerate this file
+# Run ./gradlew writeProductDependenciesLocks to regenerate this file
 com.palantir.auth:auth-service (1.2.0, 1.6.x)
 com.palantir.storage:storage-service (3.56.0, 3.x.x)
 com.palantir.email:email-service (1.200.3, 2.x.x) optional
@@ -142,7 +142,7 @@ Run **`./gradlew --write-locks`** or **`./gradlew writeSchemaVersionLocks`** to 
 
 ```
 ---
-comment: "Run ./gradlew --write-locks to regenerate this file"
+comment: "Run ./gradlew writeSchemaVersionLocks to regenerate this file"
 schemaMigrations:
 - type: "online"
   from: 100


### PR DESCRIPTION
Builds on https://github.com/palantir/sls-packaging/pull/1178 which added the `writeProductDependenciesLocks` command, and https://github.com/palantir/sls-packaging/pull/1454 which added the `writeSchemaVersionLocks` command.

## Before this PR
For the same reasons as in https://github.com/palantir/gradle-consistent-versions/pull/1122, we'd like to give users a more specific command than `./gradlew --write-locks` to update their `product-dependencies.lock` and `schema-versions.lock` files.

`--write-locks` updates all lock files, not just the file with the header.  We mention these commands in the README, and have them in code at https://github.com/palantir/sls-packaging/blob/c99e99bbdacc8c3a97661c25c0d307c6aab3764b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java#L67-L68 but do not use them in the file headers.

On one internal repo, the difference is about 20s -> 12s for using `writeProductDependenciesLocks` instead of `--write-locks`, and 20s -> 9s for using `writeSchemaVersionLocks` instead of `--write-locks`.

## After this PR
==COMMIT_MSG==
More specific command in lock file headers
==COMMIT_MSG==

The old `--write-locks` syntax still works, it is just not advertised in the file's header comment.

## Possible downsides?
The `--write-locks` syntax is now de-emphasized, and users wanting to update all their lock files in one command may have trouble discovering it.