### PR TITLE
Bump the minimum required gradle version to handle mr-jars

### DIFF
--- a/changelog/@unreleased/pr-1642.v2.yml
+++ b/changelog/@unreleased/pr-1642.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump the minimum required gradle version to handle mr-jars
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1642

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/SlsBaseDistPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/SlsBaseDistPlugin.java
@@ -31,7 +31,7 @@ public class SlsBaseDistPlugin implements Plugin<Project> {
 
     public static final String SLS_DIST_USAGE = "sls-dist";
 
-    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("7.6");
+    public static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("7.6.4");
 
     @Override
     public final void apply(Project project) {


### PR DESCRIPTION
This will unblock jackson upgrades in this repo, and allow some other repos to take dependency upgrades as well!

==COMMIT_MSG==
Bump the minimum required gradle version to handle mr-jars
==COMMIT_MSG==
