### PR TITLE
AlwaysPreTouch option includes UseTransparentHugePages

### DIFF
--- a/changelog/@unreleased/pr-1787.v2.yml
+++ b/changelog/@unreleased/pr-1787.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: The enableAlwaysPreTouch() option will include the `+UseTransparentHugePages`
+    JVM opt.
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1787

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -89,7 +89,8 @@ public final class LaunchConfig {
     // When a system supports UseAVX=N, setting UseAVX=N+1 will set the flag to the highest supported value.
     private static final ImmutableList<String> disableAvx512 = ImmutableList.of("-XX:UseAVX=2");
 
-    private static final ImmutableList<String> alwaysPreTouchOptions = ImmutableList.of("-XX:+AlwaysPreTouch");
+    private static final ImmutableList<String> alwaysPreTouchOptions =
+            ImmutableList.of("-XX:+AlwaysPreTouch", "-XX:+UseTransparentHugePages");
 
     // Reduce memory usage for some versions of glibc.
     // Default value is 8 * CORES.

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1568,6 +1568,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.jvmOpts().containsAll([
                 "-XX:+AlwaysPreTouch",
+                "-XX:+UseTransparentHugePages",
         ])
     }
 

--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ And the complete list of configurable properties:
    Java 9 or higher will default to `$JAVA_<majorversion>_HOME` ie for Java 11 this would be `$JAVA_11_HOME`.
  * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default for Java 14 and lower), `hybrid` (default for Java 15 and higher) and `response-time`. Additionally, there is also `dangerous-no-profile` which does not apply any additional JVM flags and allows you to fully configure any GC settings through JVM options (not recommended for normal usage!).
  * (optional) `addJava8GcLogging` add java 8 specific gc logging options.
- * (optional) `enableAlwaysPreTouch()` adds the `-XX:+AlwaysPreTouch` JVM option.
+ * (optional) `enableAlwaysPreTouch()` adds the `-XX:+AlwaysPreTouch` and `-XX:+UseTransparentHugePages` JVM options.
 
 #### JVM Options
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

The enableAlwaysPreTouch() option will include the `+UseTransparentHugePages` JVM opt.

If the OS enables THP [madvise], this option will tell the JVM to start using madvise to use THP. 
If the OS enables THP [always], the JVM is already using THP in the background, and this option will tell the JVM to start using madvise to use THP instead, which is preferable
If the OS does not enable THP, this option will have no effect. 

`+UseTransparentHugePages` is bundled with `+AlwaysPreTouch` since using THP w/o AlwaysPreTouch can lead to increased memory fragmentation. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The enableAlwaysPreTouch() option will include the `+UseTransparentHugePages` JVM opt.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

