### PR TITLE
Allow plugins to configure where the configuration.yml is included from, take 2

### DIFF
--- a/changelog/@unreleased/pr-1633.v2.yml
+++ b/changelog/@unreleased/pr-1633.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Allow plugins to configure/read where the configuration.yml is included
+    from
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1633

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -56,6 +57,7 @@ public class BaseDistributionExtension {
     private final SetProperty<ProductId> ignoredProductDependencies;
     private final ProviderFactory providerFactory;
     private final MapProperty<String, Object> manifestExtensions;
+    private final RegularFileProperty configurationYml;
     private final String projectName;
     private Configuration productDependenciesConfig;
 
@@ -75,6 +77,8 @@ public class BaseDistributionExtension {
 
         manifestExtensions =
                 project.getObjects().mapProperty(String.class, Object.class).empty();
+
+        configurationYml = project.getObjects().fileProperty().fileValue(project.file("deployment/configuration.yml"));
 
         projectName = project.getName();
     }
@@ -245,6 +249,10 @@ public class BaseDistributionExtension {
 
     public final void setManifestExtensions(Map<String, Object> extensions) {
         manifestExtensions.set(extensions);
+    }
+
+    public final RegularFileProperty getConfigurationYml() {
+        return configurationYml;
     }
 
     public final Configuration getProductDependenciesConfig() {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -101,9 +101,18 @@ final class DistTarTask {
             });
 
             root.into("deployment", t -> {
+                // We exclude configuration.yml from the general "deployment" importer, as it is special cased and
+                // handled separately below.
+                t.exclude("configuration.yml");
                 t.from("deployment");
                 t.from(project.getLayout().getBuildDirectory().dir("deployment"));
                 t.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE);
+            });
+
+            root.into("deployment", t -> {
+                // Import configuration.yml from the where it is declared in the extension, allowing tasks to
+                // generate it and have dependent tasks (like this distTar) get the correct task deps.
+                t.from(distributionExtension.getConfigurationYml()).rename(_ignored -> "configuration.yml");
             });
         });
     }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -112,7 +112,22 @@ final class DistTarTask {
             root.into("deployment", t -> {
                 // Import configuration.yml from the where it is declared in the extension, allowing tasks to
                 // generate it and have dependent tasks (like this distTar) get the correct task deps.
-                t.from(distributionExtension.getConfigurationYml()).rename(_ignored -> "configuration.yml");
+                t.from(distributionExtension.getConfigurationYml().map(file -> {
+                    // We enforce the file is called configuration.yml. Unfortunately, there is an internal
+                    // piece of code that deduplicates files in gradle-sls-docker. This deduplication is done
+                    // using this copyspec. Were we to just call `.rename()` on this copyspec arm (to allow plugin
+                    // devs to output their generated configuration.ymls to some file not called configuration.yml) this
+                    // rename happens after the renames in the file deduplication code. Unfortunately, it was very hard
+                    // to disentangle the file deduplication from using this copyspec and maintain build performance
+                    // - instead we choose to simply check that the `configuration.yml` is called the right thing
+                    // so it doesn't need to be renamed here.
+                    if (file.getAsFile().getName().equals("configuration.yml")) {
+                        return file;
+                    }
+
+                    throw new IllegalStateException("The file set to be the value of getConfigurationYml() "
+                            + "must be called configuration.yml. Instead, it was called " + file.getAsFile());
+                }));
             });
         });
     }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -386,6 +386,33 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         actualConfiguration == 'custom: yml'
     }
 
+    def 'errors out if the custom configuration.yml location is not a file called configuration.yml'() {
+        given:
+        createUntarBuildFile(buildFile)
+        debug = true
+
+        // language=Gradle
+        buildFile << '''
+            task createConfigurationYml {
+                outputs.file('build/some-place/something-else.yml')
+                
+                doFirst {
+                    file('build/some-place/something-else.yml').text = 'custom: yml'
+                }
+            }
+
+            distribution {
+                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile }) 
+            }
+        '''.stripIndent(true)
+
+        when:
+        def output = runTasksAndFail(':build', ':distTar', ':untar').output
+
+        then:
+        output.contains('must be called configuration.yml')
+    }
+
     def 'produce distribution bundle with start script that passes default JVM options'() {
         given:
         createUntarBuildFile(buildFile)

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -366,10 +366,10 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         // language=Gradle
         buildFile << '''
             task createConfigurationYml {
-                outputs.file('build/some-place/configuration-but-called-something-else.yml')
+                outputs.file('build/some-place/configuration.yml')
                 
                 doFirst {
-                    file('build/some-place/configuration-but-called-something-else.yml').text = 'custom: yml'
+                    file('build/some-place/configuration.yml').text = 'custom: yml'
                 }
             }
 


### PR DESCRIPTION
## Before this PR
See original issue at https://github.com/palantir/sls-packaging/pull/1629

When we rolled this out internally, it interacted poorly with some internal code that does file deduplication in container image layers. This deduplication code uses the copyspec from this repo in order to avoid actually running `distTar` in order to build a container image, so it meant that adding the `.rename` messed with what it was doing. These interactions are extremely unfortunate, but there's no clear way to remove the copyspec copying without destroying build iteration performance.

## After this PR
==COMMIT_MSG==
Allow plugins to configure/read where the configuration.yml is included from
==COMMIT_MSG==

We just carefully avoid doing a `rename` this time and add a mega comment about it.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

