### PR TITLE
Allow extraFiles to be added into a distribution

### DIFF
--- a/changelog/@unreleased/pr-1825.v2.yml
+++ b/changelog/@unreleased/pr-1825.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow extraFiles to be added into a distribution
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1825

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -40,7 +40,6 @@ final class DistTarTask {
         distTarTask.getArchiveBaseName().set(serviceName);
 
         Callable<String> archiveRootDir = () -> serviceName.get() + "-" + project.getVersion();
-        distTarTask.with(distributionExtension.getExtraFiles().into(archiveRootDir));
 
         distTarTask.into(archiveRootDir, root -> {
             root.from("var", t -> {
@@ -108,6 +107,8 @@ final class DistTarTask {
                     distributionExtension,
                     root,
                     t -> t.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE));
+
+            root.with(distributionExtension.getExtraFiles());
         });
     }
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -40,6 +40,7 @@ final class DistTarTask {
         distTarTask.getArchiveBaseName().set(serviceName);
 
         Callable<String> archiveRootDir = () -> serviceName.get() + "-" + project.getVersion();
+        distTarTask.with(distributionExtension.getExtraFiles().into(archiveRootDir));
 
         distTarTask.into(archiveRootDir, root -> {
             root.from("var", t -> {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -19,6 +19,8 @@ package com.palantir.gradle.dist.service;
 import com.palantir.gradle.dist.BaseDistributionExtension;
 import com.palantir.gradle.dist.ProductType;
 import com.palantir.gradle.dist.service.gc.GcProfile;
+import com.palantir.gradle.dist.service.gc.GcProfile.Hybrid;
+import com.palantir.gradle.dist.service.gc.GcProfile.Throughput;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import java.util.List;
@@ -29,7 +31,9 @@ import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -51,6 +55,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     private final ListProperty<String> excludeFromVar;
     private final MapProperty<String, String> env;
     private final MapProperty<JavaVersion, Object> jdks;
+    private final CopySpec extraFiles;
 
     private final ObjectFactory objectFactory;
 
@@ -62,7 +67,7 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         this.project = project;
         objectFactory = project.getObjects();
         javaVersion = objectFactory.property(JavaVersion.class).value(project.provider(() -> project.getExtensions()
-                .getByType(org.gradle.api.plugins.JavaPluginExtension.class)
+                .getByType(JavaPluginExtension.class)
                 .getTargetCompatibility()));
         mainClass = objectFactory.property(String.class);
 
@@ -101,6 +106,15 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
 
         env = objectFactory.mapProperty(String.class, String.class);
         setProductType(ProductType.SERVICE_V1);
+        extraFiles = project.copySpec();
+    }
+
+    public CopySpec getExtraFiles() {
+        return extraFiles;
+    }
+
+    public void extraFiles(Action<? super CopySpec> action) {
+        action.execute(extraFiles);
     }
 
     public final Provider<JavaVersion> getJavaVersion() {
@@ -271,9 +285,9 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
     private static GcProfile getDefaultGcProfile(JavaVersion javaVersion) {
         // For Java 15 and above, use hybrid as the default garbage collector
         if (javaVersion.compareTo(JavaVersion.toVersion("14")) > 0) {
-            return new GcProfile.Hybrid();
+            return new Hybrid();
         }
-        return new GcProfile.Throughput();
+        return new Throughput();
     }
 
     public final String jdkPathInDist(JavaVersion javaVersionValue) {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionExtension.java
@@ -109,11 +109,11 @@ public class JavaServiceDistributionExtension extends BaseDistributionExtension 
         extraFiles = project.copySpec();
     }
 
-    public CopySpec getExtraFiles() {
+    public final CopySpec getExtraFiles() {
         return extraFiles;
     }
 
-    public void extraFiles(Action<? super CopySpec> action) {
+    public final void extraFiles(Action<? super CopySpec> action) {
         action.execute(extraFiles);
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1589,7 +1589,10 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                     }
                 }
             }""".stripIndent()
-        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+        file('src/main/java/test/Test.java') << """
+          package test;
+          public class Test {}
+        """
 
         when:
         runTasks(':build', ':distTar', ':untar')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1598,8 +1598,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         runTasks(':build', ':distTar', ':untar')
 
         then:
-        def externalJar = new File(projectDir, "dist/service-name-0.0.1/service/maven/${Path.of(EXTERNAL_JAR).getFileName()}")
-        externalJar.exists()
+        fileExists("dist/service-name-0.0.1/service/maven/${Path.of(EXTERNAL_JAR).getFileName()}")
     }
 
     private static createUntarBuildFile(File buildFile) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1598,7 +1598,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         runTasks(':build', ':distTar', ':untar')
 
         then:
-        def externalJar = new File(projectDir, String.format('dist/service-name-0.0.1/service/maven/%s', Path.of(EXTERNAL_JAR).getFileName()))
+        def externalJar = new File(projectDir, "dist/service-name-0.0.1/service/maven/${Path.of(EXTERNAL_JAR).getFileName()}")
         externalJar.exists()
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -27,6 +27,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import spock.lang.Unroll
 
+import java.nio.file.Path
 import java.util.jar.Attributes
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
@@ -1570,6 +1571,32 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "-XX:+AlwaysPreTouch",
                 "-XX:+UseTransparentHugePages",
         ])
+    }
+
+    def 'produce distribution bundle that can bundle extra Jars'() {
+        given:
+        createUntarBuildFile(buildFile)
+
+        buildFile << """
+            dependencies { implementation files("${EXTERNAL_JAR}") }
+            tasks.jar.archiveBaseName = "internal"
+            distribution {
+                javaVersion 11
+                javaHome 'foo'
+                extraFiles {
+                    into('service/maven') {
+                      from(files("${EXTERNAL_JAR}"))
+                    }
+                }
+            }""".stripIndent()
+        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+
+        when:
+        runTasks(':build', ':distTar', ':untar')
+
+        then:
+        def externalJar = new File(projectDir, String.format('dist/service-name-0.0.1/service/maven/%s', Path.of(EXTERNAL_JAR).getFileName()))
+        externalJar.exists()
     }
 
     private static createUntarBuildFile(File buildFile) {

--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,7 @@ And the complete list of configurable properties:
  * (optional) `gc` override the default GC settings. Available GC settings: `throughput` (default for Java 14 and lower), `hybrid` (default for Java 15 and higher) and `response-time`. Additionally, there is also `dangerous-no-profile` which does not apply any additional JVM flags and allows you to fully configure any GC settings through JVM options (not recommended for normal usage!).
  * (optional) `addJava8GcLogging` add java 8 specific gc logging options.
  * (optional) `enableAlwaysPreTouch()` adds the `-XX:+AlwaysPreTouch` and `-XX:+UseTransparentHugePages` JVM options.
+ * (optional) `extraFiles` a collection of additional files (CopySpecs) to be included in the distribution.
 
 #### JVM Options
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
No easy way to add extra files to the distribution eg. 
```
tasks.named("distTar").configure {
    it.from(tasks.named("mavenBundle"), copySpec -> {
        copySpec.into(project.provider(() -> "${distribution.getDistributionServiceName().get()}-${project.getVersion()}/service/maven"));
        copySpec.exclude("**/.index/**")
        copySpec.duplicatesStrategy DuplicatesStrategy.EXCLUDE
    }
}
```

it also depends on the internals of the plugin (`"${distribution.getDistributionServiceName().get()}-${project.getVersion()}`)

## After this PR
Internal discussion [here](https://pl.ntr/2v4)
We can include extra files in the distribution by setting: 
```
distribution {
  extraFiles {
    into('service/maven') {
      from(tasks.named("mavenBundle"))
    }
  }
}
```

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow extraFiles to be added into a distribution
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

