### PR TITLE
Add Foundry Product Type

### DIFF
--- a/changelog/@unreleased/pr-1703.v2.yml
+++ b/changelog/@unreleased/pr-1703.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Added Foundry Product Type
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1703

--- a/changelog/@unreleased/pr-1703.v2.yml
+++ b/changelog/@unreleased/pr-1703.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Added Foundry Product Type
+  description: Added the `FOUNDRY_PRODUCT_V1` `ProductType`.
   links:
   - https://github.com/palantir/sls-packaging/pull/1703

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductType.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductType.java
@@ -30,4 +30,7 @@ public enum ProductType {
 
     @JsonProperty("helm-chart.v1")
     HELM_CHART_V1,
+
+    @JsonProperty("foundry-product.v1")
+    FOUNDRY_PRODUCT_V1,
 }


### PR DESCRIPTION
## Before this PR
The createManifest task could only be used to create services, daemons, helm charts, or assets.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add Foundry Product Type

Foundry Products were recently introduced as a concept in Apollo. With this PR, we can create products with this product type using the sls packaging plugin.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->


This PR is analogous to how helm-charts were added here: https://github.com/palantir/sls-packaging/pull/1645