### PR TITLE
use new file permissions API

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -27,7 +27,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Tar;
 
-@SuppressWarnings("deprecation") // for the setFileMode calls
 final class DistTarTask {
     static final String SCRIPTS_DIST_LOCATION = "service/bin";
 
@@ -54,7 +53,7 @@ final class DistTarTask {
 
             root.from("service/bin", t -> {
                 t.into("service/bin");
-                t.setFileMode(0755);
+                t.filePermissions(filePerms -> filePerms.unix(0755));
             });
 
             // We do this trick of iterating through every java version and making a from with a lazy value to be lazy
@@ -89,17 +88,17 @@ final class DistTarTask {
 
             root.into(SCRIPTS_DIST_LOCATION, t -> {
                 t.from(project.getLayout().getBuildDirectory().dir("scripts"));
-                t.setFileMode(0755);
+                t.filePermissions(filePerms -> filePerms.unix(0755));
             });
 
             root.into("service/monitoring/bin", t -> {
                 t.from(project.getLayout().getBuildDirectory().dir("monitoring"));
-                t.setFileMode(0755);
+                t.filePermissions(filePerms -> filePerms.unix(0755));
             });
 
             root.into("service/lib/linux-x86-64", t -> {
                 t.from(project.getLayout().getBuildDirectory().dir("libs/linux-x86-64"));
-                t.setFileMode(0755);
+                t.filePermissions(filePerms -> filePerms.unix(0755));
             });
 
             DeploymentDirInclusion.includeFromDeploymentDirs(


### PR DESCRIPTION
## Before this PR
the setFileMode of copy task is deprecated for gradle9.  Using it causes gradle deprecation warnings which cause any nebula integration tests to fail.

Note that this repo still has the ignoreDeprecations flag set to true because tests use the GCV plugin which also has gradle9 issues.  But at least this plugin will not directly cause tests in other repos to have deprecation issues.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

