### PR TITLE
[Gradle 9] Java 17 + Gradle 8.14.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
 }
 
 javaVersions {
-    libraryTarget = 11
+    libraryTarget = 17
 }
 
 jdks {

--- a/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
+++ b/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         }
         apply plugin: 'java'
         apply plugin: 'com.palantir.recommended-product-dependencies'
-        """.stripIndent()
+        """.stripIndent(true)
 
     }
 
@@ -48,7 +48,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
                 optional = true
             }
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         runTasksSuccessfully(':jar')
@@ -82,7 +82,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
             java {
                withSourcesJar()
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('src/main/java/Main.java') << '''
                 public class Main {
@@ -110,7 +110,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
                     recommendedVersion = '1.2.3'
                 }
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def result = runTasksSuccessfully(':jar')
@@ -152,7 +152,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
                 maximumVersion = '1.x.x'
             }
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def result = runTasksSuccessfully( '--write-locks', ':jar')

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -48,6 +48,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 import org.gradle.StartParameter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
@@ -65,6 +66,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.process.ExecOperations;
 
 public abstract class CreateManifestTask extends DefaultTask {
 
@@ -98,6 +100,9 @@ public abstract class CreateManifestTask extends DefaultTask {
     final String getProjectVersion() {
         return getProject().getVersion().toString();
     }
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
 
     /**
      * Intentionally checking whether file exists as gradle's {@link org.gradle.api.tasks.Optional} only operates on
@@ -270,15 +275,14 @@ public abstract class CreateManifestTask extends DefaultTask {
             Files.writeString(tempFile.toPath(), upToDateContents);
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            getProject().exec(spec -> {
+            getExecOperations().exec(spec -> {
                 spec.commandLine("diff", "-u", existing.getAbsolutePath(), tempFile.getAbsolutePath());
                 spec.setStandardOutput(baos);
                 spec.setIgnoreExitValue(true);
             });
-            return Optional.of(
-                    Streams.stream(Splitter.on("\n").split(new String(baos.toByteArray(), StandardCharsets.UTF_8)))
-                            .skip(2)
-                            .collect(Collectors.joining("\n")));
+            return Optional.of(Streams.stream(Splitter.on("\n").split(baos.toString(StandardCharsets.UTF_8)))
+                    .skip(2)
+                    .collect(Collectors.joining("\n")));
         } catch (IOException e) {
             getLogger().debug("Unable to provide diff", e);
             return Optional.empty();

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
@@ -27,7 +27,7 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
         file("product-dependencies.lock").text = '''\
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
             com.palantir.product:test (1.0.0, 1.x.x)
-        '''.stripIndent()
+        '''.stripIndent(true)
         def mavenRepo = generateMavenRepo('com.palantir.product:test:1.0.0')
         buildFile << """
             repositories {
@@ -41,7 +41,7 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
             dependencies {
                 foo 'com.palantir.product:test'
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def result = runTasksSuccessfully('dependencies', '--configuration', 'foo')
@@ -54,12 +54,12 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
         file("a/product-dependencies.lock").text = '''\
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
             com.palantir.product:test (1.0.0, 1.x.x)
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         file("b/product-dependencies.lock").text = '''\
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
             com.palantir.product:test (1.2.0, 1.6.x)
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         addSubproject('a', 'apply plugin: com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin')
         addSubproject('b', 'apply plugin: com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin')
@@ -80,7 +80,7 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
                 foo project(path: ':b', configuration: 'productDependencies')
                 foo 'com.palantir.product:test'
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def result = runTasksSuccessfully('dependencies', '--configuration', 'foo')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginTest.groovy
@@ -29,7 +29,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
         project.file("product-dependencies.lock").text = '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:test (1.0.0, 1.x.x)
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         def result = project.ext.getMinimumProductVersion("com.palantir.product:test")
@@ -43,7 +43,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
         project.file("product-dependencies.lock").text = '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:test ($projectVersion, 1.x.x)
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         def result = project.ext.getMinimumProductVersion("com.palantir.product:test")
@@ -65,7 +65,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
         project.file("product-dependencies.lock").text = '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:test (1.0.0, 1.x.x)
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         project.ext.getMinimumProductVersion("com.palantir.other:test")

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -33,7 +33,7 @@ class ProductDependencyLockFileTest extends Specification {
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.other:bar (0.2.0, 0.x.x) optional
         com.palantir.product:foo (1.20.0, 1.x.x)
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     def 'serialize project version'() {
@@ -46,7 +46,7 @@ class ProductDependencyLockFileTest extends Specification {
         result == '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.product:foo ($projectVersion, 1.x.x)
-        '''.stripIndent()
+        '''.stripIndent(true)
     }
 
     def 'deserialize'() {
@@ -55,7 +55,7 @@ class ProductDependencyLockFileTest extends Specification {
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.other:bar (0.2.0, 0.x.x)
         com.palantir.product:foo (1.20.0, 1.x.x) optional
-        """.stripIndent(), "0.0.0")
+        """.stripIndent(true), "0.0.0")
 
         then:
         result.size() == 2

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/SchemaVersionLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/SchemaVersionLockFileTest.groovy
@@ -42,7 +42,7 @@ public class SchemaVersionLockFileTest extends Specification {
         - type: "online"
           from: 100
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     void 'works with contiguous range'() {
@@ -66,7 +66,7 @@ public class SchemaVersionLockFileTest extends Specification {
         - type: "online"
           from: 102
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     void 'works with gap'() {
@@ -87,7 +87,7 @@ public class SchemaVersionLockFileTest extends Specification {
         - type: "online"
           from: 102
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     void 'works with multiple ranges'() {
@@ -120,7 +120,7 @@ public class SchemaVersionLockFileTest extends Specification {
         - type: "offline"
           from: 105
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     void 'deserialization works'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -30,7 +30,7 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
             distribution {
                 serviceName 'asset-name'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         runTasks(':distTar', ':untar')
@@ -58,7 +58,7 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
                 assets "static/abc", "maven"
                 assets file("static/abs").getAbsolutePath(), "maven"
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         runTasks(':distTar', ':untar')
@@ -81,7 +81,7 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
                 id 'com.palantir.sls-java-service-distribution'
                 id 'com.palantir.sls-asset-distribution'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         def result = runTasksAndFail(":tasks")
@@ -109,12 +109,12 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
                     maximumVersion = "2.x.x"
                 }
             }
-        """.stripIndent()
+        """.stripIndent(true)
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 2.0.0)
         group2:name2 (1.0.0, 2.x.x)
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         runTasks(':distTar', ':untar')
@@ -223,7 +223,7 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
                     configurations.fromOtherProject.resolve()
                 }
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         helper.addSubproject('dist', '''
             plugins {
@@ -262,6 +262,6 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
                 dependsOn distTar
                 duplicatesStrategy = 'WARN'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
@@ -35,7 +35,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         maximumVersion = "1.3.x"
         recommendedVersion = "1.2.1"
     }
-    """.stripIndent()
+    """.stripIndent(true)
 
     def setup() {
         buildFile << """
