### PR TITLE
Disable compact object headers for JDK 25+

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/tasks/LaunchConfig.java
@@ -66,8 +66,7 @@ public final class LaunchConfig {
     // Disable C2 compilation for problematic structure in JDK 11.0.16, see https://bugs.openjdk.org/browse/JDK-8291665
     private static final ImmutableList<String> jdk11DisableC2Compile =
             ImmutableList.of("-XX:CompileCommand=exclude,sun/security/ssl/SSLEngineInputRecord.decodeInputRecord");
-    // Enable compact object headers for JDK 25+, reducing memory overhead per object
-    private static final ImmutableList<String> compactObjectHeaders = ImmutableList.of("-XX:+UseCompactObjectHeaders");
+    // Compact object headers (JEP 519) disabled pending resolution of https://bugs.openjdk.org/browse/JDK-8380060
 
     private static final ImmutableList<String> alwaysOnJvmOptions = ImmutableList.of(
             "-XX:+CrashOnOutOfMemoryError",
@@ -197,10 +196,6 @@ public final class LaunchConfig {
                         .addAllJvmOpts(
                                 javaVersion.compareTo(JavaVersion.toVersion("15")) < 0
                                         ? disableBiasedLocking
-                                        : ImmutableList.of())
-                        .addAllJvmOpts(
-                                javaVersion.compareTo(JavaVersion.toVersion("25")) >= 0
-                                        ? compactObjectHeaders
                                         : ImmutableList.of())
                         .addAllJvmOpts(ModuleArgs.collectClasspathArgs(javaVersion, params.getFullClasspath()))
                         .addAllJvmOpts(params.getGcJvmOptions().get())

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
@@ -826,8 +826,9 @@ class JavaServiceDistributionPluginTests {
                 .isTrue();
     }
 
+    // Compact object headers (JEP 519) disabled pending resolution of https://bugs.openjdk.org/browse/JDK-8380060
     @Test
-    void jdk_25_enables_compact_object_headers(GradleInvoker gradle, RootProject rootProject) throws Exception {
+    void jdk_25_does_not_enable_compact_object_headers(GradleInvoker gradle, RootProject rootProject) throws Exception {
         createUntarBuildFile(rootProject);
         rootProject.buildGradle().append("""
             dependencies { implementation files("%s") }
@@ -849,7 +850,7 @@ class JavaServiceDistributionPluginTests {
                         .path()
                         .toFile(),
                 LaunchConfig.LaunchConfigInfo.class);
-        assertThat(actualStaticConfig.jvmOpts().contains("-XX:+UseCompactObjectHeaders"))
+        assertThat(actualStaticConfig.jvmOpts().stream().noneMatch(opt -> opt.contains("UseCompactObjectHeaders")))
                 .isTrue();
     }
 


### PR DESCRIPTION
## Before this PR

Reverts #1912 pending resolution of https://bugs.openjdk.org/browse/JDK-8380060. A C2 JIT bug can corrupt byte arrays when compact headers are enabled.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

