### PR TITLE
assets can also have custom configuration.yml locations

### DIFF
--- a/changelog/@unreleased/pr-1666.v2.yml
+++ b/changelog/@unreleased/pr-1666.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Allow plugins to configure/read where the configuration.yml is included
+    from **for assets**
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1666

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -16,12 +16,12 @@
 
 package com.palantir.gradle.dist.asset;
 
+import com.palantir.gradle.dist.DeploymentDirInclusion;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import com.palantir.gradle.dist.tasks.ConfigTarTask;
 import com.palantir.gradle.dist.tasks.CreateManifestTask;
-import java.io.File;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -81,13 +81,10 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
             String archiveRootDir = String.format(
                     "%s-%s", distributionExtension.getDistributionServiceName().get(), p.getVersion());
 
-            task.from(
-                    new File(project.getProjectDir(), "deployment"),
-                    t -> t.into(new File(String.format("%s/deployment", archiveRootDir))));
-
-            task.from(
-                    new File(project.getBuildDir(), "deployment"),
-                    t -> t.into(new File(String.format("%s/deployment", archiveRootDir))));
+            task.into(archiveRootDir, root -> {
+                DeploymentDirInclusion.includeFromDeploymentDirs(
+                        project.getLayout(), distributionExtension, root, _ignored -> {});
+            });
 
             distributionExtension
                     .getAssets()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -137,6 +137,34 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         dep2['maximum-version'] == '2.x.x'
     }
 
+    def 'allows another task to produce configuration.yml'() {
+        given:
+        createUntarBuildFile(buildFile)
+        debug = true
+
+        // language=Gradle
+        buildFile << '''
+            task createConfigurationYml {
+                outputs.file('build/some-place/configuration.yml')
+                
+                doFirst {
+                    file('build/some-place/configuration.yml').text = 'custom: yml'
+                }
+            }
+
+            distribution {
+                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile }) 
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasks(':distTar', ':untar')
+
+        then:
+        String actualConfiguration = new File(projectDir, 'dist/asset-name-0.0.1/deployment/configuration.yml').text
+        actualConfiguration == 'custom: yml'
+    }
+
     /**
      * Note: in this test, we are not checking that we can resolve exactly the right artifact,
      * as that is tricky to get right, when the configuration being resolved doesn't set any required attributes.


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/sls-packaging/pull/1629, we allowed plugins to specify where the configuration.yml comes from for java services. However, we forgot to the same for assets, which has caused issues internally.

## After this PR
==COMMIT_MSG==
Allow plugins to configure/read where the configuration.yml is included from **for assets**
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