@@ -46,7 +46,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def ext = project.extensions.create("distribution", BaseDistributionExtension, project)
         ext.setProductDependenciesConfig(configurations.runtimeClasspath)
         ProductDependencies.registerProductDependencyTasks(project, ext);
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     def 'consumes declared product dependencies'() {
@@ -55,7 +55,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
             distribution {
                 ${PDEP}
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         runTasksSuccessfully(':resolveProductDependencies')
@@ -75,12 +75,12 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         recommendedProductDependencies {
             ${PDEP}
         }
-        """.stripIndent())
+        """.stripIndent(true))
         buildFile << """
         dependencies {
             implementation project('child')
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def result = runTasksSuccessfully(':resolveProductDependencies')
@@ -112,7 +112,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         dependencies {
             implementation 'a:a:1.0'
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         runTasksSuccessfully(':resolveProductDependencies')
@@ -143,7 +143,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         dependencies {
             implementation 'missingmanifest:missingmanifest:1.0'
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         runTasksSuccessfully(':resolveProductDependencies')
@@ -164,7 +164,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
             apply plugin: 'java'
             apply plugin: 'com.palantir.recommended-product-dependencies'
             apply plugin: 'com.palantir.sls-asset-distribution'
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         then:
         runTasksSuccessfully('resolveProductDependencies', 'processResources')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
         repositories {
           mavenCentral()
         }
-        """.stripIndent()
+        """.stripIndent(true)
         addResource("src/main/resources/sls-manifest", "diagnostics.json",
                 '[{"type": "foo.v1", "docs" : "This does something", "safe" : false}]')
 
@@ -43,7 +43,7 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
           "type" : "foo.v1",
           "docs" : "This does something",
           "safe" : false
-        } ]""".stripIndent()
+        } ]""".stripIndent(true)
 
         when:
         def result2 = runTasksSuccessfully("mergeDiagnosticsJson", '-is')
@@ -97,6 +97,6 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
         }, {
           "type" : "myproject2.v1",
           "docs" : "Click me if you dare!"
-        } ]""".stripIndent()
+        } ]""".stripIndent(true)
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
@@ -53,7 +53,7 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
                 from { tarTree(distTar.outputs.files.singleFile) }
                 into projectDir
             }
-        """.stripIndent()
+        """.stripIndent(true)
         Path path = projectDir.toPath().resolve(
                 "src/main/java/com/palantir/gradle/dist/service/ExampleTouchService.java")
         Files.createDirectories(path.getParent())
@@ -68,7 +68,7 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
         distribution {
             gc '${gc}'
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         runTasks(':extractDistTarForTest')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -47,13 +47,13 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 checkArgs 'healthcheck'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
         file('var/conf/launcher-custom.yml') << '''
             configType: java
             configVersion: 1
             jvmOpts:
               - '-Dcustom.property=myCustomValue'
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         file('src/main/java/test/Test.java') << '''
         package test;
@@ -69,7 +69,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 while(true);
             }
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         def result = runTasks(':build', ':distTar', ':untar')
@@ -100,7 +100,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 enableManifestClasspath true
             }
-         '''.stripIndent()
+         '''.stripIndent(true)
         file('src/main/java/test/Test.java') << '''
         package test;
         public class Test {
@@ -108,13 +108,13 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 while(true);
             }
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         runTasks(':build', ':distTar', ':untar')
         buildFile << '''
             version '0.0.2'
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         then:
         def result = runTasks(':build', ':distTar', ':untar')
@@ -159,7 +159,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 Files.write(Files.createTempFile("prefix", "suffix"), "temp content".getBytes());
             }
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         runTasks(':build', ':distTar', ':untar')
@@ -193,7 +193,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
 
             sourceCompatibility = '1.7'
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         createUntarTask(buildFile)
 
@@ -242,7 +242,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
 
             sourceCompatibility = '1.7'
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         createUntarTask(buildFile)
 
@@ -290,12 +290,12 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                     maximumVersion = "1.x.x"
                 }
             }
-        """.stripIndent()
+        """.stripIndent(true)
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
         group2:name2 (1.0.0, 1.x.x)
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         runTasks(':build', ':distTar', ':untar')
@@ -329,7 +329,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                     maximumVersion = "2.0.0"
                 }
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def result = runTasksAndFail('distTar')
@@ -440,7 +440,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 checkArgs 'myCheckArg1', 'myCheckArg2'
                 env "key1": "val1",
                     "key2": "val2"
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -524,7 +524,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 checkArgs 'myCheckArg1', 'myCheckArg2'
                 env "key1": "val1",
                     "key2": "val2"
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -600,7 +600,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 javaHome 'foo'
                 addJava8GcLogging true
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -652,7 +652,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 javaVersion 14
                 gc 'response-time'
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -676,7 +676,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 javaVersion 21
                 gc 'response-time'
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -699,7 +699,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 21
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -718,7 +718,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 checkArgs 'healthcheck', 'var/conf/service.yml'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         runTasks(':build', ':distTar', ':untar')
@@ -741,7 +741,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             dependencies {
               implementation "com.google.guava:guava:19.0"
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         runTasks(':build', ':distTar', ':untar')
@@ -803,7 +803,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                             "expected: ${expectedTarballPath}")
                 }
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         expect:
         runTasks(':tasks')
@@ -928,7 +928,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                     configurations.fromOtherProject.resolve()
                 }
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         helper.addSubproject('dist', '''
             plugins {
@@ -956,7 +956,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 id 'com.palantir.sls-asset-distribution'
                 id 'com.palantir.sls-java-service-distribution'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         def result = runTasksAndFail(":tasks")
@@ -1058,7 +1058,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 version = '1.0.0'
             }
 
-        """.stripIndent()
+        """.stripIndent(true)
         helper.addSubproject("first", """
             plugins {
                 id 'java'
@@ -1072,7 +1072,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                     minimumVersion = project.version
                 }
             }
