### PR TITLE
Make input/output methods public on CreateManifestTask

### DIFF
--- a/changelog/@unreleased/pr-1641.v2.yml
+++ b/changelog/@unreleased/pr-1641.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Make input/output methods public on CreateManifestTask
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1641

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -66,25 +66,25 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 public abstract class CreateManifestTask extends DefaultTask {
 
     @Input
-    abstract SetProperty<ProductId> getInRepoProductIds();
+    public abstract SetProperty<ProductId> getInRepoProductIds();
 
     @Input
-    abstract Property<String> getServiceName();
+    public abstract Property<String> getServiceName();
 
     @Input
-    abstract Property<String> getServiceGroup();
+    public abstract Property<String> getServiceGroup();
 
     @Input
-    abstract Property<ProductType> getProductType();
+    public abstract Property<ProductType> getProductType();
 
     @Input
-    abstract MapProperty<String, Object> getManifestExtensions();
+    public abstract MapProperty<String, Object> getManifestExtensions();
 
     @InputFile
-    abstract RegularFileProperty getProductDependenciesFile();
+    public abstract RegularFileProperty getProductDependenciesFile();
 
     @OutputFile
-    abstract RegularFileProperty getManifestFile();
+    public abstract RegularFileProperty getManifestFile();
 
     @Input
     final String getProjectVersion() {


### PR DESCRIPTION
## Before this PR
Need to access the output property of `CreateManifestTask` but it is package-private

## After this PR
==COMMIT_MSG==
Make input/output methods public on CreateManifestTask
==COMMIT_MSG==

## Possible downsides?
Makes this "public api" but this should be public api anyway.
