### PR TITLE
MainClassResolver checks in generated sources as well

### DIFF
--- a/changelog/@unreleased/pr-1841.v2.yml
+++ b/changelog/@unreleased/pr-1841.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: MainClassResolver checks in generated sources as well
+  links:
+  - https://github.com/palantir/sls-packaging/pull/1841

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/util/MainClassResolver.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/util/MainClassResolver.java
@@ -47,7 +47,6 @@ public final class MainClassResolver {
                 .resolve("sources")
                 .toFile();
         if (generatedDir.exists() && generatedDir.isDirectory()) {
-            // Add all subdirectories of generated sources (e.g., annotationProcessor/java/main, etc.)
             File[] subDirs = generatedDir.listFiles(File::isDirectory);
             if (subDirs != null) {
                 sourceDirs.addAll(Arrays.asList(subDirs));

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/util/MainClassResolver.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/util/MainClassResolver.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -36,7 +38,23 @@ public final class MainClassResolver {
                 .getByType(org.gradle.api.plugins.JavaPluginExtension.class)
                 .getSourceSets()
                 .getByName("main");
-        Set<Path> javaFilesWithMainMethods = main.getAllSource().getSrcDirs().stream()
+
+        Set<File> sourceDirs = new HashSet<>(main.getAllSource().getSrcDirs());
+
+        File generatedDir = project.getBuildDir()
+                .toPath()
+                .resolve("generated")
+                .resolve("sources")
+                .toFile();
+        if (generatedDir.exists() && generatedDir.isDirectory()) {
+            // Add all subdirectories of generated sources (e.g., annotationProcessor/java/main, etc.)
+            File[] subDirs = generatedDir.listFiles(File::isDirectory);
+            if (subDirs != null) {
+                sourceDirs.addAll(Arrays.asList(subDirs));
+            }
+        }
+
+        Set<Path> javaFilesWithMainMethods = sourceDirs.stream()
                 .filter(File::exists)
                 .map(File::toPath)
                 .flatMap(sourceDir -> allJavaFilesIn(sourceDir)


### PR DESCRIPTION
## Before this PR
MainClassResolver did not check generated sources for a main method meaning packages with generated main methods were incompatible. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
MainClassResolver checks in generated sources as well
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

