### PR TITLE
Hybrid (G1) GC uses the defeault 200ms MaxGCPauseMillis on JDK-21+

### DIFF
--- a/changelog/@unreleased/pr-1706.v2.yml
+++ b/changelog/@unreleased/pr-1706.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Hybrid (G1) GC uses the defeault 200ms MaxGCPauseMillis on JDK-21+
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1706

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -103,13 +103,13 @@ public interface GcProfile extends Serializable {
     // Match the MaxGCPauseMillis case
     @SuppressWarnings("AbbreviationAsWordInName")
     class Hybrid implements GcProfile {
-        // Applies to jdks older than 21:
-        // We use 500ms by default, up from the JDK default value of 200ms. Using G1, eden space is dynamically
-        // chosen based on the amount of memory which can be collected within the pause time target.
-        // Higher pause target values allow for more eden space, resulting in more stable old generation
-        // in high-garbage or low-gc-thread scenarios. In the happy case, increasing the pause target increases
-        // both throughput and latency. In degenerate cases, a low target can cause the garbage collector to
-        // thrash and reduce throughput while increasing latency.
+        // For Java versions older than 21 we use 500ms by default, up from the JDK default value of 200ms for
+        // historical reasons. Java 21 builds seem to interact poorly with this value, causing frequent full
+        // GC cycles. The 500ms value was chosen at a time when GC thread counts were based on cpu shares
+        // rather than the underlying physical cores (prior to https://bugs.openjdk.org/browse/JDK-8281181),
+        // so services tended to thrash in GC to meet the 200ms threshold, promoting data too quickly to old gen.
+        // This is no longer the case, however we are leaving the Java 17 values where they've been, and making
+        // changes targeting Java 21 and beyond where we've observed significant improvements.
         private static final int LEGACY_MAX_GC_PAUSE_MILLIS = 500;
 
         private OptionalInt maxGCPauseMillis = OptionalInt.empty();

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1366,7 +1366,8 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
-        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseNUMA', "-XX:MaxGCPauseMillis=200"])
+        actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseNUMA'])
+        actualStaticConfig.jvmOpts().stream().noneMatch { it.contains("MaxGCPauseMillis") }
     }
 
     def 'applies java agents'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1336,7 +1336,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
     }
 
     def 'gc profile null configuration closure on java 21'() {
-        // We set a different different default MaxGCPauseMillis in JDK-21 than older JDKs.
+        // We do not declare MaxGCPauseMillis in JDK-21 unless a value is explicitly configured.
         given:
         buildFile << '''
             plugins {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1285,6 +1285,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 serviceName 'service-name'
                 mainClass 'test.Test'
+                javaVersion 17
                 gc 'hybrid'
             }
         '''.stripIndent()


### PR DESCRIPTION
It seems that the heuristics have gone a bit sideways in JDK-21 causing degenerate full gc pauses unnecessarily when we configure `-XX:MaxGCPauseMillis=500`, however setting the default 200ms value resolves this behavior.

Note that we deployed the increase from 200ms to 500ms at a time when container cpu shares informed the JDKs processor count, thus gc threads/etc, which is no longer the case. As such, it should be safe (and generally more stable) to use the hardened default values from the jdk.

==COMMIT_MSG==
Hybrid (G1) GC uses the defeault 200ms MaxGCPauseMillis on JDK-21+
==COMMIT_MSG==

## Possible downsides?
Performance could change in unexpected ways!

## Alternatives:

We could change the default across the board, however it's a bit safer to apply this more precisely to the java version where our previous default value causes problems.

We could slowly ratchet the value down over time, however that makes it more difficult to root cause changes, as they would be less abrupt. We're currently rolling this out explicitly (via the configuration dsl) in a subset of services of varying sizes to validate that metrics look the same or better before rolling this out.