### PR TITLE
Enable compact object headers on JDK 25+

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -66,6 +66,8 @@ public final class LaunchConfig {
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
             ImmutableList.of("-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord");
+    // Enable compact object headers for JDK 25+, reducing memory overhead per object
+    private static final ImmutableList<String> compactObjectHeaders = ImmutableList.of("-XX:+UseCompactObjectHeaders");
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
@@ -195,6 +197,10 @@ public final class LaunchConfig {
                         .addAllJvmOpts(
                                 javaVersion.compareTo(JavaVersion.toVersion("15")) < 0
                                         ? disableBiasedLocking
+                                        : ImmutableList.of())
+                        .addAllJvmOpts(
+                                javaVersion.compareTo(JavaVersion.toVersion("25")) >= 0
+                                        ? compactObjectHeaders
                                         : ImmutableList.of())
                         .addAllJvmOpts(ModuleArgs.collectClasspathArgs(javaVersion, params.getFullClasspath()))
                         .addAllJvmOpts(params.getGcJvmOptions().get())

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -838,7 +838,7 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         then:
         def actualStaticConfig = OBJECT_MAPPER.readValue(
                 new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
-        !actualStaticConfig.jvmOpts().contains("-XX:+UseCompactObjectHeaders")
+        actualStaticConfig.jvmOpts().stream().noneMatch { it.contains("UseCompactObjectHeaders") }
 
         where:
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.groovy
@@ -796,6 +796,54 @@ class JavaServiceDistributionPluginTests extends GradleIntegrationSpec {
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
+    def '#gradleVersionNumber: jdk-25 enables compact object headers'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        createUntarBuildFile(buildFile)
+        buildFile << """
+            dependencies { implementation files("${EXTERNAL_JAR}") }
+            tasks.jar.archiveBaseName = "internal"
+            distribution {
+                javaVersion 25
+            }""".stripIndent(true)
+        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+
+        when:
+        runTasks(':build', ':distTar', ':untar')
+
+        then:
+        def actualStaticConfig = OBJECT_MAPPER.readValue(
+                new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
+        actualStaticConfig.jvmOpts().contains("-XX:+UseCompactObjectHeaders")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+    }
+
+    def '#gradleVersionNumber: jdk-24 does not enable compact object headers'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        createUntarBuildFile(buildFile)
+        buildFile << """
+            dependencies { implementation files("${EXTERNAL_JAR}") }
+            tasks.jar.archiveBaseName = "internal"
+            distribution {
+                javaVersion 24
+            }""".stripIndent(true)
+        file('src/main/java/test/Test.java') << "package test;\npublic class Test {}"
+
+        when:
+        runTasks(':build', ':distTar', ':untar')
+
+        then:
+        def actualStaticConfig = OBJECT_MAPPER.readValue(
+                new File(projectDir, 'dist/service-name-0.0.1/service/bin/launcher-static.yml'), LaunchConfig.LaunchConfigInfo)
+        !actualStaticConfig.jvmOpts().contains("-XX:+UseCompactObjectHeaders")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+    }
+
     def '#gradleVersionNumber: produce distribution bundle that populates check.sh'() {
         given:
         gradleVersion = gradleVersionNumber


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Enable compact object headers on JDK 25+

In [JEP 519](https://openjdk.org/jeps/519), compact object headers were graduated from experimental. 

Technically compact object headers could be enabled in JDK 24, but given we don't use that JDK widely and it would require enabling experimental options, let's just enable the JVM flag for JDK 25+. 

A [future JEP](https://openjdk.org/jeps/8361187) plans to make compact object headers by default. At that point we can update sls-packaging to not add the flag for that JDK and up. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable compact object headers on JDK 25+
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

