### PR TITLE
remove accidental connection between task outputs

### DIFF
--- a/changelog/@unreleased/pr-1709.v2.yml
+++ b/changelog/@unreleased/pr-1709.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: remove accidental connection between task outputs
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1709

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
@@ -38,7 +38,7 @@ public final class ProductDependencies {
 
     public static TaskProvider<ResolveProductDependenciesTask> registerProductDependencyTasks(
             Project project, BaseDistributionExtension ext) {
-        Provider<Directory> pdepsDir = project.getLayout().getBuildDirectory().dir("product-dependencies");
+        Provider<Directory> pdepsDir = project.getLayout().getBuildDirectory().dir("resolved-pdeps");
 
         // Register compatibility rule to ensure that ResourceTransform is applied onto project dependencies so we
         // avoid compilation
@@ -56,32 +56,23 @@ public final class ProductDependencies {
                 });
 
         Provider<ArtifactView> discoveredDependencies = getDiscoveredDependencies(project, ext);
-        TaskProvider<ResolveProductDependenciesTask> resolveProductDependencies = project.getTasks()
-                .register("resolveProductDependencies", ResolveProductDependenciesTask.class, task -> {
-                    task.getServiceName().set(ext.getDistributionServiceName());
-                    task.getServiceGroup().set(ext.getDistributionServiceGroup());
+        return project.getTasks().register("resolveProductDependencies", ResolveProductDependenciesTask.class, task -> {
+            task.getServiceName().set(ext.getDistributionServiceName());
+            task.getServiceGroup().set(ext.getDistributionServiceGroup());
 
-                    task.getInRepoProductIds()
-                            .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(
-                                            project.getRootProject())
+            task.getInRepoProductIds()
+                    .set(project.provider(
+                            () -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(project.getRootProject())
                                     .keySet()));
-                    task.getProductDependencies().set(ext.getAllProductDependencies());
-                    task.getOptionalProductIds().set(ext.getOptionalProductDependencies());
-                    task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
+            task.getProductDependencies().set(ext.getAllProductDependencies());
+            task.getOptionalProductIds().set(ext.getOptionalProductDependencies());
+            task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
 
-                    task.getProductDependenciesFiles().from(discoveredDependencies.map(pdeps -> pdeps.getArtifacts()
-                            .getArtifactFiles()));
+            task.getProductDependenciesFiles().from(discoveredDependencies.map(pdeps -> pdeps.getArtifacts()
+                    .getArtifactFiles()));
 
-                    task.getManifestFile().set(pdepsDir.map(dir -> dir.file("pdeps-manifest.json")));
-                });
-
-        // the RecommendedProductDependenciesPlugin adds the entire build/product-dependencies directory as a source
-        // directory to the main sourceset's resources.  This makes gradle8 complain that processResources uses
-        // the output of resolveProductDependencies as an input, so need to declare it specifically.
-        project.getPluginManager().withPlugin("com.palantir.recommended-product-dependencies", _plugin -> {
-            project.getTasks().named("processResources").configure(task -> task.dependsOn(resolveProductDependencies));
+            task.getManifestFile().set(pdepsDir.map(dir -> dir.file("pdeps-manifest.json")));
         });
-        return resolveProductDependencies;
     }
 
     private static Provider<ArtifactView> getDiscoveredDependencies(

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
@@ -62,7 +62,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
 
         then:
         def manifest = ObjectMappers.readProductDependencyManifest(
-                file('build/product-dependencies/pdeps-manifest.json'))
+                file('build/resolved-pdeps/pdeps-manifest.json'))
         !manifest.productDependencies().isEmpty()
     }
 
@@ -88,7 +88,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         then:
         !result.wasExecuted(':child:jar')
         def manifest = ObjectMappers.readProductDependencyManifest(
-                file('build/product-dependencies/pdeps-manifest.json'))
+                file('build/resolved-pdeps/pdeps-manifest.json'))
         !manifest.productDependencies().isEmpty()
     }
 
@@ -119,7 +119,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
 
         then:
         def manifest = ObjectMappers.readProductDependencyManifest(
-                file('build/product-dependencies/pdeps-manifest.json'))
+                file('build/resolved-pdeps/pdeps-manifest.json'))
         !manifest.productDependencies().isEmpty()
     }
 
@@ -150,12 +150,15 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
 
         then:
         def manifest = ObjectMappers.readProductDependencyManifest(
-                file('build/product-dependencies/pdeps-manifest.json'))
+                file('build/resolved-pdeps/pdeps-manifest.json'))
         manifest.productDependencies().isEmpty()
     }
 
-    def 'resolveProductDependencies and processResources work together under gradle8'() {
-        given:
+    def 'resolveProductDependencies and processResources work together'() {
+        // this is a strange setup that really shouldn't happen in a real repo - a project shouldn't be both an API
+        // jar and a distribution.  But in case it does happen we want to make sure there are no accidental
+        // connections between the tasks.
+        when:
         //language=gradle
         buildFile.text = '''
             apply plugin: 'java'
@@ -163,10 +166,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
             apply plugin: 'com.palantir.sls-asset-distribution'
         '''.stripIndent()
 
-        when:
-        def result = runTasksSuccessfully('resolveProductDependencies', 'processResources')
-
         then:
-        result.wasExecuted('compileRecommendedProductDependencies')
+        runTasksSuccessfully('resolveProductDependencies', 'processResources')
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
@@ -18,6 +18,8 @@ package com.palantir.gradle.dist.pdeps
 
 import com.palantir.gradle.dist.BaseDistributionExtension
 import com.palantir.gradle.dist.ObjectMappers
+import spock.lang.Unroll
+
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import nebula.test.IntegrationSpec
@@ -150,5 +152,21 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def manifest = ObjectMappers.readProductDependencyManifest(
                 file('build/product-dependencies/pdeps-manifest.json'))
         manifest.productDependencies().isEmpty()
+    }
+
+    def 'resolveProductDependencies and processResources work together under gradle8'() {
+        given:
+        //language=gradle
+        buildFile.text = '''
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.recommended-product-dependencies'
+            apply plugin: 'com.palantir.sls-asset-distribution'
+        '''.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully('resolveProductDependencies', 'processResources')
+
+        then:
+        result.wasExecuted('compileRecommendedProductDependencies')
     }
 }


### PR DESCRIPTION
## Before this PR
If a project has both the com.palantir.recommended-product-dependencies plugin and one of the distribution plugins (asset or service) then gradle8+ will fail with an error like this:

```
 Reason: Task 'processResources' uses this output of task 'resolveProductDependencies' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

The reason is that both the resolveProductDependencies and the compileRecommendedProductDependencies tasks would write into a directory called build/product-dependencies.  The RecommendedProductDependenciesPlugin adds that directory as a resources source.  It properly adds compileRecommendedProductDependencies as a dependency of processResources.  The fact that resolveProductDependencies gets involved is a coincidence - we just happened to name it's output the same thing even though it's in a different project and plugin.

The two plugins should never be applied to the same project - something shouldn't be both an API jar with recommended dependencies and an SLS distribution that consumes them.  But many repos do have both applied (likely accidentally), so this just makes it clear that the two outputs have nothing to do with each other.  I may do another PR to enforce this (like we do for the Asset and Service plugins), but I want to get a release out that solves the problem first because it's blocking  some repos from upgrading to gradle8.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

