### PR TITLE
[Gradle 9] For `LaunchConfigTask`, ensure consistent classpath used regardless of manifest classpath

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -44,6 +44,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.plugins.JavaPlugin;
@@ -315,8 +316,12 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
 
         project.afterEvaluate(_p -> launchConfigTask.configure(task -> {
             task.getJavaAgents().setFrom(javaAgentConfiguration);
-            FileCollection fullClasspath =
-                    jarTask.get().getOutputs().getFiles().plus(distributionExtension.getProductDependenciesConfig());
+
+            ConfigurableFileCollection fullClasspath = project.getObjects()
+                    .fileCollection()
+                    .from(jarTask.get().getOutputs().getFiles())
+                    .from(project.getConfigurations().named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+
             task.getFullClasspath().from(fullClasspath);
             task.getClasspath()
                     .from(


### PR DESCRIPTION
## Before this PR
As part of figuring out how to support Gradle 9 for sls-packaging in #1868, I stumbled across some weird behaviour.

### Fix incorrect usage of `getProductDependenciesConfig` for `LaunchConfigTask`

The `LaunchConfig` task is what writes out `launcher-static.yml` and `launcher-check.yml` to be consumed by [go-java-launcher](https://github.com/palantir/go-java-launcher).

Part of that config, is specifying the classpath, and there's some code in `ModuleArgs` which extracts jvm module information from the classpath. We have to collect two types of classpath because there's an option for a classpath to be specified in a manifest jar instead. The `ModuleArgs` operates on the "full"/"realised" classpath. 

What's weird is that, when we're *not* using the manifest classpath, what we end up doing is using the `productDependenciesConfig` `Configuration` from the extension. For most cases this is actually equivalent i.e. it's the `runtimeClasspath`. However, there are cases where it's been set to something else so that excludes can be applied, or additional product dependencies can be inferred. This is incorrect as it's the wrong usage! Regardless of using the manifest classpath or not, it should "resolve" to the same set of jars, namely the `runtimeClasspath`. This just sets it up correctly. 

If we really did want to use the `productDependenciesConfig` (which I don't think we should), we should ensure that the manifest classpath is the same. In any case, none of that makes sense and I believe this is the correct usage.

In a later Gradle 9 PR, I'm going to do what I can to remove this capability, it makes for really weird usage of Gradle.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

