### PR TITLE
Do not cache any artifact transforms

### DIFF
--- a/changelog/@unreleased/pr-1803.v2.yml
+++ b/changelog/@unreleased/pr-1803.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Do not cache any artifact transforms
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1803

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractSingleFileOrManifest.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ExtractSingleFileOrManifest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 import java.util.Optional;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
-import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformOutputs;
@@ -32,8 +31,10 @@ import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.work.DisableCachingByDefault;
 
-@CacheableTransform
+@DisableCachingByDefault(
+        because = "Extracting a single file from a zip is much faster than making network requests to the build cache")
 public abstract class ExtractSingleFileOrManifest implements TransformAction<FileAndManifestExtractParameter> {
     @PathSensitive(PathSensitivity.NAME_ONLY)
     @InputArtifact

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/SelectSingleFile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/SelectSingleFile.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformOutputs;
@@ -28,10 +27,12 @@ import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.work.DisableCachingByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@CacheableTransform
+@DisableCachingByDefault(
+        because = "Extracting a single file from a zip is much faster than making network requests to the build cache")
 public abstract class SelectSingleFile implements TransformAction<FileExtractParameter> {
     private static final Logger log = LoggerFactory.getLogger(SelectSingleFile.class);
 


### PR DESCRIPTION
## Before this PR
To run the task `mergeDiagnosticJson` and `resolveProductDependencies`, an artifact transform is run to extract files from the input i.e. typically all the jars on the classpath for example. These transforms are marked as `@CacheableTransform` and  its result will be stored in the build cache, analogously we will check the build cache first to see if an earlier result has been cached and retrieve the result.

This latter operation is not free, and it is usually 1-2 orders of magnitude faster to just redo the work especially if it's just a jar which is just a zip file with seekable contents. Typically you also have hundreds to thousands of files to transform, and if the build cache server is feeling a bit wobbly, you can get dramatic slow downs. 

There is little to no reason to have to do a round trip on an artifact that is a also a seekable file.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

I've marked all of the transforms classes as `@DisableCachingByDefault`.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

