### PR TITLE
[Fix] Upgrade the "Fallback Version" to a `go-java-launcher` that is CVE Free

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -59,7 +59,7 @@ import org.gradle.util.GradleVersion;
 
 public final class JavaServiceDistributionPlugin implements Plugin<Project> {
     // Used as fallback version if no higher version is specified in 'versions.props'.
-    private static final String FALLBACK_GO_JAVA_VERSION = "1.18.0";
+    private static final String FALLBACK_GO_JAVA_VERSION = "1.215.0";
     private static final String GO_JAVA_LAUNCHER = "com.palantir.launching:go-java-launcher";
     private static final String GO_INIT = "com.palantir.launching:go-init";
     public static final String GROUP_NAME = "Distribution";


### PR DESCRIPTION
## Before this PR
`1.18.0` used an ancient version of golang which had a few vendored CVE's.

## After this PR
Bumps to the latest version (`1.215.0`) which is CVE free as of `10/2025`.