-        """.stripIndent())
+        """.stripIndent(true))
         helper.addSubproject("second", """
             plugins {
                 id 'java'
@@ -1082,7 +1082,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 serviceName = 'second-product'
                 mainClass "dummy.service.MainClass"
             }
-        """.stripIndent())
+        """.stripIndent(true))
 
         runTasks(writeLocksTask)
 
@@ -1192,7 +1192,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 while(true);
             }
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         when:
         runTasks(':build', ':distTar', ':untar')
@@ -1224,7 +1224,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                     initiatingOccupancyFraction 75
                 }
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         createUntarTask(buildFile)
 
@@ -1258,7 +1258,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                     maxGCPauseMillis 1234
                 }
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         createUntarTask(buildFile)
 
@@ -1290,7 +1290,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 mainClass 'test.Test'
                 gc 'hybrid'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         createUntarTask(buildFile)
 
@@ -1313,7 +1313,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 11
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1336,7 +1336,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 11
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1353,7 +1353,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 17
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1385,7 +1385,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 17
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1424,7 +1424,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 17
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1464,7 +1464,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 javaVersion 17
                 enableManifestClasspath true
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1500,7 +1500,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 javaVersion 17
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1515,7 +1515,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         // GCV
         file('gradle.properties') << """
         ${JavaServiceDistributionPlugin.TEST_GO_JAVA_LAUNCHER_FALLBACK_VERSION_OVERRIDE}=1.17.0
