### PR TITLE
sls-packaging sets the individual-addressability extension

### DIFF
--- a/changelog/@unreleased/pr-1643.v2.yml
+++ b/changelog/@unreleased/pr-1643.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: sls-packaging sets the individual-addressability extension default
+    value to `true` when not otherwise specified
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1643

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.dist;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -48,6 +49,9 @@ public class BaseDistributionExtension {
             + "(:(?<classifier>[^:@?]*))?"
             + "(@(?<type>[^:@?]*))?");
 
+    private static final ImmutableMap<String, Object> DEFAULT_MANIFEST_EXTENSIONS =
+            ImmutableMap.of("require-individual-addressability", true);
+
     private final Project project;
     private final Property<String> serviceGroup;
     private final Property<String> serviceName;
@@ -76,7 +80,7 @@ public class BaseDistributionExtension {
         serviceName.set(project.provider(project::getName));
 
         manifestExtensions =
-                project.getObjects().mapProperty(String.class, Object.class).empty();
+                project.getObjects().mapProperty(String.class, Object.class).value(DEFAULT_MANIFEST_EXTENSIONS);
 
         configurationYml = project.getObjects().fileProperty().fileValue(project.file("deployment/configuration.yml"));
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionExtensionTest.groovy
@@ -50,6 +50,8 @@ class JavaServiceDistributionExtensionTest extends Specification {
 
             env 'a': 'b'
             env 'c': 'd'
+
+            manifestExtensions 'foo': 'bar'
         }
 
         then:
@@ -58,6 +60,9 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.defaultJvmOpts.get() == ['a', 'b', 'c', 'd']
         ext.excludeFromVar.get() == ['log', 'run', 'a', 'b', 'c', 'd']
         ext.env.get() == ['a': 'b', 'c': 'd']
+        // defaults should be present
+        ext.manifestExtensions.get().get('require-individual-addressability') == true
+        ext.manifestExtensions.get().get('foo') == 'bar'
     }
 
     def 'collection setters replace existing data'() {
@@ -86,6 +91,7 @@ class JavaServiceDistributionExtensionTest extends Specification {
         ext.defaultJvmOpts.get() == ['c', 'd']
         ext.excludeFromVar.get() == ['c', 'd']
         ext.env.get() == ['foo': 'bar']
+        ext.manifestExtensions.get() == ['foo': 'bar']
     }
 
     def 'sensible defaults' () {


### PR DESCRIPTION
We enforce this everywhere in code, however we need to make sure stragglers are picked up to avoid infrastructure failures. We could assume the manifest default is true, however that is risky for older product. This way new releases pick up the new value if it's not already specified.

==COMMIT_MSG==
sls-packaging sets the individual-addressability extension default value to `true` when not otherwise specified
==COMMIT_MSG==

## Possible downsides?
Ideally we excavate this into buildscripts first, which we've done in 99.9% of projects at this point. This acts as a backstop for one-off projects, assuming they take sls-packaging upgrades. This will apply to other languages as well as Java.

