### PR TITLE
Revert "Allow plugins to configure where the configuration.yml is included from (#1629)"

### DIFF
--- a/changelog/@unreleased/pr-1632.v2.yml
+++ b/changelog/@unreleased/pr-1632.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Revert "Allow plugins to configure where the configuration.yml is included
+    from (#1629)"
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1632

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -57,7 +56,6 @@ public class BaseDistributionExtension {
     private final SetProperty<ProductId> ignoredProductDependencies;
     private final ProviderFactory providerFactory;
     private final MapProperty<String, Object> manifestExtensions;
-    private final RegularFileProperty configurationYml;
     private final String projectName;
     private Configuration productDependenciesConfig;
 
@@ -77,8 +75,6 @@ public class BaseDistributionExtension {
 
         manifestExtensions =
                 project.getObjects().mapProperty(String.class, Object.class).empty();
-
-        configurationYml = project.getObjects().fileProperty().fileValue(project.file("deployment/configuration.yml"));
 
         projectName = project.getName();
     }
@@ -249,10 +245,6 @@ public class BaseDistributionExtension {
 
     public final void setManifestExtensions(Map<String, Object> extensions) {
         manifestExtensions.set(extensions);
-    }
-
-    public final RegularFileProperty getConfigurationYml() {
-        return configurationYml;
     }
 
     public final Configuration getProductDependenciesConfig() {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -101,18 +101,9 @@ final class DistTarTask {
             });
 
             root.into("deployment", t -> {
-                // We exclude configuration.yml from the general "deployment" importer, as it is special cased and
-                // handled separately below.
-                t.exclude("configuration.yml");
                 t.from("deployment");
                 t.from(project.getLayout().getBuildDirectory().dir("deployment"));
                 t.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE);
-            });
-
-            root.into("deployment", t -> {
-                // Import configuration.yml from the where it is declared in the extension, allowing tasks to
-                // generate it and have dependent tasks (like this distTar) get the correct task deps.
-                t.from(distributionExtension.getConfigurationYml()).rename(_ignored -> "configuration.yml");
             });
         });
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -358,34 +358,6 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         actualConfiguration == deploymentConfiguration
     }
 
-    def 'allows another task to produce configuration.yml'() {
-        given:
-        createUntarBuildFile(buildFile)
-        debug = true
-
-        // language=Gradle
-        buildFile << '''
-            task createConfigurationYml {
-                outputs.file('build/some-place/configuration-but-called-something-else.yml')
-                
-                doFirst {
-                    file('build/some-place/configuration-but-called-something-else.yml').text = 'custom: yml'
-                }
-            }
-
-            distribution {
-                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile }) 
-            }
-        '''.stripIndent(true)
-
-        when:
-        runTasks(':build', ':distTar', ':untar')
-
-        then:
-        String actualConfiguration = new File(projectDir, 'dist/service-name-0.0.1/deployment/configuration.yml').text
-        actualConfiguration == 'custom: yml'
-    }
-
     def 'produce distribution bundle with start script that passes default JVM options'() {
         given:
         createUntarBuildFile(buildFile)


### PR DESCRIPTION
This reverts commit b7b16f7556dd1dc1351f9bad7a0642787024d844.

## Before this PR
After #1629, internal repos are failing with an error. 

## After this PR
Revert the PR until we have time to work out why this went wrong.

cc @pkoenig10 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

