### PR TITLE
Fix 'depenendencies' typo in readme

### DIFF
--- a/changelog/@unreleased/pr-2035.v2.yml
+++ b/changelog/@unreleased/pr-2035.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix 'depenendencies' typo in readme
+  links:
+  - https://github.com/palantir/sls-packaging/pull/2035

--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ configurations {
 }
 ```
 
-Concretely, this means any product depenendencies coming from `group:should-exclude` and other dependencies in its dependency graph will not contribute any product dependencies.
+Concretely, this means any product dependencies coming from `group:should-exclude` and other dependencies in its dependency graph will not contribute any product dependencies.
 #### Accessing product dependencies
 
 You can programmatically access the minimum product dependency version as follows:


### PR DESCRIPTION
Fixes a double-letter typo on line 152: "depenendencies" → "dependencies".