-        """.stripIndent()
+        """.stripIndent(true)
 
         def goJavaLauncherVersion = "1.18.0"
 
@@ -1534,11 +1534,11 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             serviceName 'service-name'
             mainClass 'test.Test'
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('versions.props') << """
         com.palantir.launching:* = ${goJavaLauncherVersion}
-        """.stripIndent()
+        """.stripIndent(true)
 
         createUntarTask(buildFile)
 
@@ -1560,7 +1560,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             tasks.jar.archiveBaseName = "internal"
             distribution {
                 enableAlwaysPreTouch()
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
 
         when:
@@ -1590,7 +1590,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                       from(files("${EXTERNAL_JAR}"))
                     }
                 }
-            }""".stripIndent()
+            }""".stripIndent(true)
         file('src/main/java/test/Test.java') << """
           package test;
           public class Test {}
@@ -1628,7 +1628,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             }
 
             sourceCompatibility = '1.7'
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         createUntarTask(buildFile)
     }
@@ -1642,7 +1642,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 dependsOn distTar
                 duplicatesStrategy = 'INCLUDE'
             }
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     def readFromZip(File zipFile, String pathInZipFile) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1218,6 +1218,8 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
             distribution {
                 serviceName 'service-name'
                 mainClass 'test.Test'
+                // only available on JDKs < 14
+                javaVersion 11
                 gc 'response-time', {
                     initiatingOccupancyFraction 75
                 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/LazyCreateStartScriptTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/LazyCreateStartScriptTaskIntegrationSpec.groovy
@@ -28,7 +28,7 @@ class LazyCreateStartScriptTaskIntegrationSpec extends IntegrationSpec {
             lazyMainClassName = 'myMainClass'
             outputDir = file('build/scripts')
         }
-        """.stripIndent()
+        """.stripIndent(true)
         def successfully = runTasksSuccessfully('createStartScripts')
 
         then:

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
             }
 
             version '0.0.1'
-        '''.stripIndent()
+        '''.stripIndent(true)
     }
 
     def 'infers main class correctly'() {
@@ -59,7 +59,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
             task Foo {} 
             tasks.run.dependsOn Foo
             ${unTarTask('service-name')}
-        """.stripIndent()
+        """.stripIndent(true)
         file('src/main/java/test/Test.java') << mainClass('Test')
         file('src/main/java/test/TestSchema.java') << schemaClass('TestSchema')
 
@@ -79,7 +79,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
                 serviceName 'service-name'
                 gc 'hybrid'
             }
-        '''.stripIndent()
+        '''.stripIndent(true)
         file('src/main/java/test/Test.java') << mainClass('Test')
         file('src/main/java/test/Test2.java') << mainClass('Test2')
 
