### PR TITLE
[Gradle 9] Support Gradle 9 (take 2)

### DIFF
--- a/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
+++ b/gradle-recommended-product-dependencies/src/test/groovy/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationSpec.groovy
@@ -27,7 +27,7 @@ class RecommendedProductDependenciesPluginIntegrationSpec extends IntegrationSpe
         System.setProperty("ignoreDeprecations", "true")
         buildFile << """
         plugins {
-            id 'com.palantir.consistent-versions' version '2.25.0' apply false
+            id 'com.palantir.consistent-versions' version '3.3.0' apply false
         }
         apply plugin: 'java'
         apply plugin: 'com.palantir.recommended-product-dependencies'

--- a/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
+++ b/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
@@ -21,5 +21,5 @@ import java.util.List;
 public final class GradleTestVersions {
     private GradleTestVersions() {}
 
-    public static final List<String> GRADLE_VERSIONS = List.of("7.6.4", "8.14.3");
+    public static final List<String> GRADLE_VERSIONS = List.of("7.6.4", "8.14.3", "9.1.0");
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -21,6 +21,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.palantir.gradle.dist.artifacts.ArtifactLocator;
+import com.palantir.gradle.dist.pdeps.ProductDependencies;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import groovy.lang.Closure;
@@ -31,6 +32,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Project;
@@ -68,6 +70,7 @@ public class BaseDistributionExtension {
     private final RegularFileProperty configurationYml;
     private final String projectName;
     private Configuration productDependenciesConfig;
+    private final Property<String> consumableProductDependenciesConfigurationName;
 
     @Inject
     public BaseDistributionExtension(Project project) {
@@ -80,6 +83,7 @@ public class BaseDistributionExtension {
         optionalProductDependencies = project.getObjects().setProperty(ProductId.class);
         ignoredProductDependencies = project.getObjects().setProperty(ProductId.class);
         artifacts = project.getObjects().domainObjectSet(ArtifactLocator.class);
+        consumableProductDependenciesConfigurationName = project.getObjects().property(String.class);
 
         serviceGroup.set(project.provider(() -> project.getGroup().toString()));
         serviceName.set(project.provider(project::getName));
@@ -285,7 +289,47 @@ public class BaseDistributionExtension {
         return productDependenciesConfig;
     }
 
+    public final Provider<String> getConsumableProductDependenciesConfigName() {
+        return consumableProductDependenciesConfigurationName;
+    }
+
+    /**
+     * Passing in a non-consumable {@link Configuration} is deprecated as it won't be compatible with Gradle 9.
+     * It will be an error in version 4.0.0. We work around this by creating a consumable {@link Configuration} that
+     * extends the given {@code productDependenciesConfig} {@link Configuration}. This is somewhat surprising
+     * behaviour, and undesirable, but here to maintain backwards compatibility as we transition to Gradle 9.
+     *
+     * <p>
+     * You should be able to just extend {@link ProductDependencies#PRODUCT_DEPENDENCY_DISCOVERY_CONFIGURATION_NAME}
+     * with the configuration in question for example:
+     *
+     * <pre>
+     * configurations {
+     *   productDependencyDiscovery {
+     *     extendsFrom configurations.nonConsumableConfiguration
+     *   }
+     * }
+     * </pre>
+     *
+     * Ideally, a consumable configuration is used, and even still, this method is not required. An easier way would be
+     * to just add a dependency on the consumable configuration like so:
+     *
+     * <pre>
+     * dependencies {
+     *     productDependencyDiscovery project(name: project.path, conf: 'myConsumableConfiguration')
+     * }
+     * </pre>
+     */
     public final void setProductDependenciesConfig(Configuration productDependenciesConfig) {
+        String consumableConfigName =
+                productDependenciesConfig.getName() + "For" + StringUtils.capitalize("productDependencies");
+        project.getConfigurations().register(consumableConfigName, conf -> {
+            conf.extendsFrom(productDependenciesConfig);
+            conf.setCanBeConsumed(true);
+            conf.setCanBeResolved(false);
+            conf.setVisible(false);
+        });
+        consumableProductDependenciesConfigurationName.set(consumableConfigName);
         this.productDependenciesConfig = productDependenciesConfig;
     }
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/DependencyDiscovery.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist.artifacts;
 
+import com.palantir.gradle.dist.pdeps.ProductDependencies;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
@@ -40,6 +41,20 @@ public final class DependencyDiscovery {
         });
     }
 
+    /**
+     * This is not compatible with Gradle 9. This will be removed in version 4.0.0.
+     * <p>
+     * Whatever consumes this will not be able to resolve it as it both a resolution root and a consumable variant.
+     * This is an error in Gradle 9. To resolve this, you need to split the configuration into both a resolvable
+     * configuration and a consumable configuration. As a result, this largely depends on what consumes this method.
+     * <p>
+     * You should reevaluate whether "copying" a configuration is actually required. It may be advantageous to have a
+     * standard consumable configuration that consumers can extend with their own provided configurations. An example
+     * of this in {@link ProductDependencies#registerProductDependencyTasks}.
+     * @deprecated This is not compatible with Gradle 9.
+     * @see ProductDependencies#registerProductDependencyTasks
+     */
+    @Deprecated
     public static Configuration copyConfiguration(Project project, String configurationName, String name) {
         String consumableConfigName = configurationName + "For" + StringUtils.capitalize(name);
         Configuration consumable = project.getConfigurations().create(consumableConfigName, conf -> {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
@@ -24,17 +24,20 @@ import com.palantir.gradle.dist.artifacts.DependencyDiscovery;
 import com.palantir.gradle.dist.artifacts.ExtractSingleFileOrManifest;
 import com.palantir.gradle.dist.artifacts.PreferProjectCompatibilityRule;
 import com.palantir.gradle.dist.artifacts.SelectSingleFile;
+import java.util.Map;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.Directory;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 
 public final class ProductDependencies {
 
     private static final String PRODUCT_DEPENDENCIES = "product-dependencies";
+    public static final String PRODUCT_DEPENDENCY_DISCOVERY_CONFIGURATION_NAME = "productDependencyDiscovery";
 
     public static TaskProvider<ResolveProductDependenciesTask> registerProductDependencyTasks(
             Project project, BaseDistributionExtension ext) {
@@ -55,7 +58,29 @@ public final class ProductDependencies {
                     params.getPathToExtract().set(RecommendedProductDependenciesPlugin.RESOURCE_PATH);
                 });
 
-        Provider<ArtifactView> discoveredDependencies = getDiscoveredDependencies(project, ext);
+        NamedDomainObjectProvider<Configuration> productDependencyDependencyScope = project.getConfigurations()
+                .register(PRODUCT_DEPENDENCY_DISCOVERY_CONFIGURATION_NAME, conf -> {
+                    conf.setCanBeResolved(false);
+                    conf.setCanBeConsumed(false);
+                });
+        NamedDomainObjectProvider<Configuration> productDependencyClasspath = project.getConfigurations()
+                .register("productDependencyClasspath", conf -> {
+                    conf.setCanBeResolved(true);
+                    conf.setCanBeConsumed(false);
+                    conf.extendsFrom(productDependencyDependencyScope.get());
+                });
+
+        Provider<Dependency> consumableProjectDependency = ext.getConsumableProductDependenciesConfigName()
+                .map(configurationName -> {
+                    Map<String, String> projectDependency =
+                            Map.of("path", project.getPath(), "configuration", configurationName);
+                    return project.getDependencies().project(projectDependency);
+                });
+        project.getDependencies().addProvider(productDependencyDependencyScope.getName(), consumableProjectDependency);
+
+        Provider<ArtifactView> discoveredDependencies = productDependencyClasspath.map(
+                conf -> DependencyDiscovery.getFilteredArtifact(project, conf, PRODUCT_DEPENDENCIES));
+
         return project.getTasks().register("resolveProductDependencies", ResolveProductDependenciesTask.class, task -> {
             task.getServiceName().set(ext.getDistributionServiceName());
             task.getServiceGroup().set(ext.getDistributionServiceGroup());
@@ -73,23 +98,6 @@ public final class ProductDependencies {
 
             task.getManifestFile().set(pdepsDir.map(dir -> dir.file("pdeps-manifest.json")));
         });
-    }
-
-    private static Provider<ArtifactView> getDiscoveredDependencies(
-            Project project, BaseDistributionExtension distribution) {
-        // Use a property with `Property#finalizeValueOnRead` instead of a provider as the provider can get resolved
-        // multiple times during the Gradle execution (e.g. for up-to-date checks) which would result in the pdeps
-        // configuration getting copied multiple times.
-        Property<ArtifactView> discoveredDependencies = project.getObjects().property(ArtifactView.class);
-        discoveredDependencies.finalizeValueOnRead();
-
-        discoveredDependencies.set(project.provider(() -> {
-            Configuration pdepsConfig = DependencyDiscovery.copyConfiguration(
-                    project, distribution.getProductDependenciesConfig().getName(), "productDependencies");
-            return DependencyDiscovery.getFilteredArtifact(project, pdepsConfig, PRODUCT_DEPENDENCIES);
-        }));
-
-        return discoveredDependencies;
     }
 
     private ProductDependencies() {}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/DistTarTask.java
@@ -21,13 +21,14 @@ import java.util.Arrays;
 import java.util.concurrent.Callable;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Tar;
+import org.gradle.util.GradleVersion;
 
-@SuppressWarnings("deprecation") // for the setFileMode calls
 final class DistTarTask {
     static final String SCRIPTS_DIST_LOCATION = "service/bin";
 
@@ -54,7 +55,7 @@ final class DistTarTask {
 
             root.from("service/bin", t -> {
                 t.into("service/bin");
-                t.setFileMode(0755);
+                fileModeWorkaround(t, 0755);
             });
 
             // We do this trick of iterating through every java version and making a from with a lazy value to be lazy
@@ -89,17 +90,17 @@ final class DistTarTask {
 
             root.into(SCRIPTS_DIST_LOCATION, t -> {
                 t.from(project.getLayout().getBuildDirectory().dir("scripts"));
-                t.setFileMode(0755);
+                fileModeWorkaround(t, 0755);
             });
 
             root.into("service/monitoring/bin", t -> {
                 t.from(project.getLayout().getBuildDirectory().dir("monitoring"));
-                t.setFileMode(0755);
+                fileModeWorkaround(t, 0755);
             });
 
             root.into("service/lib/linux-x86-64", t -> {
                 t.from(project.getLayout().getBuildDirectory().dir("libs/linux-x86-64"));
-                t.setFileMode(0755);
+                fileModeWorkaround(t, 0755);
             });
 
             DeploymentDirInclusion.includeFromDeploymentDirs(
@@ -110,6 +111,15 @@ final class DistTarTask {
 
             root.with(distributionExtension.getExtraFiles());
         });
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void fileModeWorkaround(CopySpec copySpec, int newFileMode) {
+        if (GradleVersion.current().compareTo(GradleVersion.version("8.3")) < 0) {
+            copySpec.setFileMode(newFileMode);
+        } else {
+            copySpec.filePermissions(permissions -> permissions.unix(newFileMode));
+        }
     }
 
     private DistTarTask() {}

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/Versions.java
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/Versions.java
@@ -18,7 +18,7 @@ package com.palantir.gradle.dist;
 
 public final class Versions {
 
-    public static final String GRADLE_CONSISTENT_VERSIONS = "2.25.0";
+    public static final String GRADLE_CONSISTENT_VERSIONS = "3.3.0";
 
     private Versions() {}
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/pdeps/ResolveProductDependenciesIntegrationSpec.groovy
@@ -19,6 +19,7 @@ package com.palantir.gradle.dist.pdeps
 import com.palantir.gradle.dist.BaseDistributionExtension
 import com.palantir.gradle.dist.GradleTestVersions
 import com.palantir.gradle.dist.ObjectMappers
+import com.palantir.gradle.dist.ProductDependency
 
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
@@ -44,15 +45,15 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         import ${BaseDistributionExtension.class.getCanonicalName()}
         
         def ext = project.extensions.create("distribution", BaseDistributionExtension, project)
-        ext.setProductDependenciesConfig(configurations.runtimeClasspath)
         ProductDependencies.registerProductDependencyTasks(project, ext);
         """.stripIndent(true)
     }
 
