### PR TITLE
Add a helm-chart.v1 product type

### DIFF
--- a/changelog/@unreleased/pr-1645.v2.yml
+++ b/changelog/@unreleased/pr-1645.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Added the `HELM_CHART_V1` `ProductType`.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1645

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductType.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductType.java
@@ -27,4 +27,7 @@ public enum ProductType {
 
     @JsonProperty("asset.v1")
     ASSET_V1,
+
+    @JsonProperty("helm-chart.v1")
+    HELM_CHART_V1,
 }


### PR DESCRIPTION
## Before this PR
The createManifest task could only be used to create services, daemons, or assets.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added the `HELM_CHART_V1` `ProductType`.
==COMMIT_MSG==

This can be used by downstream Gradle logic bundling Helm charts.