@@ -100,7 +100,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
                 gc 'hybrid'
             }
             ${unTarTask('service-name')}
-        """.stripIndent()
+        """.stripIndent(true)
         file('src/main/java/test/Test.java') << mainClass('Test')
         file('src/main/java/test/Test2.java') << mainClass('Test2')
 
@@ -121,7 +121,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
             into "dist"
             dependsOn distTar
         }
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     static def mainClass(String className) {
@@ -132,7 +132,7 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
                 while(true);
             }
         }
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     static def schemaClass(String className) {
@@ -144,6 +144,6 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
                 while(true);
             }
         }
-        """.stripIndent()
+        """.stripIndent(true)
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
@@ -149,6 +149,6 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
                 into "\${projectDir}/dist"
                 dependsOn configTar
             }
-        """.stripIndent()
+        """.stripIndent(true)
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                 serviceName "serviceName"
                 serviceGroup "serviceGroup"
             }
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     def 'fails if lockfile is not up to date'() {
@@ -46,12 +46,12 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group:name2 (2.0.0, 2.x.x)
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def buildResult = runTasksWithFailure(':createManifest')
@@ -78,12 +78,12 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
-        """.stripIndent()
+        """.stripIndent(true)
 
         runTasksSuccessfully('createManifest') // ensure task is run once
         runTasksSuccessfully('createManifest')
@@ -100,12 +100,12 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
-        """.stripIndent()
+        """.stripIndent(true)
 
         runTasksSuccessfully('createManifest') // ensure task is run once
         runTasksSuccessfully('createManifest')
@@ -138,7 +138,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                     recommendedVersion = rootProject.version
                 }
             }
-        """.stripIndent())
+        """.stripIndent(true))
         helper.addSubproject("foo-server", """
             apply plugin: 'com.palantir.sls-java-service-distribution'
             distribution {
@@ -147,7 +147,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                 mainClass 'com.palantir.foo.bar.MyServiceMainClass'
                 args 'server', 'var/conf/my-service.yml'
             }
-        """.stripIndent())
+        """.stripIndent(true))
         def barDir = helper.addSubproject("bar-server", """
             apply plugin: 'com.palantir.sls-java-service-distribution'
             dependencies {
@@ -159,12 +159,12 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                 mainClass 'com.palantir.foo.bar.MyServiceMainClass'
                 args 'server', 'var/conf/my-service.yml'
             }
-        """.stripIndent())
+        """.stripIndent(true))
 
         file('product-dependencies.lock', barDir).text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         com.palantir.group:foo-service (\$projectVersion, 1.x.x)
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def result = runTasksSuccessfully('bar-server:createManifest')
@@ -189,7 +189,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def buildResult = runTasksSuccessfully(writeLocksTask)
@@ -199,7 +199,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         file('product-dependencies.lock').text == """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         group1:name1 (1.0.0, 1.3.x)
-        """.stripIndent()
+        """.stripIndent(true)
 
         where:
         writeLocksTask << ['--write-locks', 'writeProductDependenciesLocks', 'wPDL']
@@ -213,7 +213,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                 uri = "registry.example.io/foo/bar:v1.3.0"
             }
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def buildResult = runTasksSuccessfully('createManifest')
@@ -231,7 +231,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                 uri = "registry.example[.io/foo/bar:v1.3.0"
             }
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def buildResult = runTasksWithFailure('createManifest')
@@ -276,7 +276,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                     uri = artifactOutput.flatMap { it.output }.map { Files.readString(it.getAsFile().toPath())}
                 }
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def buildResult = runTasksSuccessfully('createManifest')

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
                 'type': 'offline'
             ],
         ]
-    """.stripIndent()
+    """.stripIndent(true)
 
     def setup() {
         buildFile << """
@@ -41,7 +41,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
                 serviceName "serviceName"
                 serviceGroup "serviceGroup"
             }
