### PR TITLE
Add product-id to product-dependencies.lock

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 public final class ProductDependencyLockFile {
 
     private static final String HEADER = "# Run ./gradlew writeProductDependenciesLocks to regenerate this file\n";
+    public static final String PRODUCT_ID_PREFIX = "product-id: ";
     public static final String PROJECT_VERSION = "$projectVersion";
     private static final Pattern LOCK_PATTERN = Pattern.compile(
             "^(?<group>[^:]+):(?<name>[^ ]+) \\((?<min>[^,]+), (?<max>[^\\)]+)\\)(?<optional> optional)?$");
@@ -52,7 +53,8 @@ public final class ProductDependencyLockFile {
                 .collect(toList());
     }
 
-    public static String asString(List<ProductDependency> deps, Set<ProductId> servicesDeclaredInProject) {
+    public static String asString(
+            ProductId productId, List<ProductDependency> deps, Set<ProductId> servicesDeclaredInProject) {
         return deps.stream()
                 .map(dep -> String.format(
                         "%s:%s (%s, %s)%s",
@@ -62,7 +64,7 @@ public final class ProductDependencyLockFile {
                         dep.getMaximumVersion(),
                         dep.getOptional() ? " optional" : ""))
                 .sorted()
-                .collect(Collectors.joining("\n", HEADER, "\n"));
+                .collect(Collectors.joining("\n", HEADER + PRODUCT_ID_PREFIX + productId + "\n", "\n"));
     }
 
     /**

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -230,7 +230,8 @@ public abstract class CreateManifestTask extends DefaultTask {
 
     private void ensurePdepsLockfileIsUpToDate(List<ProductDependency> productDeps) throws IOException {
         File lockfile = getProductDependenciesLockfile();
-        ProductId productId = new ProductId(getServiceGroup().get(), getServiceName().get());
+        ProductId productId =
+                new ProductId(getServiceGroup().get(), getServiceName().get());
         String upToDateContents = ProductDependencyLockFile.asString(
                 productId, productDeps, getInRepoProductIds().get());
         ensureFileIsUpToDate(WriteProductDependenciesLocksMarkerTask.NAME, lockfile, upToDateContents);

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -230,8 +230,9 @@ public abstract class CreateManifestTask extends DefaultTask {
 
     private void ensurePdepsLockfileIsUpToDate(List<ProductDependency> productDeps) throws IOException {
         File lockfile = getProductDependenciesLockfile();
+        ProductId productId = new ProductId(getServiceGroup().get(), getServiceName().get());
         String upToDateContents = ProductDependencyLockFile.asString(
-                productDeps, getInRepoProductIds().get());
+                productId, productDeps, getInRepoProductIds().get());
         ensureFileIsUpToDate(WriteProductDependenciesLocksMarkerTask.NAME, lockfile, upToDateContents);
     }
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginIntegrationSpec.groovy
@@ -29,6 +29,7 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
 
         file("product-dependencies.lock").text = '''\
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+            product-id: com.palantir.test:my-service
             com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent(true)
         def mavenRepo = generateMavenRepo('com.palantir.product:test:1.0.0')
@@ -61,11 +62,13 @@ class ProductDependencyIntrospectionPluginIntegrationSpec extends IntegrationSpe
         gradleVersion = gradleVersionNumber
         file("a/product-dependencies.lock").text = '''\
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+            product-id: com.palantir.test:service-a
             com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent(true)
 
         file("b/product-dependencies.lock").text = '''\
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+            product-id: com.palantir.test:service-b
             com.palantir.product:test (1.2.0, 1.6.x)
         '''.stripIndent(true)
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyIntrospectionPluginTest.groovy
@@ -28,6 +28,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
     def "get version from lock file"() {
         project.file("product-dependencies.lock").text = '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.palantir.test:my-service
         com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent(true)
 
@@ -42,6 +43,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
         project.version = "1.1.0"
         project.file("product-dependencies.lock").text = '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.palantir.test:my-service
         com.palantir.product:test ($projectVersion, 1.x.x)
         '''.stripIndent(true)
 
@@ -64,6 +66,7 @@ class ProductDependencyIntrospectionPluginTest extends ProjectSpec {
     def "fails if dependency does not exist in lock file"() {
         project.file("product-dependencies.lock").text = '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.palantir.test:my-service
         com.palantir.product:test (1.0.0, 1.x.x)
         '''.stripIndent(true)
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -29,8 +29,9 @@ class ProductDependencyLockFileTest extends Specification {
         ]
 
         then:
-        ProductDependencyLockFile.asString(sample, [] as Set<ProductId>) == """\
+        ProductDependencyLockFile.asString(new ProductId("com.palantir.test", "my-service"), sample, [] as Set<ProductId>) == """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.palantir.test:my-service
         com.palantir.other:bar (0.2.0, 0.x.x) optional
         com.palantir.product:foo (1.20.0, 1.x.x)
         """.stripIndent(true)
@@ -39,12 +40,14 @@ class ProductDependencyLockFileTest extends Specification {
     def 'serialize project version'() {
         when:
         def result = ProductDependencyLockFile.asString(
+                new ProductId("com.palantir.test", "my-service"),
                 [new ProductDependency("com.palantir.product", "foo", "1.0.0", "1.x.x", null),],
                 [new ProductId("com.palantir.product", "foo")] as Set<ProductId>
         )
         then:
         result == '''\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.palantir.test:my-service
         com.palantir.product:foo ($projectVersion, 1.x.x)
         '''.stripIndent(true)
     }
@@ -53,6 +56,7 @@ class ProductDependencyLockFileTest extends Specification {
         when:
         List<ProductDependency> result = ProductDependencyLockFile.fromString("""\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.palantir.test:my-service
         com.palantir.other:bar (0.2.0, 0.x.x)
         com.palantir.product:foo (1.20.0, 1.x.x) optional
         """.stripIndent(true), "0.0.0")
@@ -71,6 +75,6 @@ class ProductDependencyLockFileTest extends Specification {
         ]
 
         then:
-        input == ProductDependencyLockFile.fromString(ProductDependencyLockFile.asString(input, [] as Set<ProductId>), "0.0.0")
+        input == ProductDependencyLockFile.fromString(ProductDependencyLockFile.asString(new ProductId("com.palantir.test", "my-service"), input, [] as Set<ProductId>), "0.0.0")
     }
 }

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/asset/AssetDistributionPluginIntegrationSpec.groovy
@@ -130,6 +130,7 @@ class AssetDistributionPluginIntegrationSpec extends GradleIntegrationSpec {
         """.stripIndent(true)
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: service-group:asset-name
         group1:name1 (1.0.0, 2.0.0)
         group2:name2 (1.0.0, 2.x.x)
         """.stripIndent(true)

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -53,6 +53,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: serviceGroup:serviceName
         group:name2 (2.0.0, 2.x.x)
         """.stripIndent(true)
 
@@ -97,6 +98,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: serviceGroup:serviceName
         group1:name1 (1.0.0, 1.3.x)
         """.stripIndent(true)
 
@@ -125,6 +127,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         file('product-dependencies.lock').text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: serviceGroup:serviceName
         group1:name1 (1.0.0, 1.3.x)
         """.stripIndent(true)
 
@@ -189,6 +192,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
 
         file('product-dependencies.lock', barDir).text = """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.palantir.group:bar-service
         com.palantir.group:foo-service (\$projectVersion, 1.x.x)
         """.stripIndent(true)
 
@@ -230,6 +234,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         buildResult.wasExecuted(':createManifest')
         file('product-dependencies.lock').text == """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: serviceGroup:serviceName
         group1:name1 (1.0.0, 1.3.x)
         """.stripIndent(true)
 

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
@@ -345,6 +345,7 @@ class JavaServiceDistributionPluginTests {
             """);
         rootProject.file("product-dependencies.lock").overwrite("""
             # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+            product-id: service-group:service-name
             group1:name1 (1.0.0, 1.3.x)
             group2:name2 (1.0.0, 1.x.x)
             """);


### PR DESCRIPTION
## Description

Adds a `product-id: <groupId>:<artifactId>` line as the first line of the lock file:
```
product-id: com.palantir.group:service
com.palantir.foundry:foundry-api (1.234.0, 2.x.x)
```

Today, every bot that processes lock files independently resolves the owning product by parsing `build.gradle` (Java) or reading a sidecar `product.lock` (Go). This is fragile, duplicated, and costs extra GitHub API calls.

With the product ID in the lock file itself, bots can read it directly from the file they've already fetched. Existing parsers are unaffected as they match `group:name (min, max)` and will skip the `product-id:` line.

==COMMIT_MSG==
Add product-id to product-dependencies.lock
==COMMIT_MSG==

## Possible downsides?

Clients may fail to parse product-dependencies.lock. We've checked internal bots that they would be able to silently ignore the new line.