### PR TITLE
assets can also have custom configuration.yml locations and fall back to `build/deployment/configuration.yml`

### DIFF
--- a/changelog/@unreleased/pr-1668.v2.yml
+++ b/changelog/@unreleased/pr-1668.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: assets can also have custom configuration.yml locations and the asset
+    plugin will fall back to `build/deployment/configuration.yml` if the `deployment/configuration.yml`
+    does not exist.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1668

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/DeploymentDirInclusion.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/DeploymentDirInclusion.java
@@ -63,8 +63,6 @@ public final class DeploymentDirInclusion {
             // `build/deployment/configuration.yml`.
             t.from(projectLayout.getBuildDirectory().file("deployment/configuration.yml"));
         });
-
-        root.int
     }
 
     private DeploymentDirInclusion() {}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/DeploymentDirInclusion.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/DeploymentDirInclusion.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.dist;
 import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.file.RegularFile;
 
 public final class DeploymentDirInclusion {
 
@@ -42,30 +41,6 @@ public final class DeploymentDirInclusion {
             // Import configuration.yml from the where it is declared in the extension, allowing tasks to
             // generate it and have dependent tasks (like this distTar) get the correct task deps.
             t.from(distributionExtension.getConfigurationYml().map(file -> {
-                // This is a bit of hack to "fall back" to a `build/deployment/configuration.yml` if the
-                // `deployment/configuration.yml` does not exist. This can happen when there's a templating setup
-                // that pre-exists the being able to configuration.yml on the extension and it outputs to
-                // `build/deployment/configuration.yml`.
-                if (!file.getAsFile().exists()) {
-                    RegularFile buildConfiguration = projectLayout
-                            .getBuildDirectory()
-                            .file("deployment/configuration.yml")
-                            .get();
-
-                    if (buildConfiguration.getAsFile().exists()) {
-                        return buildConfiguration;
-                    }
-
-                    throw new RuntimeException(
-                            "No configuration.yml found for product. SLS distributions require a configuration.yml. "
-                                    + "There are two reasons this could happen:\n"
-                                    + "* You have not added a static `deployment/configuration.yml`\n"
-                                    + "* There's a task that generates the configuration.yml that did not before run "
-                                    + "this task. You should ideally use the internal `sls-configuration-templating` "
-                                    + "plugin rather than rolling your own templating task (or manually set up the "
-                                    + "task dependency).");
-                }
-
                 // We enforce the file is called configuration.yml. Unfortunately, there is an internal
                 // piece of code that deduplicates files in gradle-sls-docker. This deduplication is done
                 // using this copyspec. Were we to just call `.rename()` on this copyspec arm (to allow plugin
@@ -81,7 +56,15 @@ public final class DeploymentDirInclusion {
                 throw new IllegalStateException("The file set to be the value of getConfigurationYml() "
                         + "must be called configuration.yml. Instead, it was called " + file.getAsFile());
             }));
+
+            // This is a bit of hack to "fall back" to a `build/deployment/configuration.yml` if the
+            // `deployment/configuration.yml` does not exist. This can happen when there's a templating setup
+            // that pre-exists the being able to configuration.yml on the extension and it outputs to
+            // `build/deployment/configuration.yml`.
+            t.from(projectLayout.getBuildDirectory().file("deployment/configuration.yml"));
         });
+
+        root.int
     }
 
     private DeploymentDirInclusion() {}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -16,12 +16,12 @@
 
 package com.palantir.gradle.dist.asset;
 
+import com.palantir.gradle.dist.DeploymentDirInclusion;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.SlsBaseDistPlugin;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import com.palantir.gradle.dist.tasks.ConfigTarTask;
 import com.palantir.gradle.dist.tasks.CreateManifestTask;
-import java.io.File;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -81,13 +81,10 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
             String archiveRootDir = String.format(
                     "%s-%s", distributionExtension.getDistributionServiceName().get(), p.getVersion());
 
-            task.from(
-                    new File(project.getProjectDir(), "deployment"),
-                    t -> t.into(new File(String.format("%s/deployment", archiveRootDir))));
-
-            task.from(
-                    new File(project.getBuildDir(), "deployment"),
-                    t -> t.into(new File(String.format("%s/deployment", archiveRootDir))));
+            task.into(archiveRootDir, root -> {
+                DeploymentDirInclusion.includeFromDeploymentDirs(
+                        project.getLayout(), distributionExtension, root, _ignored -> {});
+            });
 
             distributionExtension
                     .getAssets()

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -165,6 +165,32 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         actualConfiguration == 'custom: yml'
     }
 
+    def 'falls back to build/deployment/configuration.yml'() {
+        given:
+        createUntarBuildFile(buildFile)
+        debug = true
+
+        // language=Gradle
+        buildFile << '''
+            task createConfigurationYml {
+                outputs.file('build/deployment/configuration.yml')
+                
+                doFirst {
+                    file('build/deployment/configuration.yml').text = 'buildDir: yml'
+                }
+            }
+
+            tasks.distTar.dependsOn tasks.createConfigurationYml
+        '''.stripIndent(true)
+
+        when:
+        runTasks(':distTar', ':untar')
+
+        then:
+        String actualConfiguration = new File(projectDir, 'dist/asset-name-0.0.1/deployment/configuration.yml').text
+        actualConfiguration == 'buildDir: yml'
+    }
+
     /**
      * Note: in this test, we are not checking that we can resolve exactly the right artifact,
      * as that is tricky to get right, when the configuration being resolved doesn't set any required attributes.

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -137,6 +137,34 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         dep2['maximum-version'] == '2.x.x'
     }
 
+    def 'allows another task to produce configuration.yml'() {
+        given:
+        createUntarBuildFile(buildFile)
+        debug = true
+
+        // language=Gradle
+        buildFile << '''
+            task createConfigurationYml {
+                outputs.file('build/some-place/configuration.yml')
+                
+                doFirst {
+                    file('build/some-place/configuration.yml').text = 'custom: yml'
+                }
+            }
+
+            distribution {
+                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile }) 
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasks(':distTar', ':untar')
+
+        then:
+        String actualConfiguration = new File(projectDir, 'dist/asset-name-0.0.1/deployment/configuration.yml').text
+        actualConfiguration == 'custom: yml'
+    }
+
     /**
      * Note: in this test, we are not checking that we can resolve exactly the right artifact,
      * as that is tricky to get right, when the configuration being resolved doesn't set any required attributes.


### PR DESCRIPTION
## Before this PR
In #1666, we tried to allow assets to have a configurable location for their `configuration.yml`. However, the new codepath did not support having a templating task output to `build/deployment/configuration.yml`, which some internal products did for assets. Some of these products are very "basic" assets containing nothing apart from templated configuration and lack any real tests, meaning they managed to slip through and get published without any `configuration.yml`, go straight to prod and caused PDS-560061 and PDS-560082. Detailed RCA [here](https://pl.ntr/2nx). As part of the remediation, this change was reverted in #1667.

## After this PR
==COMMIT_MSG==
assets can also have custom configuration.yml locations and the asset plugin will fall back to `build/deployment/configuration.yml` if the `deployment/configuration.yml` does not exist.
==COMMIT_MSG==

## Possible downsides?
I haven't yet worked out how to make the task fail if there is no `configuration.yml` at all

