### PR TITLE
Wire up dependency between compileRecommendedProductDependencies and sourcesJar

### DIFF
--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/CompileRecommendedProductDependencies.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/CompileRecommendedProductDependencies.java
@@ -17,31 +17,39 @@
 package com.palantir.gradle.dist;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
 import java.io.IOException;
-import java.util.Set;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 public abstract class CompileRecommendedProductDependencies extends DefaultTask {
+
     static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Input
     abstract SetProperty<ProductDependency> getRecommendedProductDependencies();
 
-    @OutputFile
-    abstract RegularFileProperty getOutputFile();
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir();
 
     @TaskAction
     final void action() throws IOException {
-        Set<ProductDependency> value = getRecommendedProductDependencies().get();
+        File outputFile = getOutputDir()
+                .get()
+                .file(RecommendedProductDependenciesPlugin.RESOURCE_PATH)
+                .getAsFile();
+
+        outputFile.getParentFile().mkdirs();
+
         MAPPER.writeValue(
-                getOutputFile().getAsFile().get(),
+                outputFile,
                 RecommendedProductDependencies.builder()
-                        .addAllRecommendedProductDependencies(value)
+                        .addAllRecommendedProductDependencies(
+                                getRecommendedProductDependencies().get())
                         .build());
     }
 }

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
@@ -18,16 +18,13 @@ package com.palantir.gradle.dist;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.file.Directory;
-import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
 
 public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
+
     public static final String RESOURCE_PATH =
             RecommendedProductDependencies.SLS_RECOMMENDED_PRODUCT_DEPS_KEY + "/product-dependencies.json";
 
@@ -55,13 +52,13 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
     }
 
     private void embedResource(Project project, RecommendedProductDependenciesExtension ext) {
-        Provider<Directory> dir = project.getLayout().getBuildDirectory().dir("product-dependencies");
-        TaskProvider<? extends Task> compilePdeps = project.getTasks()
+        TaskProvider<CompileRecommendedProductDependencies> compilePdeps = project.getTasks()
                 .register(
                         "compileRecommendedProductDependencies", CompileRecommendedProductDependencies.class, task -> {
                             task.getRecommendedProductDependencies()
                                     .set(ext.getRecommendedProductDependenciesProvider());
-                            task.getOutputFile().set(dir.map(directory -> directory.file(RESOURCE_PATH)));
+                            task.getOutputDir()
+                                    .set(project.getLayout().getBuildDirectory().dir("product-dependencies"));
                         });
 
         project.getTasks()
@@ -70,11 +67,8 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
                         processResources -> processResources.dependsOn(compilePdeps));
 
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
-        sourceSets.getByName("main").resources(resources -> {
-            SourceDirectorySet sourceDir = project.getObjects()
-                    .sourceDirectorySet("product-dependencies", "Recommended product dependencies")
-                    .srcDir(dir);
-            resources.source(sourceDir);
+        sourceSets.named("main").configure(sourceSet -> {
+            sourceSet.getResources().srcDir(compilePdeps.map(CompileRecommendedProductDependencies::getOutputDir));
         });
     }
 }


### PR DESCRIPTION
## Before this PR

There is an implicit dependency between `compileRecommendedProductDependencies` and `sourcesJar`

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':foo-api:foo-api-dialogue:sourcesJar' (type 'Jar').
  - Gradle detected a problem with the following location: '/home/circleci/project/foo-api/foo-api-dialogue/build/product-dependencies'.
    
    Reason: Task ':foo-api:foo-api-dialogue:sourcesJar' uses this output of task ':foo-api:foo-api-dialogue:compileRecommendedProductDependencies' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':foo-api:foo-api-dialogue:compileRecommendedProductDependencies' as an input of ':foo-api:foo-api-dialogue:sourcesJar'.
      2. Declare an explicit dependency on ':foo-api:foo-api-dialogue:compileRecommendedProductDependencies' from ':foo-api:foo-api-dialogue:sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':foo-api:foo-api-dialogue:compileRecommendedProductDependencies' from ':foo-api:foo-api-dialogue:sourcesJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.8/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

## After this PR

There is an implicit dependency between `compileRecommendedProductDependencies` and `sourcesJar` because we've defined the resource source directory to be the task output directory.

