### PR TITLE
[Gradle 9] Prepare tests for Gradle 9

### DIFF
--- a/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
+++ b/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.dist
 
-
 import com.google.common.collect.Iterables
 import java.util.zip.ZipFile
 import nebula.test.IntegrationSpec
@@ -36,7 +35,9 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
 
     }
 
-    def "Manifest includes recommended product dependencies"() {
+    def "#gradleVersionNumber: Manifest includes recommended product dependencies"() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
         recommendedProductDependencies {
             productDependency {
@@ -64,9 +65,14 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         dep.maximumVersion == "1.x.x"
         dep.recommendedVersion == "1.2.3"
         dep.optional
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'sourcesJar runs compileRecommendedProductDependencies'() {
+    def '#gradleVersionNumber: sourcesJar runs compileRecommendedProductDependencies'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         //language=groovy
         buildFile << """
             recommendedProductDependencies {
@@ -97,9 +103,13 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         result.wasExecuted("compileRecommendedProductDependencies")
         fileExists("build/libs/${moduleName}-sources.jar")
 
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'Jar includes recommended product dependencies'() {
+    def '#gradleVersionNumber: Jar includes recommended product dependencies'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             recommendedProductDependencies {
                 productDependency {
@@ -126,9 +136,14 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         dep.minimumVersion == "1.0.0"
         dep.maximumVersion == "1.x.x"
         dep.recommendedVersion == "1.2.3"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def "Works with consistent-versions"() {
+    def "#gradleVersionNumber: Works with consistent-versions"() {
+        setup:
+        gradleVersion = gradleVersionNumber
         def repo = generateMavenRepo('group:name:1.0.0')
         buildFile << """
         apply plugin: 'com.palantir.consistent-versions'   
@@ -167,6 +182,9 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         dep.productName == "name"
         dep.minimumVersion == "1.0.0"
         dep.maximumVersion == "1.x.x"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     def readRecommendedProductDeps(File jarFile) {

--- a/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
+++ b/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import java.util.List;
+
+public final class GradleTestVersions {
+    private GradleTestVersions() {}
+
+    public static final List<String> GRADLE_VERSIONS = List.of("7.6.4", "8.14.3");
+}

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/GradleIntegrationSpec.groovy
@@ -18,8 +18,6 @@ package com.palantir.gradle.dist
 
 import com.google.common.collect.ImmutableList
 import nebula.test.IntegrationTestKitSpec
-import nebula.test.dependencies.DependencyGraph
-import nebula.test.dependencies.GradleDependencyGenerator
 import nebula.test.multiproject.MultiProjectIntegrationHelper
 import org.gradle.testkit.runner.GradleRunner
 
@@ -36,13 +34,6 @@ class GradleIntegrationSpec extends IntegrationTestKitSpec {
 
     protected boolean fileExists(String path) {
         new File(projectDir, path).exists()
-    }
-
-    GradleDependencyGenerator generateMavenRepo(String... graph) {
-        DependencyGraph dependencyGraph = new DependencyGraph(graph)
-        GradleDependencyGenerator generator = new GradleDependencyGenerator(dependencyGraph)
-        generator.generateTestMavenRepo()
-        return generator
     }
 
     /** Just here to ensure we display the gradle warnings, if any. */

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
@@ -21,7 +21,10 @@ import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.GradleDependencyGenerator
 
 class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpec {
-    def "adds product dependency constraints to configuration"() {
+    def "#gradleVersionNumber: adds product dependency constraints to configuration"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        
         buildFile << 'apply plugin: com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin'
 
         file("product-dependencies.lock").text = '''\
@@ -48,9 +51,14 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
 
         then:
         result.standardOutput.contains("com.palantir.product:test -> 1.0.0")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def "merges product dependency constraints from different projects"() {
+    def "#gradleVersionNumber: merges product dependency constraints from different projects"() {
+        setup:
+        gradleVersion = gradleVersionNumber
         file("a/product-dependencies.lock").text = '''\
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
             com.palantir.product:test (1.0.0, 1.x.x)
@@ -87,6 +95,9 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
 
         then:
         result.standardOutput.contains("com.palantir.product:test -> 1.2.0")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     File generateMavenRepo(String... graph) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -18,13 +18,16 @@ package com.palantir.gradle.dist.asset
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.palantir.gradle.dist.GradleIntegrationSpec
+import com.palantir.gradle.dist.GradleTestVersions
 import com.palantir.gradle.dist.Versions
 import spock.lang.Ignore
 
 class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
 
-    def 'manifest file contains expected fields'() {
+    def '#gradleVersionNumber: manifest file contains expected fields'() {
         given:
+        gradleVersion = gradleVersionNumber
+
         createUntarBuildFile(buildFile)
         buildFile << '''
             distribution {
@@ -42,10 +45,15 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         manifest.contains('"product-name" : "asset-name"')
         manifest.contains('"product-version" : "0.0.1"')
         manifest.contains('"product-type" : "asset.v1"')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'asset dirs are copied correctly'() {
+    def '#gradleVersionNumber: asset dirs are copied correctly'() {
         given:
+        gradleVersion = gradleVersionNumber
+
         file("static/foo/bar") << "."
         file("static/baz/abc") << "."
         file("static/abc") << "overwritten file"
@@ -72,10 +80,15 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         def lines = file("dist/asset-name-0.0.1/asset/maven/abc").readLines()
         lines.size() == 1
         lines.get(0) == "overwritten file"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails when asset and service plugins are used'() {
+    def '#gradleVersionNumber: fails when asset and service plugins are used'() {
         given:
+        gradleVersion = gradleVersionNumber
+
         buildFile << '''
             plugins {
                 id 'com.palantir.sls-java-service-distribution'
@@ -88,10 +101,15 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
 
         then:
         result.output.contains("The plugins 'com.palantir.sls-asset-distribution' and 'com.palantir.sls-java-service-distribution' cannot be used in the same Gradle project.")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'can specify service dependencies'() {
+    def '#gradleVersionNumber: can specify service dependencies'() {
         given:
+        gradleVersion = gradleVersionNumber
+
         createUntarBuildFile(buildFile)
         buildFile << """
             distribution {
@@ -135,10 +153,15 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         dep2['product-name'] == 'name2'
         dep2['minimum-version'] == '1.0.0'
         dep2['maximum-version'] == '2.x.x'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'allows another task to produce configuration.yml'() {
+    def '#gradleVersionNumber: allows another task to produce configuration.yml'() {
         given:
+        gradleVersion = gradleVersionNumber
+
         createUntarBuildFile(buildFile)
         debug = true
 
@@ -163,10 +186,15 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         then:
         String actualConfiguration = new File(projectDir, 'dist/asset-name-0.0.1/deployment/configuration.yml').text
         actualConfiguration == 'custom: yml'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'falls back to build/deployment/configuration.yml'() {
+    def '#gradleVersionNumber: falls back to build/deployment/configuration.yml'() {
         given:
+        gradleVersion = gradleVersionNumber
+
         createUntarBuildFile(buildFile)
         debug = true
 
@@ -189,6 +217,9 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         then:
         String actualConfiguration = new File(projectDir, 'dist/asset-name-0.0.1/deployment/configuration.yml').text
         actualConfiguration == 'buildDir: yml'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     /**

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
@@ -17,8 +17,8 @@
 package com.palantir.gradle.dist.pdeps
 
 import com.palantir.gradle.dist.BaseDistributionExtension
+import com.palantir.gradle.dist.GradleTestVersions
 import com.palantir.gradle.dist.ObjectMappers
-import spock.lang.Unroll
 
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
@@ -49,8 +49,9 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
     }
 
-    def 'consumes declared product dependencies'() {
+    def '#gradleVersionNumber: consumes declared product dependencies'() {
         setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             distribution {
                 ${PDEP}
@@ -64,10 +65,14 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def manifest = ObjectMappers.readProductDependencyManifest(
                 file('build/resolved-pdeps/pdeps-manifest.json'))
         !manifest.productDependencies().isEmpty()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'discovers project dependencies without compilation'() {
+    def '#gradleVersionNumber: discovers project dependencies without compilation'() {
         given:
+        gradleVersion = gradleVersionNumber
         addSubproject('child', """
         apply plugin: 'java'
         apply plugin: 'com.palantir.recommended-product-dependencies'
@@ -90,10 +95,14 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def manifest = ObjectMappers.readProductDependencyManifest(
                 file('build/resolved-pdeps/pdeps-manifest.json'))
         !manifest.productDependencies().isEmpty()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'discovers external dependencies'() {
+    def '#gradleVersionNumber: discovers external dependencies'() {
         given:
+        gradleVersion = gradleVersionNumber
         GradleDependencyGenerator generator = new GradleDependencyGenerator(
                 new DependencyGraph("a:a:1.0"), new File(projectDir, "build/testrepogen").toString())
         def mavenRepo = generator.generateTestMavenRepo()
@@ -121,10 +130,14 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def manifest = ObjectMappers.readProductDependencyManifest(
                 file('build/resolved-pdeps/pdeps-manifest.json'))
         !manifest.productDependencies().isEmpty()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'handles jars without manifest'() {
+    def '#gradleVersionNumber: handles jars without manifest'() {
         given:
+        gradleVersion = gradleVersionNumber
         GradleDependencyGenerator generator = new GradleDependencyGenerator(
                 new DependencyGraph(
                         "missingmanifest:missingmanifest:1.0"), new File(projectDir, "build/testrepogen").toString())
@@ -152,9 +165,15 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         def manifest = ObjectMappers.readProductDependencyManifest(
                 file('build/resolved-pdeps/pdeps-manifest.json'))
         manifest.productDependencies().isEmpty()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'resolveProductDependencies and processResources work together'() {
+    def '#gradleVersionNumber: resolveProductDependencies and processResources work together'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        
         // this is a strange setup that really shouldn't happen in a real repo - a project shouldn't be both an API
         // jar and a distribution.  But in case it does happen we want to make sure there are no accidental
         // connections between the tasks.
@@ -168,5 +187,8 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
 
         then:
         runTasksSuccessfully('resolveProductDependencies', 'processResources')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/DiagnosticsManifestPluginIntegrationSpec.groovy
@@ -16,12 +16,14 @@
 
 package com.palantir.gradle.dist.service
 
+import com.palantir.gradle.dist.GradleTestVersions
 import nebula.test.IntegrationSpec
 
 class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
 
-    def 'detects stuff defined in current project'() {
+    def '#gradleVersionNumber: detects stuff defined in current project'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << """
         apply plugin: 'java-library'
         ${applyPlugin(DiagnosticsManifestPlugin.class)}
@@ -50,10 +52,14 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         result2.wasUpToDate(":mergeDiagnosticsJson")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'detects stuff defined in sibling projects'() {
+    def '#gradleVersionNumber: detects stuff defined in sibling projects'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
         subprojects {
             apply plugin: 'java-library'
@@ -98,5 +104,8 @@ class DiagnosticsManifestPluginIntegrationSpec extends IntegrationSpec {
           "type" : "myproject2.v1",
           "docs" : "Click me if you dare!"
         } ]""".stripIndent(true)
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/GcProfileIntegrationSpec.groovy
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.dist.service.tasks
+package com.palantir.gradle.dist.service
 
 import com.palantir.gradle.dist.GradleIntegrationSpec
+import com.palantir.gradle.dist.GradleTestVersions
 import com.palantir.gradle.dist.service.gc.GcProfile
 import java.nio.file.Files
 import java.nio.file.Path
@@ -62,8 +63,10 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
     }
 
     @Unroll
-    def 'successfully create a distribution using gc: #gc'() {
+    def '#gradleVersionNumber: successfully create a distribution using gc: #gc'() {
         setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
         distribution {
             gc '${gc}'
@@ -83,7 +86,10 @@ class GcProfileIntegrationSpec extends GradleIntegrationSpec {
         println file("touch-service-1.0.0/var/log/startup.log").text
 
         where:
-        gc << GcProfile.PROFILE_NAMES.keySet().toArray()
+        [gc, gradleVersionNumber] << [
+                GcProfile.PROFILE_NAMES.keySet().toArray(),
+                GradleTestVersions.GRADLE_VERSIONS
+        ].combinations()
     }
 
     int execWithExitCode(String... tasks) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -1214,8 +1214,10 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         runTasks("generateDockerCompose")
 
         where:
-        writeLocksTask << ['--write-locks', 'writeProductDependenciesLocks']
-        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+        [writeLocksTask, gradleVersionNumber] << [
+                ['--write-locks', 'writeProductDependenciesLocks'],
+                GradleTestVersions.GRADLE_VERSIONS
+        ].combinations()
     }
 
     def '#gradleVersionNumber: uses the runtimeClasspath in manifest jar'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.datatype.guava.GuavaModule
 import com.palantir.gradle.dist.GradleIntegrationSpec
+import com.palantir.gradle.dist.GradleTestVersions
 import com.palantir.gradle.dist.SlsManifest
 import com.palantir.gradle.dist.Versions
 import com.palantir.gradle.dist.service.tasks.LaunchConfig
@@ -40,8 +41,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
     private static final String EXTERNAL_JAR = new File("src/test/resources/external.jar").getAbsolutePath();
 
-    def 'produce distribution bundle and check start, stop, restart, check behavior'() {
+    def '#gradleVersionNumber: produce distribution bundle and check start, stop, restart, check behavior'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << '''
             distribution {
@@ -91,10 +93,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         execWithOutput('dist/service-name-0.0.1/service/monitoring/bin/check.sh').readLines().any {
             it ==~ /Checking health of 'service-name'\.\.\.\s+Healthy/
         }
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'packaging tasks re-run after version change'() {
+    def '#gradleVersionNumber: packaging tasks re-run after version change'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << '''
             distribution {
@@ -127,10 +133,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         execWithExitCode('dist/service-name-0.0.2/service/bin/init.sh', 'start') == 0
         execWithExitCode('dist/service-name-0.0.2/service/bin/init.sh', 'stop') == 0
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle and check var/log and var/run are excluded'() {
+    def '#gradleVersionNumber: produce distribution bundle and check var/log and var/run are excluded'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         createFile('var/log/service-name.log')
@@ -145,10 +155,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         !fileExists('dist/service-name-0.0.1/var/log')
         !fileExists('dist/service-name-0.0.1/var/run')
         fileExists('dist/service-name-0.0.1/var/conf/service-name.yml')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle and check var/data/tmp is created and used for temporary files'() {
+    def '#gradleVersionNumber: produce distribution bundle and check var/data/tmp is created and used for temporary files'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         file('src/main/java/test/Test.java') << '''
         package test;
@@ -169,10 +183,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         sleep(1000)
         file('dist/service-name-0.0.1/var/data/tmp').listFiles().length == 1
         file('dist/service-name-0.0.1/var/data/tmp').listFiles()[0].text == "temp content"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle with custom exclude set'() {
+    def '#gradleVersionNumber: produce distribution bundle with custom exclude set'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             plugins {
                 id 'java'
@@ -208,10 +226,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         !fileExists('dist/service-name-0.0.1/var/log')
         !fileExists('dist/service-name-0.0.1/var/data/database')
         fileExists('dist/service-name-0.0.1/var/conf/service-name.yml')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle with a non-string version object'() {
+    def '#gradleVersionNumber: produce distribution bundle with a non-string version object'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             plugins {
                 id 'java'
@@ -252,10 +274,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         def manifest = OBJECT_MAPPER.readValue(file('dist/service-name-0.0.1/deployment/manifest.yml'), SlsManifest);
         manifest.productVersion() == "0.0.1"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'manifest file contains expected fields'() {
+    def '#gradleVersionNumber: manifest file contains expected fields'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         when:
@@ -269,10 +295,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         manifest.get("product-version") == "0.0.1"
         manifest.get("product-type") == "service.v1"
         manifest.get("extensions").get("foo") == ["bar": ["1", "2"]]
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'can specify service dependencies'() {
+    def '#gradleVersionNumber: can specify service dependencies'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             distribution {
@@ -315,10 +345,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         dep2['product-group'] == 'group2'
         dep2['product-name'] == 'name2'
         dep2['minimum-version'] == '1.0.0'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'cannot specify service dependencies with invalid versions, with closure constructor'() {
+    def '#gradleVersionNumber: cannot specify service dependencies with invalid versions, with closure constructor'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             distribution {
@@ -336,10 +370,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         result.output.contains("minimumVersion must be an SLS version")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle with files in deployment/'() {
+    def '#gradleVersionNumber: produce distribution bundle with files in deployment/'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         String deploymentConfiguration = 'log: service-name.log'
@@ -357,10 +395,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         // check files in deployment/ copied successfully
         String actualConfiguration = new File(projectDir, 'dist/service-name-0.0.1/deployment/configuration.yml').text
         actualConfiguration == deploymentConfiguration
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'allows another task to produce configuration.yml'() {
+    def '#gradleVersionNumber: allows another task to produce configuration.yml'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         debug = true
 
@@ -385,10 +427,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         String actualConfiguration = new File(projectDir, 'dist/service-name-0.0.1/deployment/configuration.yml').text
         actualConfiguration == 'custom: yml'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'errors out if the custom configuration.yml location is not a file called configuration.yml'() {
+    def '#gradleVersionNumber: errors out if the custom configuration.yml location is not a file called configuration.yml'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         debug = true
 
@@ -412,10 +458,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         output.contains('must be called configuration.yml')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle with start script that passes default JVM options'() {
+    def '#gradleVersionNumber: produce distribution bundle with start script that passes default JVM options'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         when:
@@ -424,10 +474,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         String startScript = new File(projectDir, 'dist/service-name-0.0.1/service/bin/service-name').text
         startScript.contains('DEFAULT_JVM_OPTS=\'"-Xmx4M" "-Djavax.net.ssl.trustStore=truststore.jks"\'')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle that populates launcher-static.yml and launcher-check.yml'() {
+    def '#gradleVersionNumber: produce distribution bundle that populates launcher-static.yml and launcher-check.yml'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         buildFile << """
@@ -506,11 +560,15 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-check.yml'), LaunchConfig.LaunchConfigInfo)
         expectedCheckConfig == actualCheckConfig
         expectedStaticConfig == actualStaticConfig
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
 
-    def 'produce distribution bundle that populates launcher-static.yml and launcher-check.yml with bundled jdk'() {
+    def '#gradleVersionNumber: produce distribution bundle that populates launcher-static.yml and launcher-check.yml with bundled jdk'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         buildFile << """
@@ -590,9 +648,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 file('dist/service-name-0.0.1/service/bin/launcher-check.yml'), LaunchConfig.LaunchConfigInfo)
         expectedCheckConfig == actualCheckConfig
         expectedStaticConfig == actualStaticConfig
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution with java 8 gc logging'() {
+    def '#gradleVersionNumber: produce distribution with java 8 gc logging'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies { implementation files("${EXTERNAL_JAR}") }
@@ -642,9 +705,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         expectedStaticConfig == actualStaticConfig
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'respects java version'() {
+    def '#gradleVersionNumber: respects java version'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies { implementation files("${EXTERNAL_JAR}") }
@@ -666,9 +734,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "-XX:+ExplicitGCInvokesConcurrent",
                 "-XX:+ClassUnloadingWithConcurrentMark",
         ])
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'Uses generational zgc for jdk-21'() {
+    def '#gradleVersionNumber: Uses generational zgc for jdk-21'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies { implementation files("${EXTERNAL_JAR}") }
@@ -690,9 +763,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "-XX:+ZGenerational",
                 "-XX:+ExplicitGCInvokesConcurrent",
         ])
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'jdk-21 uses default AVX level'() {
+    def '#gradleVersionNumber: jdk-21 uses default AVX level'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies { implementation files("${EXTERNAL_JAR}") }
@@ -709,10 +787,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.jvmOpts().stream().noneMatch { it.contains("UseAVX") }
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle that populates check.sh'() {
+    def '#gradleVersionNumber: produce distribution bundle that populates check.sh'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << '''
             distribution {
@@ -725,10 +807,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         new File(projectDir, 'dist/service-name-0.0.1/service/monitoring/bin/check.sh').exists()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produces manifest-classpath jar and windows start script with no classpath length limitations'() {
+    def '#gradleVersionNumber: produces manifest-classpath jar and windows start script with no classpath length limitations'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         settingsFile << '''
         rootProject.name = 'root-project'
@@ -759,10 +845,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         zipManifest.contains('guava-19.0.jar')
         zipManifest.contains('root-project-manifest-classpath-0.0.1.jar')
         zipManifest.contains('root-project-0.0.1.jar')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'does not produce manifest-classpath jar when disabled in extension'() {
+    def '#gradleVersionNumber: does not produce manifest-classpath jar when disabled in extension'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         when:
@@ -774,10 +864,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         startScript.contains("-classpath \"%CLASSPATH%\"")
         !new File(projectDir, 'dist/service-name-0.0.1/service/lib/').listFiles()
                 .find({ it.name.endsWith("-manifest-classpath-0.1.jar") })
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'distTar artifact name is set during appropriate lifecycle events'() {
+    def '#gradleVersionNumber: distTar artifact name is set during appropriate lifecycle events'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             plugins {
                 id 'java'
@@ -807,10 +901,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         expect:
         runTasks(':tasks')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'exposes an artifact through the sls configuration'() {
+    def '#gradleVersionNumber: exposes an artifact through the sls configuration'() {
         given:
+        gradleVersion = gradleVersionNumber
         helper.addSubproject('parent', '''
             plugins {
                 id 'java'
@@ -851,10 +949,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         buildResult.task(':parent:distTar').outcome == TaskOutcome.SUCCESS
         new File(childProject,'build/exploded/my-service-0.0.1/deployment/manifest.yml').exists()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'exposes an artifact via dependency with sls-dist usage'() {
+    def '#gradleVersionNumber: exposes an artifact via dependency with sls-dist usage'() {
         given:
+        gradleVersion = gradleVersionNumber
         helper.addSubproject('producer', '''
             plugins {
                 id 'java'
@@ -899,6 +1001,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         buildResult.task(':producer:distTar').outcome == TaskOutcome.SUCCESS
         new File(consumer,'build/exploded/my-service-0.0.1/deployment/manifest.yml').exists()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     /**
@@ -910,7 +1015,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
      * However, here we only care about testing that it can resolve to <i>something</i>, for the sole purpose of
      * extracting the version the resolved component.
      */
-    def 'dist project can be resolved through plain dependency when GCV is applied'() {
+    def '#gradleVersionNumber: dist project can be resolved through plain dependency when GCV is applied'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             plugins {
                 id 'com.palantir.consistent-versions' version '${Versions.GRADLE_CONSISTENT_VERSIONS}'
@@ -947,10 +1054,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         expect:
         runTasks(':verify')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails when asset and service plugins are both applied'() {
+    def '#gradleVersionNumber: fails when asset and service plugins are both applied'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             plugins {
                 id 'com.palantir.sls-asset-distribution'
@@ -963,10 +1074,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         result.output.contains("The plugins 'com.palantir.sls-asset-distribution' and 'com.palantir.sls-java-service-distribution' cannot be used in the same Gradle project.")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'uses the runtimeClasspath so api and implementation configurations work with java-library plugin'() {
+    def '#gradleVersionNumber: uses the runtimeClasspath so api and implementation configurations work with java-library plugin'() {
         given:
+        gradleVersion = gradleVersionNumber
         def parent = helper.addSubproject('parent', '''
             plugins {
                 id 'java'
@@ -1039,10 +1154,15 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         launcherStatic.classpath.any { it.contains('/lib/annotations-3.0.1.jar') }
         launcherStatic.classpath.any { it.contains('/lib/guava-19.0.jar') }
         launcherStatic.classpath.any { it.contains('/lib/mockito-core-2.7.22.jar') }
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     @Unroll
-    def 'docker can resolve inter-project product dependencies (#writeLocksTask)'() {
+    def '#gradleVersionNumber: docker can resolve inter-project product dependencies (#writeLocksTask)'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             buildscript {
                 repositories {
@@ -1095,10 +1215,12 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         where:
         writeLocksTask << ['--write-locks', 'writeProductDependenciesLocks']
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'uses the runtimeClasspath in manifest jar'() {
+    def '#gradleVersionNumber: uses the runtimeClasspath in manifest jar'() {
         given:
+        gradleVersion = gradleVersionNumber
         def parent = helper.addSubproject('parent', '''
             plugins {
                 id 'java'
@@ -1180,10 +1302,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 LaunchConfig.LaunchConfigInfo.class)
 
         launcherStatic.classpath.any { it.contains('-manifest-classpath-0.0.1.jar') }
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'project class files do not appear in output lib directory'() {
+    def '#gradleVersionNumber: project class files do not appear in output lib directory'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         file('src/main/java/test/Test.java') << '''
         package test;
@@ -1199,10 +1325,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         !new File(projectDir, 'dist/service-name-0.0.1/service/lib/com/test/Test.class').exists()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'adds initiatingOccupancyFraction gc profile jvm settings'() {
+    def '#gradleVersionNumber: adds initiatingOccupancyFraction gc profile jvm settings'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             plugins {
                 id 'java'
@@ -1235,10 +1365,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.jvmOpts.containsAll(['-XX:+UseParNewGC', '-XX:+UseConcMarkSweepGC', '-XX:CMSInitiatingOccupancyFraction=75'])
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'adds maxGCPauseMillis gc profile jvm settings'() {
+    def '#gradleVersionNumber: adds maxGCPauseMillis gc profile jvm settings'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             plugins {
                 id 'java'
@@ -1269,10 +1403,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseNUMA', '-XX:MaxGCPauseMillis=1234'])
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'gc profile null configuration closure'() {
+    def '#gradleVersionNumber: gc profile null configuration closure'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             plugins {
                 id 'java'
@@ -1301,9 +1439,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.jvmOpts.containsAll(['-XX:+UseG1GC', '-XX:+UseNUMA', "-XX:MaxGCPauseMillis=500"])
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'applies java agents'() {
+    def '#gradleVersionNumber: applies java agents'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies {
@@ -1324,9 +1467,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.jvmOpts().contains("-javaagent:service/lib/agent/byte-buddy-agent-1.10.21.jar")
         fileExists('dist/service-name-0.0.1/service/lib/agent/byte-buddy-agent-1.10.21.jar')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails at build time when non-agent jars are provided as agents'() {
+    def '#gradleVersionNumber: fails at build time when non-agent jars are provided as agents'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies {
@@ -1344,9 +1492,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         result.output.contains('is not a java agent and contains no Premain-Class manifest entry')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'exports management packages on new javas'() {
+    def '#gradleVersionNumber: exports management packages on new javas'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies { implementation files("${EXTERNAL_JAR}") }
@@ -1366,9 +1519,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "--add-exports",
                 "java.management/sun.management=ALL-UNNAMED"
         ])
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'applies exports based on classpath manifests'() {
+    def '#gradleVersionNumber: applies exports based on classpath manifests'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
         manifest.getMainAttributes().putValue('Add-Exports', 'jdk.compiler/com.sun.tools.javac.file')
@@ -1405,9 +1563,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         // Verify args are set in the correct order
         int compilerPairIndex = actualOpts.indexOf("jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED")
         actualOpts.get(compilerPairIndex - 1) == "--add-exports"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'applies opens based on classpath manifests'() {
+    def '#gradleVersionNumber: applies opens based on classpath manifests'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
         manifest.getMainAttributes().putValue('Add-Opens', 'jdk.compiler/com.sun.tools.javac.file')
@@ -1444,9 +1607,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         // Verify args are set in the correct order
         int compilerPairIndex = actualOpts.indexOf("jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED")
         actualOpts.get(compilerPairIndex - 1) == "--add-opens"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'applies opens based on classpath manifests for manifest classpaths'() {
+    def '#gradleVersionNumber: applies opens based on classpath manifests for manifest classpaths'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
         manifest.getMainAttributes().putValue('Add-Opens', 'jdk.compiler/com.sun.tools.javac.file')
@@ -1484,9 +1652,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         // Verify args are set in the correct order
         int compilerPairIndex = actualOpts.indexOf("jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED")
         actualOpts.get(compilerPairIndex - 1) == "--add-opens"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'Handles jars with no manifest'() {
+    def '#gradleVersionNumber: Handles jars with no manifest'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         File testJar = new File(getProjectDir(),"test.jar");
         testJar.withOutputStream { fos ->
             new ZipOutputStream(fos).close()
@@ -1508,9 +1681,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         tasksWereSuccessful(result, ':build', ':distTar', ':untar')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'can resolve go-java-launcher binaries through GCV'() {
+    def '#gradleVersionNumber: can resolve go-java-launcher binaries through GCV'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         // Set a lower default version of go-java-launcher so we can verify that we pick up the higher version through
         // GCV
         file('gradle.properties') << """
@@ -1551,9 +1729,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         fileExists("dist/service-name-0.0.1/service/bin/go-java-launcher-${goJavaLauncherVersion}/service/bin")
         fileExists("dist/service-name-0.0.1/service/bin/go-init-${goJavaLauncherVersion}/service/bin")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'enableAlwaysPreTouch'() {
+    def '#gradleVersionNumber: enableAlwaysPreTouch'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
         buildFile << """
             dependencies { implementation files("${EXTERNAL_JAR}") }
@@ -1573,10 +1756,14 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 "-XX:+AlwaysPreTouch",
                 "-XX:+UseTransparentHugePages",
         ])
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'produce distribution bundle that can bundle extra Jars'() {
+    def '#gradleVersionNumber: produce distribution bundle that can bundle extra Jars'() {
         given:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile)
 
         buildFile << """
@@ -1601,6 +1788,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         fileExists("dist/service-name-0.0.1/service/maven/${Path.of(EXTERNAL_JAR).getFileName()}")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     private static createUntarBuildFile(File buildFile) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JdksInDistsIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JdksInDistsIntegrationSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist.service
 
+import com.palantir.gradle.dist.GradleTestVersions
 import nebula.test.IntegrationSpec
 import org.rauschig.jarchivelib.ArchiveFormat
 import org.rauschig.jarchivelib.ArchiverFactory
@@ -59,7 +60,9 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
         file('build/fake-jdk/release') << 'its a jdk trust me'
     }
 
-    def 'puts jdk in dist'() {
+    def '#gradleVersionNumber: puts jdk in dist'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         // language=gradle
         buildFile << '''
             distribution {
@@ -83,9 +86,14 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
         def launcherStatic = new File(rootDir, "service/bin/launcher-static.yml").text
         launcherStatic.contains 'javaHome: "service/myService-jdks/jdk17"'
         launcherStatic.contains '  JAVA_17_HOME: "service/myService-jdks/jdk17"'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'multiple jdks can exist in the dist'() {
+    def '#gradleVersionNumber: multiple jdks can exist in the dist'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         // language=gradle
         buildFile << '''
             distribution {
@@ -116,9 +124,14 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
             def envVarLine = "  JAVA_${version}_HOME: \"service/myService-jdks/jdk${version}\""
             assert launcherStatic.contains(envVarLine)
         }
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'does not force value of jdks at configuration time when task is evaluated'() {
+    def '#gradleVersionNumber: does not force value of jdks at configuration time when task is evaluated'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         // language=gradle
         buildFile << '''
             distribution {
@@ -147,9 +160,14 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
         // A way of fixing this tests seems to open up the possibility of making extra unnecessary JDK repos - ensure
         // this does not happen.
         !new File(rootDir, "service/myService-jdks/jdk11").exists()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'even a user clearing env does not get rid of JAVA_XX_HOME env vars'() {
+    def '#gradleVersionNumber: even a user clearing env does not get rid of JAVA_XX_HOME env vars'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         // language=gradle
         buildFile << '''
             distribution {
@@ -171,6 +189,9 @@ class JdksInDistsIntegrationSpec extends IntegrationSpec {
 
         launcherStatic.contains 'JAVA_11_HOME: "service/myService-jdks/jdk11"'
         launcherStatic.contains 'JAVA_17_HOME: "service/myService-jdks/jdk17"'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     private File extractDist() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/LazyCreateStartScriptTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/LazyCreateStartScriptTaskIntegrationSpec.groovy
@@ -16,10 +16,14 @@
 
 package com.palantir.gradle.dist.service
 
+import com.palantir.gradle.dist.GradleTestVersions
 import nebula.test.IntegrationSpec
 
 class LazyCreateStartScriptTaskIntegrationSpec extends IntegrationSpec {
-    def 'correctly populates main class'() {
+    def '#gradleVersionNumber: correctly populates main class'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        
         when:
         buildFile << """
         import com.palantir.gradle.dist.service.tasks.LazyCreateStartScriptTask;
@@ -34,5 +38,8 @@ class LazyCreateStartScriptTaskIntegrationSpec extends IntegrationSpec {
         then:
         file('build/scripts/test-service').text.contains 'myMainClass'
         file('build/scripts/test-service.bat').text.contains 'myMainClass'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/MainClassInferenceIntegrationSpec.groovy
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.datatype.guava.GuavaModule
 import com.palantir.gradle.dist.GradleIntegrationSpec
+import com.palantir.gradle.dist.GradleTestVersions
 import com.palantir.gradle.dist.service.tasks.LaunchConfig
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 
@@ -41,8 +42,9 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
         '''.stripIndent(true)
     }
 
-    def 'infers main class correctly'() {
+    def '#gradleVersionNumber: infers main class correctly'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             dependencies {
                 implementation 'com.palantir.atlasdb:atlasdb-client:0.382.0'
@@ -70,10 +72,14 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.mainClass() == "test.Test"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails to infer main class if there are many'() {
+    def '#gradleVersionNumber: fails to infer main class if there are many'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << '''
             distribution {
                 serviceName 'service-name'
@@ -89,10 +95,14 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
         then:
         def error = thrown(UnexpectedBuildFailure)
         error.message.contains('Expecting to find exactly one main method, however we found 2')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'allows users to override main class if there are many'() {
+    def '#gradleVersionNumber: allows users to override main class if there are many'() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             distribution {
                 serviceName 'service-name'
@@ -111,6 +121,9 @@ class MainClassInferenceIntegrationSpec extends GradleIntegrationSpec {
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 file('dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
         actualStaticConfig.mainClass() == "test.Test"
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     def unTarTask(String serviceName) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/ConfigTarTaskIntegrationSpec.groovy
@@ -17,12 +17,14 @@
 package com.palantir.gradle.dist.tasks
 
 import com.google.common.base.Throwables
+import com.palantir.gradle.dist.GradleTestVersions
 import nebula.test.IntegrationSpec
 
 class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
 
-    def 'configTar task exists for services'() {
+    def '#gradleVersionNumber: configTar task exists for services'() {
         setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile, "java-service", "service", "foo-service")
 
         when:
@@ -30,10 +32,14 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         fileExists('build/distributions/foo-service-0.0.1.service.config.tgz')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'configTar task exists for assets'() {
+    def '#gradleVersionNumber: configTar task exists for assets'() {
         setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile, "asset", "asset", "foo-asset")
 
         when:
@@ -41,10 +47,14 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         fileExists('build/distributions/foo-asset-0.0.1.asset.config.tgz')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'configTar task contains the necessary deployment files for services'() {
+    def '#gradleVersionNumber: configTar task contains the necessary deployment files for services'() {
         setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile, "java-service", "service", "foo-service")
 
         when:
@@ -57,10 +67,14 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
         def manifest = new File(projectDir, 'dist/foo-service-0.0.1/deployment/manifest.yml').text
         manifest.contains('service.v1')
         fileExists('dist/foo-service-0.0.1/service/bin/launcher-static.yml')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'configTar task contains the necessary deployment files for assets'() {
+    def '#gradleVersionNumber: configTar task contains the necessary deployment files for assets'() {
         setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile, "asset", "asset", "foo-asset")
 
         when:
@@ -72,10 +86,14 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
         files.contains('deployment')
         def manifest = new File(projectDir, 'dist/foo-asset-0.0.1/deployment/manifest.yml').text
         manifest.contains('asset.v1')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'configTar task support configuration.ymls being generated to a non-standard location'() {
+    def '#gradleVersionNumber: configTar task support configuration.ymls being generated to a non-standard location'() {
         setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile, "asset", "asset", "foo-asset")
 
         // language=Gradle
@@ -99,10 +117,14 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
         then:
         def configuration = new File(projectDir, 'dist/foo-asset-0.0.1/deployment/configuration.yml').text
         configuration.contains('custom: yml')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'errors out if the custom configuration.yml location is not a file called configuration.yml'() {
+    def '#gradleVersionNumber: errors out if the custom configuration.yml location is not a file called configuration.yml'() {
         setup:
+        gradleVersion = gradleVersionNumber
         createUntarBuildFile(buildFile, "asset", "asset", "foo-asset")
 
         // language=Gradle
@@ -125,6 +147,9 @@ class ConfigTarTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         failureMessage.contains('must be called configuration.yml')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     private static createUntarBuildFile(buildFile, pluginType, artifactType, name) {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -234,8 +234,10 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         where:
-        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
-        writeLocksTask << ['--write-locks', 'writeProductDependenciesLocks', 'wPDL']
+        [gradleVersionNumber, writeLocksTask] << [
+                GradleTestVersions.GRADLE_VERSIONS,
+                ['--write-locks', 'writeProductDependenciesLocks', 'wPDL']
+        ].combinations()
     }
 
     def '#gradleVersionNumber: write artifacts to manifest'() {

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -17,6 +17,7 @@
 package com.palantir.gradle.dist.tasks
 
 import com.fasterxml.jackson.core.type.TypeReference
+import com.palantir.gradle.dist.GradleTestVersions
 import com.palantir.gradle.dist.ObjectMappers
 import com.palantir.gradle.dist.SlsManifest
 import com.palantir.gradle.dist.artifacts.JsonArtifactLocator
@@ -41,7 +42,9 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
     }
 
-    def 'fails if lockfile is not up to date'() {
+    def '#gradleVersionNumber: fails if lockfile is not up to date'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
@@ -59,9 +62,15 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         then:
         buildResult.getStandardError().contains(
                 "product-dependencies.lock is out of date, please run `./gradlew writeProductDependenciesLocks` to update it")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails if unexpected lockfile exists'() {
+    def '#gradleVersionNumber: fails if unexpected lockfile exists'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         runTasksSuccessfully('createManifest') // ensure task is run once
         def result = runTasksSuccessfully('createManifest')
         result.wasUpToDate(':createManifest')
@@ -71,9 +80,15 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         runTasksWithFailure('createManifest')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails if lock file disappears'() {
+    def '#gradleVersionNumber: fails if lock file disappears'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
@@ -93,9 +108,15 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         runTasksWithFailure('createManifest')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails if lockfile has changed contents'() {
+    def '#gradleVersionNumber: fails if lockfile has changed contents'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
@@ -115,10 +136,15 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         runTasksWithFailure('createManifest')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'always write projectVersion as minimum version in product dependency that is published by this repo'() {
+    def '#gradleVersionNumber: always write projectVersion as minimum version in product dependency that is published by this repo'() {
         setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
         allprojects {
             project.version = '1.0.1'
@@ -181,10 +207,16 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                         "optional"           : false
                 ]
         ]
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     @Unroll
-    def 'writes locks when #writeLocksTask is on the command line'() {
+    def '#gradleVersionNumber: writes locks when #writeLocksTask is on the command line'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
         distribution {
             ${ResolveProductDependenciesIntegrationSpec.PDEP}
@@ -202,10 +234,14 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
         writeLocksTask << ['--write-locks', 'writeProductDependenciesLocks', 'wPDL']
     }
 
-    def 'write artifacts to manifest'() {
+    def '#gradleVersionNumber: write artifacts to manifest'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
         distribution {
             artifact {
@@ -221,9 +257,15 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         then:
         buildResult.wasExecuted('createManifest')
         readArtifactsExtension() == [JsonArtifactLocator.from("oci", "registry.example.io/foo/bar:v1.3.0")]
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails if invalid'() {
+    def '#gradleVersionNumber: fails if invalid'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
         distribution {
             artifact {
@@ -238,10 +280,14 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         buildResult.failure.cause.cause.message.contains("uri is not valid")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def "write artifacts to manifest from task output"() {
+    def "#gradleVersionNumber: write artifacts to manifest from task output"() {
         given:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             
             import org.gradle.api.file.RegularFileProperty
@@ -284,6 +330,9 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         readArtifactsExtension() == [JsonArtifactLocator.from("oci", "registry.example.io/foo/bar:v1.3.0")]
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     private List<JsonArtifactLocator> readArtifactsExtension() {
@@ -291,11 +340,17 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         ObjectMappers.jsonMapper.convertValue(manifest.extensions().get("artifacts"), new TypeReference<List<JsonArtifactLocator>>() {})
     }
 
-    def "check depends on createManifest"() {
+    def "#gradleVersionNumber: check depends on createManifest"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         when:
         def result = runTasks(':check')
 
         then:
         result.wasExecuted(":createManifest")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
@@ -16,8 +16,7 @@
 
 package com.palantir.gradle.dist.tasks
 
-import com.palantir.gradle.dist.ObjectMappers
-import com.palantir.gradle.dist.pdeps.ResolveProductDependenciesIntegrationSpec
+import com.palantir.gradle.dist.GradleTestVersions
 import nebula.test.IntegrationSpec
 import spock.lang.Unroll
 
@@ -44,7 +43,9 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
     }
 
-    def 'fails if lockfile is not up to date'() {
+    def '#gradleVersionNumber: fails if lockfile is not up to date'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
         distribution {
             ${SCHEMA}
@@ -66,9 +67,15 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         then:
         buildResult.getStandardError().contains(
                 "schema-versions.lock is out of date, please run `./gradlew writeSchemaVersionLocks` to update it")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails if unexpected lockfile exists'() {
+    def '#gradleVersionNumber: fails if unexpected lockfile exists'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        
         runTasksSuccessfully('createManifest') // ensure task is run once
         def result = runTasksSuccessfully('createManifest')
         result.wasUpToDate(':createManifest')
@@ -78,9 +85,14 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
 
         then:
         runTasksWithFailure('createManifest')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails if lock file disappears'() {
+    def '#gradleVersionNumber: fails if lock file disappears'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
         distribution {
             ${SCHEMA}
@@ -104,9 +116,14 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
 
         then:
         runTasksWithFailure('createManifest')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def 'fails if lockfile has changed contents'() {
+    def '#gradleVersionNumber: fails if lockfile has changed contents'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
         distribution {
             ${SCHEMA}
@@ -130,10 +147,15 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
 
         then:
         runTasksWithFailure('createManifest')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
     @Unroll
-    def 'writes locks when #writeLocksTask is on the command line'() {
+    def '#gradleVersionNumber: writes locks when #writeLocksTask is on the command line'() {
+        setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
         distribution {
             ${SCHEMA}
@@ -155,14 +177,21 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
         writeLocksTask << ['--write-locks', 'writeSchemaVersionLocks', 'wSVL']
     }
 
-    def "check depends on createManifest"() {
+    def "#gradleVersionNumber: check depends on createManifest"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        
         when:
         def result = runTasks(':check')
 
         then:
         result.wasExecuted(":createManifest")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskSchemaVersionsIntegrationSpec.groovy
@@ -177,8 +177,10 @@ class CreateManifestTaskSchemaVersionsIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         where:
-        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
-        writeLocksTask << ['--write-locks', 'writeSchemaVersionLocks', 'wSVL']
+        [gradleVersionNumber, writeLocksTask] << [
+                GradleTestVersions.GRADLE_VERSIONS,
+                ['--write-locks', 'writeSchemaVersionLocks', 'wSVL']
+        ].combinations()
     }
 
     def "#gradleVersionNumber: check depends on createManifest"() {

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import java.util.List;
+
+public final class GradleTestVersions {
+    private GradleTestVersions() {}
+
+    public static final List<String> GRADLE_VERSIONS = List.of(SlsBaseDistPlugin.MINIMUM_GRADLE.getVersion(), "8.14.3");
+}


### PR DESCRIPTION
## Before this PR
It was only testing on the version of Gradle that the repo was running with.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

Test on all the supported versions we care about i.e. minimum supported Gradle version (7.6.4), and latest 8 (8.14.3) using spock's [data driven testing](https://spockframework.org/spock/docs/2.3/data_driven_testing.html) methods.

Claude seemed to do a pretty good job here, with a tiny bit of hand holding.

## Possible downsides?
* This is transient, as we will move to the new [plugin testing framework](https://github.com/palantir/gradle-plugin-testing/) that's purely Java. However, we can do this after the Gradle 9 pieces have merged. This is just breaking up #1868 and don't want to block on getting Gradle 9 support in. 
* Two sets of `GradleTestVersions` due to them not seeing each other. This'll probably go away with the idea @CRogers had to generate a list of versions and use that wherever we need to.

