### PR TITLE
Revert "assets can also have custom configuration.yml locations"

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -16,12 +16,12 @@
 
 package com.palantir.gradle.dist.asset;
 
-import com.palantir.gradle.dist.DeploymentDirInclusion;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import com.palantir.gradle.dist.tasks.ConfigTarTask;
 import com.palantir.gradle.dist.tasks.CreateManifestTask;
+import java.io.File;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -81,10 +81,13 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
             String archiveRootDir = String.format(
                     "%s-%s", distributionExtension.getDistributionServiceName().get(), p.getVersion());
 
-            task.into(archiveRootDir, root -> {
-                DeploymentDirInclusion.includeFromDeploymentDirs(
-                        project.getLayout(), distributionExtension, root, _ignored -> {});
-            });
+            task.from(
+                    new File(project.getProjectDir(), "deployment"),
+                    t -> t.into(new File(String.format("%s/deployment", archiveRootDir))));
+
+            task.from(
+                    new File(project.getBuildDir(), "deployment"),
+                    t -> t.into(new File(String.format("%s/deployment", archiveRootDir))));
 
             distributionExtension
                     .getAssets()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -137,34 +137,6 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         dep2['maximum-version'] == '2.x.x'
     }
 
-    def 'allows another task to produce configuration.yml'() {
-        given:
-        createUntarBuildFile(buildFile)
-        debug = true
-
-        // language=Gradle
-        buildFile << '''
-            task createConfigurationYml {
-                outputs.file('build/some-place/configuration.yml')
-                
-                doFirst {
-                    file('build/some-place/configuration.yml').text = 'custom: yml'
-                }
-            }
-
-            distribution {
-                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile }) 
-            }
-        '''.stripIndent(true)
-
-        when:
-        runTasks(':distTar', ':untar')
-
-        then:
-        String actualConfiguration = new File(projectDir, 'dist/asset-name-0.0.1/deployment/configuration.yml').text
-        actualConfiguration == 'custom: yml'
-    }
-
     /**
      * Note: in this test, we are not checking that we can resolve exactly the right artifact,
      * as that is tricky to get right, when the configuration being resolved doesn't set any required attributes.


### PR DESCRIPTION
Reverts palantir/sls-packaging#1666

See our internal ticket PDS-560061. #1666 caused some assets (~I think those that don't define a `configuration.yml` path in the plugin configuration~ this turned out not to be true, it was assets that generate a `configuration.yml` at build time) to not include the `configuration.yml` in the final package.