-        """.stripIndent()
+        """.stripIndent(true)
     }
 
     def 'fails if lockfile is not up to date'() {
@@ -49,7 +49,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         distribution {
             ${SCHEMA}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('schema-versions.lock').text = """\
         ---
@@ -58,7 +58,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         - type: "offline"
           from: 52
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def buildResult = runTasksWithFailure(':createManifest')
@@ -85,7 +85,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         distribution {
             ${SCHEMA}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('schema-versions.lock').text = """\
         ---
@@ -94,7 +94,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         - type: "offline"
           from: 53
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
 
         runTasksSuccessfully('createManifest') // ensure task is run once
         runTasksSuccessfully('createManifest')
@@ -111,7 +111,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         distribution {
             ${SCHEMA}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         file('schema-versions.lock').text = """\
         ---
@@ -120,7 +120,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         - type: "offline"
           from: 53
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
 
         runTasksSuccessfully('createManifest') // ensure task is run once
         runTasksSuccessfully('createManifest')
@@ -138,7 +138,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         distribution {
             ${SCHEMA}
         }
-        """.stripIndent()
+        """.stripIndent(true)
 
         when:
         def buildResult = runTasksSuccessfully(writeLocksTask)
@@ -152,7 +152,7 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         - type: "offline"
           from: 53
         version: 1
-        """.stripIndent()
+        """.stripIndent(true)
 
         where:
         writeLocksTask << ['--write-locks', 'writeSchemaVersionLocks', 'wSVL']

--- a/gradle/jdks/11/linux-glibc/aarch64/download-url
+++ b/gradle/jdks/11/linux-glibc/aarch64/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-linux-aarch64.tar.gz

--- a/gradle/jdks/11/linux-glibc/aarch64/local-path
+++ b/gradle/jdks/11/linux-glibc/aarch64/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1-glibc

--- a/gradle/jdks/11/linux-glibc/x86-64/download-url
+++ b/gradle/jdks/11/linux-glibc/x86-64/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-linux-x64.tar.gz

--- a/gradle/jdks/11/linux-glibc/x86-64/local-path
+++ b/gradle/jdks/11/linux-glibc/x86-64/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1-glibc

--- a/gradle/jdks/11/linux-glibc/x86/download-url
+++ b/gradle/jdks/11/linux-glibc/x86/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-linux-i386.tar.gz

--- a/gradle/jdks/11/linux-glibc/x86/local-path
+++ b/gradle/jdks/11/linux-glibc/x86/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1-glibc

--- a/gradle/jdks/11/linux-musl/aarch64/download-url
+++ b/gradle/jdks/11/linux-musl/aarch64/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-alpine-linux-aarch64.tar.gz

--- a/gradle/jdks/11/linux-musl/aarch64/local-path
+++ b/gradle/jdks/11/linux-musl/aarch64/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1-musl

--- a/gradle/jdks/11/linux-musl/x86-64/download-url
+++ b/gradle/jdks/11/linux-musl/x86-64/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-alpine-linux-x64.tar.gz

--- a/gradle/jdks/11/linux-musl/x86-64/local-path
+++ b/gradle/jdks/11/linux-musl/x86-64/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1-musl

--- a/gradle/jdks/11/macos/aarch64/download-url
+++ b/gradle/jdks/11/macos/aarch64/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-macosx-aarch64.tar.gz

--- a/gradle/jdks/11/macos/aarch64/local-path
+++ b/gradle/jdks/11/macos/aarch64/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1

--- a/gradle/jdks/11/macos/x86-64/download-url
+++ b/gradle/jdks/11/macos/x86-64/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-macosx-x64.tar.gz

--- a/gradle/jdks/11/macos/x86-64/local-path
+++ b/gradle/jdks/11/macos/x86-64/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1

--- a/gradle/jdks/11/windows/x86-64/download-url
+++ b/gradle/jdks/11/windows/x86-64/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-windows-x64-jdk.zip

--- a/gradle/jdks/11/windows/x86-64/local-path
+++ b/gradle/jdks/11/windows/x86-64/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1

--- a/gradle/jdks/11/windows/x86/download-url
+++ b/gradle/jdks/11/windows/x86/download-url
@@ -1,1 +1,0 @@
-https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-windows-i386-jdk.zip

--- a/gradle/jdks/11/windows/x86/local-path
+++ b/gradle/jdks/11/windows/x86/local-path
@@ -1,1 +1,0 @@
-amazon-corretto-11.0.29.7.1

--- a/gradle/jdks/17/linux-glibc/aarch64/download-url
+++ b/gradle/jdks/17/linux-glibc/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/17.0.17.10.1/amazon-corretto-17.0.17.10.1-linux-aarch64.tar.gz

--- a/gradle/jdks/17/linux-glibc/aarch64/local-path
+++ b/gradle/jdks/17/linux-glibc/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-17.0.17.10.1-glibc

--- a/gradle/jdks/17/linux-glibc/x86-64/download-url
+++ b/gradle/jdks/17/linux-glibc/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/17.0.17.10.1/amazon-corretto-17.0.17.10.1-linux-x64.tar.gz

--- a/gradle/jdks/17/linux-glibc/x86-64/local-path
+++ b/gradle/jdks/17/linux-glibc/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-17.0.17.10.1-glibc

--- a/gradle/jdks/17/linux-musl/aarch64/download-url
+++ b/gradle/jdks/17/linux-musl/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/17.0.17.10.1/amazon-corretto-17.0.17.10.1-alpine-linux-aarch64.tar.gz

--- a/gradle/jdks/17/linux-musl/aarch64/local-path
+++ b/gradle/jdks/17/linux-musl/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-17.0.17.10.1-musl

--- a/gradle/jdks/17/linux-musl/x86-64/download-url
+++ b/gradle/jdks/17/linux-musl/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/17.0.17.10.1/amazon-corretto-17.0.17.10.1-alpine-linux-x64.tar.gz

--- a/gradle/jdks/17/linux-musl/x86-64/local-path
+++ b/gradle/jdks/17/linux-musl/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-17.0.17.10.1-musl

--- a/gradle/jdks/17/macos/aarch64/download-url
+++ b/gradle/jdks/17/macos/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/17.0.17.10.1/amazon-corretto-17.0.17.10.1-macosx-aarch64.tar.gz

--- a/gradle/jdks/17/macos/aarch64/local-path
+++ b/gradle/jdks/17/macos/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-17.0.17.10.1

--- a/gradle/jdks/17/macos/x86-64/download-url
+++ b/gradle/jdks/17/macos/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/17.0.17.10.1/amazon-corretto-17.0.17.10.1-macosx-x64.tar.gz

--- a/gradle/jdks/17/macos/x86-64/local-path
+++ b/gradle/jdks/17/macos/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-17.0.17.10.1

--- a/gradle/jdks/17/windows/x86-64/download-url
+++ b/gradle/jdks/17/windows/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/17.0.17.10.1/amazon-corretto-17.0.17.10.1-windows-x64-jdk.zip

--- a/gradle/jdks/17/windows/x86-64/local-path
+++ b/gradle/jdks/17/windows/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-17.0.17.10.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Before this PR

Started off in #1868, but that was a rather large PR with separate concerns.

### [Meta] Need Java 17 to run a Gradle 9 daemon

Bumped to Java 17 for this repo => Java 17 is required to use this plugin. I think this is fine, we've been minimum Java 17 for a lot of our other plugins and it's also 4 years old at this point. 

> N.B. it's not a strict requirement to be on Java 17 as a *plugin*, just that we need to run our tests and code with at least Java 17 for Gradle 9 to work. We get a lot of the nice benefits by moving to Java 17 source wise, so this is also an added benefit.

[`String#stripIndent`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#stripIndent()) was added in Java 15, and it has different behaviour to the Groovy behaviour so in tests, you're forced to use 

```groovy
String#stripIndent(true /* forceGroovyBehaviour*/)
```

It manifests as really cryptic errors, but downstream of this is just poor handling of indented line files, but perhaps that's the point idk.

### `Project#exec` has been removed in Gradle 9 and deprecated in 8.11
This was [deprecated in 8.11](https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec) and [removed in Gradle 9](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#removal_of_projectexec_projectjavaexec_and_script_level_counterparts). As we've also bumped Gradle to 8.14.3, it's now a deprecated usage, and that's failing compilation as we run with `-Werror`. It's an easy fix, so might as well include it here.

Simple replace with `ExecOperations`. This is fine because `ExecOperations` was introduced in Gradle 6 which our minimum supported Gradle version is far higher than.

It's looking a bit more difficult for scripts, as that method has also been removed there. Separate to this PR, but something to note.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

* Update to latest gradle 8 wrapper
* Run tests on Java 17
* Repo runs on Java 17
* Minimum Java version required is Java 17
* `String#stripIndent()` -> `String#stripIndent(true)`

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