-    def '#gradleVersionNumber: consumes declared product dependencies'() {
+    def '#gradleVersionNumber: consumes declared product dependencies (method: #method)'() {
         setup:
         gradleVersion = gradleVersionNumber
         buildFile << """
+            ${method.getBody()}
             distribution {
                 ${PDEP}
             }
@@ -67,10 +68,13 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         !manifest.productDependencies().isEmpty()
 
         where:
-        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+        [gradleVersionNumber, method] << [
+                GradleTestVersions.GRADLE_VERSIONS,
+                DependencyMethod.values()
+        ].combinations()
     }
 
-    def '#gradleVersionNumber: discovers project dependencies without compilation'() {
+    def '#gradleVersionNumber: discovers project dependencies without compilation (method: #method)'() {
         given:
         gradleVersion = gradleVersionNumber
         addSubproject('child', """
@@ -82,6 +86,7 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         }
         """.stripIndent(true))
         buildFile << """
+        ${method.getBody()}
         dependencies {
             implementation project('child')
         }
@@ -97,10 +102,13 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         !manifest.productDependencies().isEmpty()
 
         where:
-        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+        [gradleVersionNumber, method] << [
+                GradleTestVersions.GRADLE_VERSIONS,
+                DependencyMethod.values()
+        ].combinations()
     }
 
