### PR TITLE
Use ZGC for hybrid profile on Java 21+

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
@@ -71,6 +71,7 @@ public interface GcProfile extends Serializable {
                         "-XX:+ClassUnloadingWithConcurrentMark",
                         "-XX:+UseNUMA");
             }
+
             return ImmutableList.of(
                     "-XX:+UseParNewGC",
                     "-XX:+UseConcMarkSweepGC",
@@ -111,7 +112,16 @@ public interface GcProfile extends Serializable {
         private int maxGCPauseMillis = 500;
 
         @Override
-        public final List<String> gcJvmOpts(JavaVersion _javaVersion) {
+        public final List<String> gcJvmOpts(JavaVersion javaVersion) {
+            if (javaVersion.compareTo(JavaVersion.toVersion("21")) >= 0) {
+                return ImmutableList.of(
+                        "-XX:+UseZGC",
+                        // https://openjdk.org/jeps/439
+                        "-XX:+ZGenerational",
+                        // "forces concurrent cycle instead of Full GC on System.gc()"
+                        "-XX:+ExplicitGCInvokesConcurrent");
+            }
+
             return ImmutableList.of("-XX:+UseG1GC", "-XX:+UseNUMA", "-XX:MaxGCPauseMillis=" + maxGCPauseMillis);
         }
 


### PR DESCRIPTION
Based on internal testing, using ZGC has resulting in much improved safepoint and hiccup times, at the cost of an acceptable amount of CPU. Using ZGC is very likely a better tradeoff for the vast majority of services, especially those that run in cloud environments.