### PR TITLE
Add `module.v1` to `ProductType`

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductType.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductType.java
@@ -33,4 +33,7 @@ public enum ProductType {
 
     @JsonProperty("foundry-product.v1")
     FOUNDRY_PRODUCT_V1,
+
+    @JsonProperty("module.v1")
+    MODULE_V1,
 }


### PR DESCRIPTION
## Before this PR
The `createManifest` task could only be used to create services, daemons, helm charts, assets, or foundry products.

## After this PR
`createManifest` task supports creating modules.

## Possible downsides?
This PR is analogous to how Foundry products were added here: https://github.com/palantir/sls-packaging/pull/1703
