### PR TITLE
Fix Gradle 9 issue by using equals() instead of identity comparison in `getInRepoProductIds`

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -129,9 +129,6 @@ public abstract class ProductDependencyIntrospectionPlugin implements Plugin<Pro
     }
 
     public static Map<ProductId, Project> getInRepoProductIds(Project rootProject) {
-        // Use path comparison instead of identity check (==) for Gradle 9 compatibility.
-        // During dependency resolution, Gradle may wrap/decorate project instances,
-        // causing identity comparison to fail even for the actual root project.
         Preconditions.checkArgument(
                 rootProject.getPath().equals(rootProject.getRootProject().getPath()),
                 "Must call this method with the root project",

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -129,8 +129,11 @@ public abstract class ProductDependencyIntrospectionPlugin implements Plugin<Pro
     }
 
     public static Map<ProductId, Project> getInRepoProductIds(Project rootProject) {
+        // Use path comparison instead of identity check (==) for Gradle 9 compatibility.
+        // During dependency resolution, Gradle may wrap/decorate project instances,
+        // causing identity comparison to fail even for the actual root project.
         Preconditions.checkArgument(
-                rootProject == rootProject.getRootProject(),
+                rootProject.getPath().equals(rootProject.getRootProject().getPath()),
                 "Must call this method with the root project",
                 SafeArg.of("project", rootProject.getPath()));
         // get products we publish via BaseDistributionExtension from all other projects

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyIntrospectionPlugin.java
@@ -130,7 +130,7 @@ public abstract class ProductDependencyIntrospectionPlugin implements Plugin<Pro
 
     public static Map<ProductId, Project> getInRepoProductIds(Project rootProject) {
         Preconditions.checkArgument(
-                rootProject.getPath().equals(rootProject.getRootProject().getPath()),
+                rootProject.equals(rootProject.getRootProject()),
                 "Must call this method with the root project",
                 SafeArg.of("project", rootProject.getPath()));
         // get products we publish via BaseDistributionExtension from all other projects


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

When using gradle-sls-packaging with Gradle 9, builds fail with:

`Must call this method with the root project: {project=:}`

The issue is that `getInRepoProductIds` uses identity comparison (`==`) to verify the passed project is the root project. In Gradle 9, during dependency resolution, project instances may be wrapped or decorated, causing `rootProject == rootProject.getRootProject()` to return false even when the project truly is the root project.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use `.equals()` instead of identity check (`==`) for root project validation in `getInRepoProductIds`. This ensures the check works correctly in Gradle 9 where project instances may be decorated during resolution.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->