### PR TITLE
Override the JNA temporary directory to point to var/data/tmp

### DIFF
--- a/changelog/@unreleased/pr-1673.v2.yml
+++ b/changelog/@unreleased/pr-1673.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Override the JNA temporary directory to point to var/data/tmp
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1673

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -69,6 +69,7 @@ public final class LaunchConfig {
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
             "-Djava.io.tmpdir=var/data/tmp",
+            "-Djna.tmpdir=var/data/tmp",
             "-XX:ErrorFile=var/log/hs_err_pid%p.log",
             "-XX:HeapDumpPath=var/log",
             // Set DNS cache TTL to 10s to account for systems such as RDS and other

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -367,14 +367,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         buildFile << '''
             task createConfigurationYml {
                 outputs.file('build/some-place/configuration.yml')
-                
+
                 doFirst {
                     file('build/some-place/configuration.yml').text = 'custom: yml'
                 }
             }
 
             distribution {
-                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile }) 
+                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile })
             }
         '''.stripIndent(true)
 
@@ -395,14 +395,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         buildFile << '''
             task createConfigurationYml {
                 outputs.file('build/some-place/something-else.yml')
-                
+
                 doFirst {
                     file('build/some-place/something-else.yml').text = 'custom: yml'
                 }
             }
 
             distribution {
-                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile }) 
+                configurationYml.fileProvider(tasks.named('createConfigurationYml').map { it.outputs.files.singleFile })
             }
         '''.stripIndent(true)
 
@@ -455,6 +455,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 .jvmOpts([
                         '-XX:+CrashOnOutOfMemoryError',
                         '-Djava.io.tmpdir=var/data/tmp',
+                        '-Djna.tmpdir=var/data/tmp',
                         '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                         '-XX:HeapDumpPath=var/log',
                         '-Dsun.net.inetaddr.ttl=10',
@@ -485,6 +486,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 .jvmOpts([
                         '-XX:+CrashOnOutOfMemoryError',
                         '-Djava.io.tmpdir=var/data/tmp',
+                        '-Djna.tmpdir=var/data/tmp',
                         '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                         '-XX:HeapDumpPath=var/log',
                         '-Dsun.net.inetaddr.ttl=10',
@@ -537,6 +539,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 .jvmOpts([
                         '-XX:+CrashOnOutOfMemoryError',
                         '-Djava.io.tmpdir=var/data/tmp',
+                        '-Djna.tmpdir=var/data/tmp',
                         '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                         '-XX:HeapDumpPath=var/log',
                         '-Dsun.net.inetaddr.ttl=10',
@@ -567,6 +570,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 .jvmOpts([
                         '-XX:+CrashOnOutOfMemoryError',
                         '-Djava.io.tmpdir=var/data/tmp',
+                        '-Djna.tmpdir=var/data/tmp',
                         '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                         '-XX:HeapDumpPath=var/log',
                         '-Dsun.net.inetaddr.ttl=10',
@@ -610,6 +614,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             .jvmOpts([
                 '-XX:+CrashOnOutOfMemoryError',
                 '-Djava.io.tmpdir=var/data/tmp',
+                '-Djna.tmpdir=var/data/tmp',
                 '-XX:ErrorFile=var/log/hs_err_pid%p.log',
                 '-XX:HeapDumpPath=var/log',
                 '-Dsun.net.inetaddr.ttl=10',
@@ -1516,11 +1521,11 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             id 'com.palantir.consistent-versions' version '${Versions.GRADLE_CONSISTENT_VERSIONS}'
             id 'com.palantir.sls-java-service-distribution'
         }
-        
+
         repositories {
             mavenCentral()
         }
-        
+
         version '0.0.1'
         distribution {
             serviceName 'service-name'

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ com.palantir.foo:foo-service ($projectVersion, 1.x.x)
 
 _The `$projectVersion` string is a placeholder that will appear if your repo publishes multiple services, and one of them depends on another.  The actual manifest will contain a concrete version._
 
-The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default. 
+The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default.
 
 It's possible to further restrict the acceptable version range for a dependency by declaring a tighter constraint in a
 `productDependency` block - this will be merged with any constraints detected from other jars.
@@ -208,7 +208,7 @@ Apply the plugin using standard Gradle convention:
 Additionally, declare the version of [go-java-launcher](https://github.com/palantir/go-java-launcher) to use:
 
 ```
-# Add to 'versions.props' 
+# Add to 'versions.props'
 com.palantir.launching:* = 1.18.0
 ```
 
@@ -263,7 +263,7 @@ And the complete list of configurable properties:
  * (optional) `javaHome` a fixed override for the `JAVA_HOME` environment variable that will
    be applied when `init.sh` is run. When your `targetCompatibility` is Java 8 or less, this value will be blank. For
    Java 9 or higher will default to `$JAVA_<majorversion>_HOME` ie for Java 11 this would be `$JAVA_11_HOME`.
- * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default for Java 14 and lower), `hybrid` (default for Java 15 and higher) and `response-time`. Additionally, there is also `dangerous-no-profile` which does not apply any additional JVM flags and allows you to fully configure any GC settings through JVM options (not recommended for normal usage!). 
+ * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default for Java 14 and lower), `hybrid` (default for Java 15 and higher) and `response-time`. Additionally, there is also `dangerous-no-profile` which does not apply any additional JVM flags and allows you to fully configure any GC settings through JVM options (not recommended for normal usage!).
  * (optional) `addJava8GcLogging` add java 8 specific gc logging options.
 
 #### JVM Options
@@ -275,6 +275,8 @@ concatenating the following list of hard-coded *required options* and the list o
 Hard-coded required JVM options:
 - `-Djava.io.tmpdir=var/data/tmp`: Allocates temporary files inside the application installation folder rather than on
   `/tmp`; the latter is often space-constrained on cloud hosts.
+- `-Djna.tmpdir=var/data/tmp`: Allocates temporary JNA files inside the application installation folder rather than on
+  `${USER}/.cache`; the latter is often space-constrained on cloud hosts and filling it up can result in users not being able to login.
 
 The `go-java-launcher` and `init.sh` launchers additionally append the list of JVM options specified in the
 `var/conf/launcher-custom.yml` [configuration file](https://github.com/palantir/go-java-launcher). Note that later


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The JNA temporary directory was left to it's default which for most OS's is `$USER/.cache`.

There are two issues with this:
- This can be mounted as `noexec` which means JNA will fail (seen in prod)
- If we fill up this folder, the user may not be able to SSH in as the disk is full (very unlikely)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Override the JNA temporary directory to point to var/data/tmp
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

