### PR TITLE
`ConfigTarTask` supports custom `configuration.yml` location

### DIFF
--- a/changelog/@unreleased/pr-1646.v2.yml
+++ b/changelog/@unreleased/pr-1646.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '`ConfigTarTask` supports custom `configuration.yml` location'
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1646

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/DeploymentDirInclusion.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/DeploymentDirInclusion.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.ProjectLayout;
+
+public final class DeploymentDirInclusion {
+
+    public static void includeFromDeploymentDirs(
+            ProjectLayout projectLayout,
+            BaseDistributionExtension distributionExtension,
+            CopySpec root,
+            Action<CopySpec> extraConfig) {
+
+        root.into("deployment", t -> {
+            // We exclude configuration.yml from the general "deployment" importer, as it is special cased and
+            // handled separately below.
+            t.exclude("configuration.yml");
+            t.from("deployment");
+            t.from(projectLayout.getBuildDirectory().dir("deployment"));
+            extraConfig.execute(t);
+        });
+
+        root.into("deployment", t -> {
+            // Import configuration.yml from the where it is declared in the extension, allowing tasks to
+            // generate it and have dependent tasks (like this distTar) get the correct task deps.
+            t.from(distributionExtension.getConfigurationYml().map(file -> {
+                // We enforce the file is called configuration.yml. Unfortunately, there is an internal
+                // piece of code that deduplicates files in gradle-sls-docker. This deduplication is done
+                // using this copyspec. Were we to just call `.rename()` on this copyspec arm (to allow plugin
+                // devs to output their generated configuration.ymls to some file not called configuration.yml) this
+                // rename happens after the renames in the file deduplication code. Unfortunately, it was very hard
+                // to disentangle the file deduplication from using this copyspec and maintain build performance
+                // - instead we choose to simply check that the `configuration.yml` is called the right thing
+                // so it doesn't need to be renamed here.
+                if (file.getAsFile().getName().equals("configuration.yml")) {
+                    return file;
+                }
+
+                throw new IllegalStateException("The file set to be the value of getConfigurationYml() "
+                        + "must be called configuration.yml. Instead, it was called " + file.getAsFile());
+            }));
+        });
+    }
+
+    private DeploymentDirInclusion() {}
+}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -17,9 +17,9 @@
 package com.palantir.gradle.dist.tasks;
 
 import com.palantir.gradle.dist.BaseDistributionExtension;
+import com.palantir.gradle.dist.DeploymentDirInclusion;
 import com.palantir.gradle.dist.ObjectMappers;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
-import java.io.File;
 import java.io.IOException;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -55,8 +55,8 @@ public abstract class ConfigTarTask extends Tar {
                     "Creates a compressed, gzipped tar file that contains the sls configuration files for the product");
             task.setCompression(Compression.GZIP);
 
-            task.from(new File(project.getProjectDir(), "deployment"));
-            task.from(new File(project.getBuildDir(), "deployment"));
+            DeploymentDirInclusion.includeFromDeploymentDirs(project.getLayout(), ext, task, _ignored -> {});
+
             task.getDestinationDirectory()
                     .set(project.getLayout().getBuildDirectory().dir("distributions"));
             task.getArchiveBaseName().set(ext.getDistributionServiceName());

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/ConfigTarTask.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.dist.tasks;
 import com.palantir.gradle.dist.BaseDistributionExtension;
 import com.palantir.gradle.dist.ObjectMappers;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
-import groovy.lang.Closure;
 import java.io.File;
 import java.io.IOException;
 import org.gradle.api.Action;
@@ -30,17 +29,10 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Compression;
 import org.gradle.api.tasks.bundling.Tar;
 
-public class ConfigTarTask extends Tar {
+public abstract class ConfigTarTask extends Tar {
     @Override
     public final AbstractCopyTask from(Object... sourcePaths) {
         return this.from(sourcePaths, _ignored -> {});
-    }
-
-    @Override
-    @SuppressWarnings({"RawTypes", "deprecation"})
-    public final AbstractCopyTask from(Object sourcePath, Closure closure) {
-        // TODO(fwindheuser): Replace usage of 'ClosureBackedAction' before moving to Gradle 8.
-        return this.from(sourcePath, new org.gradle.util.ClosureBackedAction<>(closure));
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/sls-packaging/pull/1629, we added support for specifying a different location/task for configuraion.ymls to be generated.

Unfortunately, as part of the PR I forgot about the `configTar` task.

## After this PR
==COMMIT_MSG==
`ConfigTarTask` supports custom `configuration.yml` location
==COMMIT_MSG==

## Possible downsides?
The number of places where Gradle plugins yolo-create their own config tar task is kinda horrifying. This certainly hasn't been built "well". I don't think these should break, but you really never know.
