### PR TITLE
Fix configuration cache for `CompileRecommendedProductDependencies` task

### DIFF
--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
@@ -52,6 +52,8 @@ public final class ProductDependency implements Serializable {
 
     public ProductDependency() {}
 
+    // isValid should not be ran as part of the constructor as this can cause issue with configuration cache, either use
+    // one of the `create` methods or run isValid manually
     public ProductDependency(
             String productGroup,
             String productName,
@@ -65,7 +67,6 @@ public final class ProductDependency implements Serializable {
         this.maximumVersion = maximumVersion;
         this.recommendedVersion = recommendedVersion;
         this.optional = optional;
-        isValid();
     }
 
     public ProductDependency(
@@ -75,6 +76,31 @@ public final class ProductDependency implements Serializable {
             String maximumVersion,
             String recommendedVersion) {
         this(productGroup, productName, minimumVersion, maximumVersion, recommendedVersion, false);
+    }
+
+    public static ProductDependency create(
+            String productGroup,
+            String productName,
+            String minimumVersion,
+            String maximumVersion,
+            String recommendedVersion,
+            boolean optional) {
+        ProductDependency dep = new ProductDependency(
+                productGroup, productName, minimumVersion, maximumVersion, recommendedVersion, optional);
+        dep.isValid();
+        return dep;
+    }
+
+    public static ProductDependency create(
+            String productGroup,
+            String productName,
+            String minimumVersion,
+            String maximumVersion,
+            String recommendedVersion) {
+        ProductDependency dep = new ProductDependency(
+                productGroup, productName, minimumVersion, maximumVersion, recommendedVersion, false);
+        dep.isValid();
+        return dep;
     }
 
     /**

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -179,7 +179,7 @@ public class BaseDistributionExtension {
                         + " 'group:name:version:classifier@type', where ':classifier' and '@type' are optional.",
                 mavenCoordVersionRange);
         String minVersion = matcher.group("version");
-        productDependencies.add(new ProductDependency(
+        productDependencies.add(ProductDependency.create(
                 matcher.group("group"),
                 matcher.group("name"),
                 minVersion,
@@ -202,7 +202,7 @@ public class BaseDistributionExtension {
             String minVersion,
             String maxVersion,
             String recommendedVersion) {
-        productDependencies.add(new ProductDependency(
+        productDependencies.add(ProductDependency.create(
                 dependencyGroup,
                 dependencyName,
                 minVersion,

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -39,7 +39,7 @@ public final class ProductDependencyLockFile {
                 .flatMap(line -> {
                     Matcher matcher = LOCK_PATTERN.matcher(line);
                     if (matcher.matches()) {
-                        return Stream.of(new ProductDependency(
+                        return Stream.of(ProductDependency.create(
                                 matcher.group("group"),
                                 matcher.group("name"),
                                 matcher.group("min").equals(PROJECT_VERSION) ? projectVersion : matcher.group("min"),


### PR DESCRIPTION
## Before this PR
`CompileRecommendedProductDependencies` task could cause a configuration cache issue as the `isValid` method was called during configuration 

```
Configuration cache state could not be cached: field `__recommendedProductDependencies__` of task `:compileRecommendedProductDependencies` of type `com.palantir.gradle.dist.CompileRecommendedProductDependencies`: error writing value of type 'org.gradle.api.internal.provider.DefaultSetProperty'
```

## After this PR
`isValid` has been removed from the constructor and new `create` methods have been added which run `isValid` as part of there creation

This only fixes configuration cache for `CompileRecommendedProductDependencies` which is required to unblock us

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix configuration cache for `CompileRecommendedProductDependencies` task
==COMMIT_MSG==

## Possible downsides?
For some reason running `CompileRecommendedProductDependencies` as part of a test with configuration cache did not trigger this bug so it is not possible to test here - I think it may be triggered by how we use this plugin else where
<!-- Please describe any way users could be negatively affected by this PR. -->

