### PR TITLE
Stop mergeDiagnosticJson having @CacheableTransform; speed up build

### DIFF
--- a/changelog/@unreleased/pr-1693.v2.yml
+++ b/changelog/@unreleased/pr-1693.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Do not use the remote build cache for `mergeDiagnosticJson`; it takes
+    far longer than just doing the operation locally. Avoids spamming output with
+    "Requesting from remote build cache" too.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1693

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractFileFromJar.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractFileFromJar.java
@@ -29,12 +29,12 @@ import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.work.DisableCachingByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Do *not* make this class cacheable using @CacheableTransform. It's far, far faster to just extract a single
-// file from a zip than to make network requrest to the remote build cache.
-// See https://github.com/palantir/sls-packaging/pull/1693
+@DisableCachingByDefault(
+        because = "Extracting a single file from a zip is much faster than making network requests to the build cache")
 public abstract class ExtractFileFromJar implements TransformAction<FileExtractParameter> {
     private static final Logger log = LoggerFactory.getLogger(ExtractFileFromJar.class);
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractFileFromJar.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractFileFromJar.java
@@ -32,6 +32,9 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// Do *not* make this class cacheable using @CacheableTransform. It's far, far faster to just extract a single
+// file from a zip than to make network requrest to the remote build cache.
+// See https://github.com/palantir/sls-packaging/pull/1693
 public abstract class ExtractFileFromJar implements TransformAction<FileExtractParameter> {
     private static final Logger log = LoggerFactory.getLogger(ExtractFileFromJar.class);
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractFileFromJar.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractFileFromJar.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformOutputs;
@@ -33,7 +32,6 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@CacheableTransform
 public abstract class ExtractFileFromJar implements TransformAction<FileExtractParameter> {
     private static final Logger log = LoggerFactory.getLogger(ExtractFileFromJar.class);
 


### PR DESCRIPTION
## Before this PR
There's a task `mergeDiagnosticJson`, which gathers up all the different possible diagnostics listed in json files from libraries and combines them together into the SLS manifest.

It does this by using an [artifact transform](https://docs.gradle.org/8.10.1/userguide/artifact_transforms.html), which has been listed as build cacheable using `@CacheableTransform`. We use remote build caches in builds, so this will, for each jar in the runtime classpath, attempt to load the result of extracting a single file from this jar from the remote build cache.

The runtime of actually executing extracting a single small file at a known path from a zip is _milliseconds_. Doing a network request to the build cache is likely 100s of milliseconds. Since there are many jars, we're making many build cache requests which all take significantly longer than just doing the operation locally. We don't even get to avoid downloading the input jars by using the build cache - they still need to exist to have their hash calculated for cache keys.

The result is that on internal projects this is a common sight:

![mergeDiagnosticJson](https://github.com/user-attachments/assets/5b7000da-af72-450c-b741-3c4f7485efce)

and we can check a build scan to see how bad this actually is: 372 cacheable transforms executed, taking a whopping 53 secs!

<img width="625" alt="Screenshot 2024-09-12 at 17 25 36" src="https://github.com/user-attachments/assets/120d2cfe-b534-41b1-8aa2-69784c2f73eb">

## After this PR
==COMMIT_MSG==
Do not use the remote build cache for `mergeDiagnosticJson`; it takes far longer than just doing the operation locally. Avoids spamming output with "Requesting from remote build cache" too.
==COMMIT_MSG==

This speeds it up hugely: 372 non-cacheable transforms executed, taking under 3 seconds!

<img width="617" alt="Screenshot 2024-09-12 at 17 25 43" src="https://github.com/user-attachments/assets/cbe7f379-3ad0-455c-9e97-a9b7f5740199">

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