-    def '#gradleVersionNumber: discovers external dependencies'() {
+    def '#gradleVersionNumber: discovers external dependencies (method: #method)'() {
         given:
         gradleVersion = gradleVersionNumber
         GradleDependencyGenerator generator = new GradleDependencyGenerator(
@@ -118,6 +126,8 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
             maven {url "file:///${mavenRepo.getAbsolutePath()}"}
         }
         
+        ${method.getBody()}
+        
         dependencies {
             implementation 'a:a:1.0'
         }
@@ -132,10 +142,13 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         !manifest.productDependencies().isEmpty()
 
         where:
-        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+        [gradleVersionNumber, method] << [
+                GradleTestVersions.GRADLE_VERSIONS,
+                DependencyMethod.values()
+        ].combinations()
     }
 
-    def '#gradleVersionNumber: handles jars without manifest'() {
+    def '#gradleVersionNumber: handles jars without manifest (method: #method)'() {
         given:
         gradleVersion = gradleVersionNumber
         GradleDependencyGenerator generator = new GradleDependencyGenerator(
@@ -153,6 +166,8 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
             maven {url "file:///${mavenRepo.getAbsolutePath()}"}
         }
         
+        ${method.getBody()}
+        
         dependencies {
             implementation 'missingmanifest:missingmanifest:1.0'
         }
@@ -167,7 +182,82 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
         manifest.productDependencies().isEmpty()
 
         where:
-        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+        [gradleVersionNumber, method] << [
+                GradleTestVersions.GRADLE_VERSIONS,
+                DependencyMethod.values()
+        ].combinations()
+    }
+
+    def "#gradleVersionNumber: can exclude discovered product dependencies by module (method: #method)"() {
+        given:
+        gradleVersion = gradleVersionNumber
+        def groupPdep = new ProductDependency("group", "name", "1.0.0", "1.x.x", "1.2.0")
+        def group1Pdep = new ProductDependency("group1", "name1", "1.0.0", "1.3.x", "1.2.1")
+
+        GradleDependencyGenerator generator = new GradleDependencyGenerator(
+                new DependencyGraph("a:a:1.0"), new File(projectDir, "build/testrepogen").toString())
+        def mavenRepo = generator.generateTestMavenRepo()
+
+        // depends on group:name:[1.0.0, 1.x.x]:1.2.0
+        Files.copy(
+                ResolveProductDependenciesIntegrationSpec.class.getResourceAsStream("/a-1.0.jar"),
+                new File(mavenRepo, "a/a/1.0/a-1.0.jar").toPath(),
+                StandardCopyOption.REPLACE_EXISTING)
+
+        buildFile << """
+            repositories {
+                maven {url "file:///${mavenRepo.getAbsolutePath()}"}
+            }
+
+            ${method.getBody()}
+
+            dependencies {
+                implementation project('localApi')
+            }
+        """.stripIndent(true)
+
+        addSubproject("localApi", """
+            repositories {
+                maven {url "file:///${mavenRepo.getAbsolutePath()}"}
+            }
+            
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.recommended-product-dependencies'
+            
+            dependencies {
+                implementation 'a:a:1.0'
+            }
+            
+            recommendedProductDependencies {
+                ${PDEP}
+            }
+        """.stripIndent(true))
+
+        when: 'we try to resolve product dependencies *without* excludes'
+        runTasksSuccessfully(':resolveProductDependencies')
+
+        then: 'we get both product dependencies'
+        def manifest = ObjectMappers.readProductDependencyManifest(
+                file('build/resolved-pdeps/pdeps-manifest.json'))
+
+        manifest.productDependencies().toSet() == [groupPdep, group1Pdep] as Set
+        when: 'we exclude `a:a` and try to resolve product dependencies'
+        buildFile << """
+            configurations {
+                productDependencyDiscovery {
+                    exclude group: 'a', module: 'a'
+                }
+            } 
+        """.stripIndent(true)
+        runTasksSuccessfully(':resolveProductDependencies')
+
+        then: '`group:name` is no longer a product dependency (brought in from `a:a`)'
+        def manifestAfterExcludes = ObjectMappers.readProductDependencyManifest(
+                file('build/resolved-pdeps/pdeps-manifest.json'))
+        manifestAfterExcludes.productDependencies().toSet() == [group1Pdep] as Set
+
+        where:
+        [gradleVersionNumber, method] << [GradleTestVersions.GRADLE_VERSIONS, DependencyMethod.values()].combinations()
     }
 
     def '#gradleVersionNumber: resolveProductDependencies and processResources work together'() {
@@ -190,5 +280,33 @@ class ResolveProductDependenciesIntegrationSpec extends IntegrationSpec {
 
         where:
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+    }
+
+
+    private enum DependencyMethod {
+        EXTENSION_SETTER("extension setter", "ext.setProductDependenciesConfig(configurations.runtimeClasspath)"),
+        CONFIGURATION_EXTENDS_FROM("extends from", "configurations.productDependencyDiscovery.extendsFrom(configurations.runtimeClasspath)"),
+        CONSUMABLE_CONFIGURATION_DEPENDENCY("consumable configuration dependency", """
+            dependencies {
+              productDependencyDiscovery project(path: project.path, configuration: 'runtimeElements')
+            }
+        """.stripIndent(true))
+
+        private final String name
+        private final String body
+
+        DependencyMethod(String name, String body) {
+            this.name = name
+            this.body = body
+        }
+
+        String getBody() {
+            return body
+        }
+
+        @Override
+        String toString() {
+            return name
+        }
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -210,7 +210,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 excludeFromVar 'data'
             }
 
-            sourceCompatibility = '1.7'
+            java {
+                sourceCompatibility = '1.7'
+            }
         '''.stripIndent(true)
 
         createUntarTask(buildFile)
@@ -263,7 +265,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 mainClass 'test.Test'
             }
 
-            sourceCompatibility = '1.7'
+            java {
+                sourceCompatibility = '1.7'
+            }
         '''.stripIndent(true)
 
         createUntarTask(buildFile)
@@ -840,7 +844,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 .find({ it.name.endsWith("-manifest-classpath-0.0.1.jar") })
         classpathJar.exists()
 
-        def zipManifest = readFromZip(classpathJar, "META-INF/MANIFEST.MF").replace('\r\n ','')
+        def zipManifest = readFromZip(classpathJar, "META-INF/MANIFEST.MF").replace('\r\n ', '')
         zipManifest.contains('Class-Path: ')
         zipManifest.contains('guava-19.0.jar')
         zipManifest.contains('root-project-manifest-classpath-0.0.1.jar')
@@ -948,7 +952,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         buildResult.task(':parent:distTar').outcome == TaskOutcome.SUCCESS
-        new File(childProject,'build/exploded/my-service-0.0.1/deployment/manifest.yml').exists()
+        new File(childProject, 'build/exploded/my-service-0.0.1/deployment/manifest.yml').exists()
 
         where:
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
@@ -1000,7 +1004,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
 
         then:
         buildResult.task(':producer:distTar').outcome == TaskOutcome.SUCCESS
-        new File(consumer,'build/exploded/my-service-0.0.1/deployment/manifest.yml').exists()
+        new File(consumer, 'build/exploded/my-service-0.0.1/deployment/manifest.yml').exists()
 
         where:
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
@@ -1129,7 +1133,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         !libFiles.any { it.toString().equals('main') }
 
         // verify start scripts
-        List<String> startScript = new File(projectDir,'parent/dist/service-name-0.0.1/service/bin/service-name')
+        List<String> startScript = new File(projectDir, 'parent/dist/service-name-0.0.1/service/bin/service-name')
                 .text
                 .find(/CLASSPATH=(.*)/) { match, classpath -> classpath }
                 .split(':')
@@ -1285,7 +1289,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         !manifestContents.contains('main')
 
         // verify start scripts
-        List<String> startScript = new File(projectDir,'parent/dist/service-name-0.0.1/service/bin/service-name')
+        List<String> startScript = new File(projectDir, 'parent/dist/service-name-0.0.1/service/bin/service-name')
                 .text
                 .find(/CLASSPATH=(.*)/) { match, classpath -> classpath }
                 .split(':')
@@ -1532,7 +1536,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
         manifest.getMainAttributes().putValue('Add-Exports', 'jdk.compiler/com.sun.tools.javac.file')
-        File testJar = new File(getProjectDir(),"test.jar");
+        File testJar = new File(getProjectDir(), "test.jar");
         testJar.withOutputStream { fos ->
             new JarOutputStream(fos, manifest).close()
         }
@@ -1576,7 +1580,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
         manifest.getMainAttributes().putValue('Add-Opens', 'jdk.compiler/com.sun.tools.javac.file')
-        File testJar = new File(getProjectDir(),"test.jar");
+        File testJar = new File(getProjectDir(), "test.jar");
         testJar.withOutputStream { fos ->
             new JarOutputStream(fos, manifest).close()
         }
@@ -1620,7 +1624,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
         manifest.getMainAttributes().putValue('Add-Opens', 'jdk.compiler/com.sun.tools.javac.file')
-        File testJar = new File(getProjectDir(),"test.jar");
+        File testJar = new File(getProjectDir(), "test.jar");
         testJar.withOutputStream { fos ->
             new JarOutputStream(fos, manifest).close()
         }
@@ -1662,7 +1666,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
     def '#gradleVersionNumber: Handles jars with no manifest'() {
         setup:
         gradleVersion = gradleVersionNumber
-        File testJar = new File(getProjectDir(),"test.jar");
+        File testJar = new File(getProjectDir(), "test.jar");
         testJar.withOutputStream { fos ->
             new ZipOutputStream(fos).close()
         }
@@ -1819,7 +1823,9 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
                 ]
             }
 
-            sourceCompatibility = '1.7'
+            java {
+                sourceCompatibility = '1.7'
+            }
         '''.stripIndent(true)
 
         createUntarTask(buildFile)

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/GradleTestVersions.java
@@ -21,5 +21,6 @@ import java.util.List;
 public final class GradleTestVersions {
     private GradleTestVersions() {}
 
-    public static final List<String> GRADLE_VERSIONS = List.of(SlsBaseDistPlugin.MINIMUM_GRADLE.getVersion(), "8.14.3");
+    public static final List<String> GRADLE_VERSIONS =
+            List.of(SlsBaseDistPlugin.MINIMUM_GRADLE.getVersion(), "8.14.3", "9.1.0");
 }

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,8 @@ distribution {
 }
 ```
 
-sls-packaging also maintains a lockfile, `product-dependencies.lock`, which should be checked in to Git.  This file is an accurate reflection of all the inferred and explicitly defined product dependencies. Run **`./gradlew --write-locks`** or **`./gradlew writeProductDependenciesLocks`** to update it. e.g.
+#### Product dependencies lock file
+`sls-packaging` also maintains a lockfile, `product-dependencies.lock`, which should be checked in to Git.  This file is an accurate reflection of all the inferred and explicitly defined product dependencies. Run **`./gradlew --write-locks`** or **`./gradlew writeProductDependenciesLocks`** to update it. e.g.
 
 ```
 # Run ./gradlew writeProductDependenciesLocks to regenerate this file
@@ -96,6 +97,35 @@ It's possible to further restrict the acceptable version range for a dependency 
 If all the constraints on a given product don't overlap, then an error will the thrown:
 `Could not merge recommended product dependencies as their version ranges do not overlap`.
 
+#### Additional product dependency discovery sources
+
+If you wanted to discover another source of product dependencies without modifying your classpath e.g. depend on a project that's not an sls service, but will be run in a different environment that *still* requires minimum versions of certain products. You can do this by adding a dependency to the `productDependencyDiscovery` configuration like so:
+
+```gradle
+dependencies {
+  // requires the configuration being passed in to be a consumable configuration
+  productDependencyDiscovery project(path: ':non-sls-service', configuration: 'runtimeElements')
+}
+```
+
+> [!INFO]
+> This requires the configuration passed in to be a [consumable](https://docs.gradle.org/current/userguide/declaring_configurations.html#sec:configuration-flags-roles) configuration 
+
+You can also decide to extend the `productDependencyDiscovery` configuration with the configuration of your choice:
+
+```gradle
+configurations {
+  productDependencyDiscovery {
+    extendsFrom configurations.myConfiguration
+  }
+}
+```
+
+> [!INFO]
+> The configuration being extended from has to exist in the same project.
+
+#### Ignore product dependencies
+
 It's also possible to explicitly ignore a dependency or mark it as optional if it comes as a recommendation from a jar:
 
 ```gradle
@@ -109,6 +139,17 @@ distribution {
 ```
 Dependencies marked as optional will appear with the `optional` suffix in the lockfile.
 
+If you want to ignore all product dependencies that come from a particular jar dependency *transitively*, you can exclude the jar like you would any other dependency on the `productDependencyDiscovery` configuration. For example, to exclude `group:should-exclude`, you would something like this:
+
+```gradle
+configurations {
+  productDependencyDiscovery {
+    exclude group: 'group', module: 'should-exclude'
+  }
+}
+```
+
+Concretely, this means any product depenendencies coming from `group:should-exclude` and other dependencies in its dependency graph will not contribute any product dependencies.
 #### Accessing product dependencies
 
 You can programmatically access the minimum product dependency version as follows:


### PR DESCRIPTION
## Before this PR
Previously attempted to do this in #1868, but split it up into smaller PRs. This is the minimal change required to support Gradle 9. 

closes #1862 

Copying relevant PR description from #1868:

### Some tests were using the non-Gradle 9 compatible version of GCV
Once I started running tests with Gradle 9, ran into familiar errors, but that was just due to GCV being super old. [Bumping to 3.3.0](https://github.com/palantir/gradle-consistent-versions/releases/tag/3.3.0) fixed this.

### `CopySpec#fileMode` has been removed
This was [deprecated in Gradle 8.8](https://docs.gradle.org/current/userguide/upgrading_version_8.html#unix_file_permissions_deprecated) and [removed in Gradle 9](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#removal_of_unix_mode_based_file_permissions)

The replacement `(Configurable)FilePermissions` was introduced [in Gradle 8.3 and stable in 8.8](https://docs.gradle.org/9.1.0/javadoc/org/gradle/api/file/FilePermissions.html).

This involves having to fallback to the old thing for Gradle 7. 

Really need to start writing that workaround library 😅 

### [Tests] `sourceCompatibility` from deprecated `java` plugin convention removed

Tests were setting `sourceCompatibility = '1.7'`, but that no longer works as the `java` convention blocks were [deprecated in Gradle 8.2](https://docs.gradle.org/current/userguide/upgrading_version_8.html#java_convention_deprecation) for removal in Gradle 9.0

This was just a simple replace to:

```gradle
java {
  sourceCompatibility = '1.7'
}
```

### `resolveProductDependencies` task cannot resolve the specially crafted `Configuration`

Problem statement in #1862, but here's the error message:

```
Could not determine the dependencies of task ':service:resolveProductDependencies'.
> Could not resolve all dependencies for configuration ':service:runtimeClasspathForProductDependencies'.
   > Could not resolve project :service.
     Required by:
         project ':service'
      > A dependency was declared on configuration 'runtimeClasspathForProductDependencies' of 'project :service' but no variant with that configuration name exists.
```

This is happening because we are creating a `Configuration` well after the time to create configurations is allowed in Gradle 9 (this is good restriction).

We were previously creating a configuration that "copied" the `Configuration` you wanted to set as the `productDependenciesConfig` inside an input property to a task and trying to use `finalizeOnRead` to stop it from being created twice 😱 

I tried to use `afterEvaluate`, which continued to work for Gradle 7/8 tests, but it was still happening too late + interactions with GCV and I wasn't super keen on `afterEvaluate`.

I settled on creating the "copy" when `setProductDependencyConfig` is called. This creates the configuration at an acceptable time for Gradle 9.

Why do we even need to "copy" this configuration?

This is because there's been no restriction on the type of configuration passed into `setProductDependencyConfig` i.e. it could be any of resolvable, declarable or consumable. As a result, we've had to hack around it to satisfy Gradle. If we actually restrict passing in anything other than a `consumable` configuration, we can get rid of the copy and everything is fine again.

That said, it *still* wasn't enough! The "copy" was both resolvable **_and_** consumable. Whilst this is fine in Gradle 7 and 8, [this is disallowed in Gradle 9](https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration) as it both a resolution root and a variant!

So moving forward, the `ProductDependenciesPlugin` creates a *declarable* configuration `productDependencyDiscovery` akin to `api` and `implementation`. This is where consumers can add more dependencies that have product dependencies, or extend the configuration with another configuration.

Then for this plugin's own usage, a *resolvable* configuration that extends from `productDependencyDiscovery` and this is what is used within the `resolveProductDependencies`. 

So instead of making the "copy" of what's passed into `setProductDependencyConfig` be both resolvable and consumable, we can just drop it consumable, since we'll never resolve it directly, we'd only ever resolve the `productDependencyClasspath` configuration. The key piece is to add a direct project configuration dependency on this new *consumable* dependency. So all that's left is keeping track of the name of the new configuration, which we can store in a provider. No `afterEvaluate`, and simpler construction.

Ideally I'd like to get rid of `setProductDependencyConfig`, but there are a number of usages internally that make it hard to remove, and without this particular PR, there's no good way to do the right thing either. So this is the middle ground for the migration period. If we can't fully get rid of it, and we force the passed in configuration to be consumable, we don't need to do the "copy" and we can just depend on it directly!

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

