### PR TITLE
Allow `ArtifactLocator` s to have inputs derived from task outputs.

### DIFF
--- a/changelog/@unreleased/pr-1662.v2.yml
+++ b/changelog/@unreleased/pr-1662.v2.yml
@@ -1,6 +1,5 @@
 type: fix
 fix:
-  description: Use `configureEach` instead of `whenObjectAdded` for the `artifacts`
-    block.
+  description: Allow `ArtifactLocator`s to have inputs derived from task outputs.
   links:
   - https://github.com/palantir/sls-packaging/pull/1662

--- a/changelog/@unreleased/pr-1662.v2.yml
+++ b/changelog/@unreleased/pr-1662.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Use `configureEach` instead of `whenObjectAdded` for the `artifacts`
+    block.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1662

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -80,7 +80,7 @@ public class BaseDistributionExtension {
         optionalProductDependencies = project.getObjects().setProperty(ProductId.class);
         ignoredProductDependencies = project.getObjects().setProperty(ProductId.class);
         artifacts = project.getObjects().domainObjectSet(ArtifactLocator.class);
-        artifacts.whenObjectAdded(ArtifactLocator::isValid);
+        artifacts.configureEach(ArtifactLocator::isValid);
 
         serviceGroup.set(project.provider(() -> project.getGroup().toString()));
         serviceName.set(project.provider(project::getName));

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -80,7 +80,6 @@ public class BaseDistributionExtension {
         optionalProductDependencies = project.getObjects().setProperty(ProductId.class);
         ignoredProductDependencies = project.getObjects().setProperty(ProductId.class);
         artifacts = project.getObjects().domainObjectSet(ArtifactLocator.class);
-        artifacts.configureEach(ArtifactLocator::isValid);
 
         serviceGroup.set(project.provider(() -> project.getGroup().toString()));
         serviceName.set(project.provider(project::getName));

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ArtifactLocator.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ArtifactLocator.java
@@ -16,9 +16,6 @@
 
 package com.palantir.gradle.dist.artifacts;
 
-import com.google.common.base.Preconditions;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import java.net.URI;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 
@@ -28,19 +25,4 @@ public interface ArtifactLocator {
 
     @Input
     Property<String> getUri();
-
-    default void isValid() {
-        Preconditions.checkNotNull(getType().get(), "type must be specified");
-        Preconditions.checkNotNull(getUri().get(), "uri must be specified");
-        uriIsValid(getUri().get());
-    }
-
-    private static void uriIsValid(String uri) {
-        try {
-            // Throws IllegalArgumentException if URI does not conform to RFC 2396
-            URI.create(uri);
-        } catch (IllegalArgumentException e) {
-            throw new SafeIllegalArgumentException("uri is not valid", e);
-        }
-    }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -60,6 +60,7 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
@@ -84,7 +85,7 @@ public abstract class CreateManifestTask extends DefaultTask {
     @Input
     public abstract MapProperty<String, Object> getManifestExtensions();
 
-    @Input
+    @Nested
     public abstract SetProperty<ArtifactLocator> getArtifacts();
 
     @InputFile


### PR DESCRIPTION
## Before this PR
~When you use `whenObjectAdded` it will eagerly realise any objects that exist in the provider:~

> ```
> Adds an {@code Action} to be executed when an object is added to this collection.
> Like {@link #all(Action)}, this method will cause all objects in this container to be realized.
> ```

~So if a provider has a task output, it will complain because it's trying to realise it at configuration time, which is not possible.~

It turns out that the validation in `ArtifactLocator` would always call `get`, so it's never enough to do a `configureEach` or a `whenObjectAdded`, as we would eagerly realise it the moment a concrete version was added to the set.

An alternative is to wrap the `ArtifactLocator` into a provider, however, I believe that will lose task dependency information!

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow `ArtifactLocator`s to have inputs derived from task outputs.
==COMMIT_MSG==

Use `@Nested` in `SetProperty` task input for `CreateManifest` task. The validation happens when converting to `JsonArtifactLocator`. Add integration tests that allow using derived task output providers.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

