### PR TITLE
Add `minimumVersionFrom` to lock product-dependency minimum versions via GCV

### DIFF
--- a/gradle-recommended-product-dependencies/build.gradle
+++ b/gradle-recommended-product-dependencies/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     api 'com.palantir.sls.versions:sls-versions'
     api 'com.palantir.safe-logging:preconditions'
 
+    compileOnly 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
+
     testImplementation gradleTestKit()
     testImplementation 'com.netflix.nebula:nebula-test'
 

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ConfigureProductDependenciesTask.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ConfigureProductDependenciesTask.java
@@ -62,7 +62,7 @@ public abstract class ConfigureProductDependenciesTask extends DefaultTask {
                 });
     }
 
-    public final void setProductDependencies(Provider<Set<ProductDependency>> productDependencies) {
+    public final void setProductDependencies(Provider<? extends Iterable<ProductDependency>> productDependencies) {
         getProductDependencies().set(productDependencies);
     }
 

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/MinimumVersionFromResolver.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/MinimumVersionFromResolver.java
@@ -99,8 +99,7 @@ public final class MinimumVersionFromResolver {
         return productDependencies.zip(
                 versionsByCoordinate,
                 (declared, versionsForCoordinate) -> declared.stream()
-                        .map(productDependency ->
-                                withResolvedMinimumVersion(productDependency, versionsForCoordinate))
+                        .map(productDependency -> withResolvedMinimumVersion(productDependency, versionsForCoordinate))
                         .toList());
     }
 

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/MinimumVersionFromResolver.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/MinimumVersionFromResolver.java
@@ -32,26 +32,10 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.provider.Provider;
 
-/**
- * Resolves {@link ProductDependency#getMinimumVersionFrom()} coordinates via a per-project resolvable configuration.
- *
- * <p>Calling {@code com.palantir.gradle.versions}'s {@code getVersion(...)} inside a {@code productDependency} closure
- * is unsafe under Gradle 9: the closure runs at task-action time on a subproject, and {@code getVersion} resolves the
- * <em>root</em> project's {@code :unifiedClasspath} configuration without holding its exclusive lock. The
- * {@code minimumVersionFrom = 'group:name'} declaration lets the plugin do the lookup against a configuration owned
- * by the <em>same</em> project — so the lock requirement is met — and, when gradle-consistent-versions is applied,
- * GCV's lockfile-driven constraints supply the resolved version.
- */
 public final class MinimumVersionFromResolver {
 
     private MinimumVersionFromResolver() {}
 
-    /**
-     * Registers a resolvable configuration named {@code configurationName} on {@code project}, populated with one
-     * dependency per distinct {@link ProductDependency#getMinimumVersionFrom()} value found in {@code productDependencies}.
-     * If gradle-consistent-versions is applied (to the root project), the configuration is added to the project's
-     * {@link VersionsLockExtension} so lockfile-driven constraints apply.
-     */
     public static NamedDomainObjectProvider<Configuration> registerVersionLookupConfiguration(
             Project project,
             String configurationName,
@@ -80,11 +64,6 @@ public final class MinimumVersionFromResolver {
         return versionLookup;
     }
 
-    /**
-     * Returns a Provider that, when queried, yields {@code productDependencies} with any
-     * {@link ProductDependency#getMinimumVersionFrom()} coordinate replaced by the version resolved from
-     * {@code versionLookup}. Dependencies without {@code minimumVersionFrom} are returned unchanged.
-     */
     public static Provider<List<ProductDependency>> resolveMinimumVersions(
             Provider<? extends Collection<ProductDependency>> productDependencies,
             NamedDomainObjectProvider<Configuration> versionLookup) {

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/MinimumVersionFromResolver.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/MinimumVersionFromResolver.java
@@ -1,0 +1,127 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist;
+
+import com.palantir.gradle.versions.VersionsLockExtension;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.gradle.api.GradleException;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.provider.Provider;
+
+/**
+ * Resolves {@link ProductDependency#getMinimumVersionFrom()} coordinates via a per-project resolvable configuration.
+ *
+ * <p>Calling {@code com.palantir.gradle.versions}'s {@code getVersion(...)} inside a {@code productDependency} closure
+ * is unsafe under Gradle 9: the closure runs at task-action time on a subproject, and {@code getVersion} resolves the
+ * <em>root</em> project's {@code :unifiedClasspath} configuration without holding its exclusive lock. The
+ * {@code minimumVersionFrom = 'group:name'} declaration lets the plugin do the lookup against a configuration owned
+ * by the <em>same</em> project — so the lock requirement is met — and, when gradle-consistent-versions is applied,
+ * GCV's lockfile-driven constraints supply the resolved version.
+ */
+public final class MinimumVersionFromResolver {
+
+    private MinimumVersionFromResolver() {}
+
+    /**
+     * Registers a resolvable configuration named {@code configurationName} on {@code project}, populated with one
+     * dependency per distinct {@link ProductDependency#getMinimumVersionFrom()} value found in {@code productDependencies}.
+     * If gradle-consistent-versions is applied (to the root project), the configuration is added to the project's
+     * {@link VersionsLockExtension} so lockfile-driven constraints apply.
+     */
+    public static NamedDomainObjectProvider<Configuration> registerVersionLookupConfiguration(
+            Project project,
+            String configurationName,
+            Provider<? extends Collection<ProductDependency>> productDependencies) {
+        Provider<List<Dependency>> versionLookupDeps = productDependencies.map(declared -> declared.stream()
+                .flatMap(productDependency -> productDependency.getMinimumVersionFrom().stream())
+                .distinct()
+                .map(coordinate -> project.getDependencies().create(coordinate))
+                .collect(Collectors.toList()));
+
+        NamedDomainObjectProvider<Configuration> versionLookup = project.getConfigurations()
+                .register(configurationName, configuration -> {
+                    configuration.setCanBeResolved(true);
+                    configuration.setCanBeConsumed(false);
+                    configuration.setVisible(false);
+                    configuration.setDescription(
+                            "Resolves versions referenced by productDependency { minimumVersionFrom ... }.");
+                    configuration.getDependencies().addAllLater(versionLookupDeps);
+                });
+
+        project.getRootProject().getPluginManager().withPlugin("com.palantir.consistent-versions", _appliedPlugin -> {
+            VersionsLockExtension versionsLock = project.getExtensions().getByType(VersionsLockExtension.class);
+            versionsLock.production(scopeConfigurer -> scopeConfigurer.from(configurationName));
+        });
+
+        return versionLookup;
+    }
+
+    /**
+     * Returns a Provider that, when queried, yields {@code productDependencies} with any
+     * {@link ProductDependency#getMinimumVersionFrom()} coordinate replaced by the version resolved from
+     * {@code versionLookup}. Dependencies without {@code minimumVersionFrom} are returned unchanged.
+     */
+    public static Provider<List<ProductDependency>> resolveMinimumVersions(
+            Provider<? extends Collection<ProductDependency>> productDependencies,
+            NamedDomainObjectProvider<Configuration> versionLookup) {
+        Provider<Map<String, String>> versionsByCoordinate = versionLookup.map(configuration ->
+                configuration.getIncoming().getResolutionResult().getAllComponents().stream()
+                        .map(ResolvedComponentResult::getModuleVersion)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toMap(
+                                moduleVersion -> moduleVersion.getGroup() + ":" + moduleVersion.getName(),
+                                ModuleVersionIdentifier::getVersion)));
+
+        return productDependencies.zip(
+                versionsByCoordinate,
+                (declared, versionsForCoordinate) -> declared.stream()
+                        .map(productDependency ->
+                                withResolvedMinimumVersion(productDependency, versionsForCoordinate))
+                        .toList());
+    }
+
+    private static ProductDependency withResolvedMinimumVersion(
+            ProductDependency original, Map<String, String> versionsByCoordinate) {
+        Optional<String> coordinate = original.getMinimumVersionFrom();
+        if (coordinate.isEmpty()) {
+            return original;
+        }
+        String resolvedVersion = Optional.ofNullable(versionsByCoordinate.get(coordinate.get()))
+                .orElseThrow(() -> new GradleException(String.format(
+                        "Unable to resolve minimumVersionFrom '%s' for product dependency %s:%s",
+                        coordinate.get(), original.getProductGroup(), original.getProductName())));
+        return new ProductDependency(
+                original.getProductGroup(),
+                original.getProductName(),
+                resolvedVersion,
+                original.getMaximumVersion() != null
+                        ? original.getMaximumVersion()
+                        : ProductDependency.generateMaxVersion(resolvedVersion),
+                original.getRecommendedVersion(),
+                original.getOptional());
+    }
+}

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.dist;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.palantir.logsafe.Preconditions;
@@ -49,6 +50,15 @@ public final class ProductDependency implements Serializable {
 
     @JsonProperty("optional")
     private boolean optional = false;
+
+    /**
+     * Module coordinate ({@code group:name}) whose resolved version should be used as {@link #minimumVersion}. The
+     * resolution is performed by the plugin (against gradle-consistent-versions' locked classpath when present),
+     * not the consumer; the resolved version is filled in before the manifest is written, so this field itself is
+     * not serialised.
+     */
+    @JsonIgnore
+    private String minimumVersionFrom;
 
     public ProductDependency() {}
 
@@ -84,6 +94,22 @@ public final class ProductDependency implements Serializable {
     public void isValid() {
         Preconditions.checkNotNull(productGroup, "productGroup must be specified");
         Preconditions.checkNotNull(productName, "productName must be specified");
+        if (minimumVersionFrom != null) {
+            Preconditions.checkArgument(
+                    minimumVersion == null,
+                    "Cannot specify both minimumVersion and minimumVersionFrom",
+                    SafeArg.of("productGroup", productGroup),
+                    SafeArg.of("productName", productName));
+            String[] parts = minimumVersionFrom.split(":", -1);
+            Preconditions.checkArgument(
+                    parts.length == 2 && !parts[0].isEmpty() && !parts[1].isEmpty(),
+                    "minimumVersionFrom must be in the format 'group:name'",
+                    SafeArg.of("minimumVersionFrom", minimumVersionFrom),
+                    SafeArg.of("productGroup", productGroup),
+                    SafeArg.of("productName", productName));
+            // Remaining validation runs after the minimum version is resolved.
+            return;
+        }
         Optional<OrderableSlsVersion> minimum = parseMinimum();
         Optional<OrderableSlsVersion> recommended = parseRecommended();
         SlsVersionMatcher maximum = parseMaximum();
@@ -227,6 +253,14 @@ public final class ProductDependency implements Serializable {
 
     public void setOptional(boolean optional) {
         this.optional = optional;
+    }
+
+    public Optional<String> getMinimumVersionFrom() {
+        return Optional.ofNullable(minimumVersionFrom);
+    }
+
+    public void setMinimumVersionFrom(String minimumVersionFrom) {
+        this.minimumVersionFrom = minimumVersionFrom;
     }
 
     @Override

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ProductDependency.java
@@ -263,6 +263,13 @@ public final class ProductDependency implements Serializable {
         this.minimumVersionFrom = minimumVersionFrom;
     }
 
+    /** Generates a maximum version (e.g. {@code "1.x.x"}) from a minimum version (e.g. {@code "1.2.3"}). */
+    public static String generateMaxVersion(String minimumVersion) {
+        int firstDot = minimumVersion.indexOf('.');
+        String major = firstDot < 0 ? minimumVersion : minimumVersion.substring(0, firstDot);
+        return major + ".x.x";
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) {

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.dist;
 
-import java.util.HashSet;
 import java.util.List;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -59,7 +58,7 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
     private void configureManifest(Project project, Provider<List<ProductDependency>> resolvedDependencies) {
         TaskProvider<ConfigureProductDependenciesTask> configureProductDependenciesTask = project.getTasks()
                 .register("configureProductDependencies", ConfigureProductDependenciesTask.class, cmt -> {
-                    cmt.setProductDependencies(resolvedDependencies.map(HashSet::new));
+                    cmt.setProductDependencies(resolvedDependencies);
                 });
 
         // Ensure that the jar task depends on this wiring task
@@ -72,7 +71,7 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
         TaskProvider<CompileRecommendedProductDependencies> compilePdeps = project.getTasks()
                 .register(
                         "compileRecommendedProductDependencies", CompileRecommendedProductDependencies.class, task -> {
-                            task.getRecommendedProductDependencies().set(resolvedDependencies.map(HashSet::new));
+                            task.getRecommendedProductDependencies().set(resolvedDependencies);
                             task.getOutputDir()
                                     .set(project.getLayout().getBuildDirectory().dir("product-dependencies"));
                         });

--- a/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
+++ b/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/RecommendedProductDependenciesPlugin.java
@@ -16,9 +16,14 @@
 
 package com.palantir.gradle.dist;
 
+import java.util.HashSet;
+import java.util.List;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
@@ -28,6 +33,9 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
     public static final String RESOURCE_PATH =
             RecommendedProductDependencies.SLS_RECOMMENDED_PRODUCT_DEPS_KEY + "/product-dependencies.json";
 
+    public static final String RECOMMENDED_PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME =
+            "recommendedProductDependencyVersionLookup";
+
     @Override
     public final void apply(Project project) {
         @SuppressWarnings({"for-rollout:GradleTypesAsFields", "for-rollout:NonAbstractGradleType"})
@@ -35,16 +43,23 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
                 .create("recommendedProductDependencies", RecommendedProductDependenciesExtension.class, project);
 
         project.getPluginManager().withPlugin("java", _plugin -> {
-            embedResource(project, ext);
-            configureManifest(project, ext);
+            NamedDomainObjectProvider<Configuration> versionLookup =
+                    MinimumVersionFromResolver.registerVersionLookupConfiguration(
+                            project,
+                            RECOMMENDED_PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME,
+                            ext.getRecommendedProductDependenciesProvider());
+            Provider<List<ProductDependency>> resolvedDependencies = MinimumVersionFromResolver.resolveMinimumVersions(
+                    ext.getRecommendedProductDependenciesProvider(), versionLookup);
+            embedResource(project, resolvedDependencies);
+            configureManifest(project, resolvedDependencies);
         });
     }
 
     @SuppressWarnings("for-rollout:TaskDependsOn")
-    private void configureManifest(Project project, RecommendedProductDependenciesExtension ext) {
+    private void configureManifest(Project project, Provider<List<ProductDependency>> resolvedDependencies) {
         TaskProvider<ConfigureProductDependenciesTask> configureProductDependenciesTask = project.getTasks()
                 .register("configureProductDependencies", ConfigureProductDependenciesTask.class, cmt -> {
-                    cmt.setProductDependencies(ext.getRecommendedProductDependenciesProvider());
+                    cmt.setProductDependencies(resolvedDependencies.map(HashSet::new));
                 });
 
         // Ensure that the jar task depends on this wiring task
@@ -53,12 +68,11 @@ public class RecommendedProductDependenciesPlugin implements Plugin<Project> {
         });
     }
 
-    private void embedResource(Project project, RecommendedProductDependenciesExtension ext) {
+    private void embedResource(Project project, Provider<List<ProductDependency>> resolvedDependencies) {
         TaskProvider<CompileRecommendedProductDependencies> compilePdeps = project.getTasks()
                 .register(
                         "compileRecommendedProductDependencies", CompileRecommendedProductDependencies.class, task -> {
-                            task.getRecommendedProductDependencies()
-                                    .set(ext.getRecommendedProductDependenciesProvider());
+                            task.getRecommendedProductDependencies().set(resolvedDependencies.map(HashSet::new));
                             task.getOutputDir()
                                     .set(project.getLayout().getBuildDirectory().dir("product-dependencies"));
                         });

--- a/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationTest.java
+++ b/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationTest.java
@@ -29,6 +29,7 @@ import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.maven.MavenArtifact;
 import com.palantir.gradle.testing.maven.MavenRepo;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.SubProject;
 import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipEntry;
@@ -177,6 +178,40 @@ class RecommendedProductDependenciesPluginIntegrationTest {
         assertThat(dep.getProductName()).isEqualTo("name");
         assertThat(dep.getMinimumVersion()).isEqualTo("1.0.0");
         assertThat(dep.getMaximumVersion()).isEqualTo("1.x.x");
+    }
+
+    @Test
+    void works_with_consistent_versions_in_subproject(
+            GradleInvoker gradle, RootProject rootProject, SubProject child, MavenRepo repo) throws IOException {
+        repo.publish(MavenArtifact.of("group:name:1.0.0"));
+        rootProject.buildGradle().plugins().add("com.palantir.consistent-versions");
+        rootProject.buildGradle().withMavenRepo(repo);
+        rootProject.buildGradle().append("allprojects { repositories { maven { url '%s' } } }", repo.path().toUri());
+
+        child.buildGradle().plugins().add("java").add("com.palantir.recommended-product-dependencies");
+        child.buildGradle().append("""
+            dependencies {
+                implementation 'group:name:1.0.0'
+            }
+
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'group'
+                    productName = 'name'
+                    minimumVersion = getVersion('group:name')
+                    maximumVersion = '1.x.x'
+                }
+            }
+            """);
+
+        InvocationResult result = gradle.withArgs("--write-locks", ":child:jar").buildsSuccessfully();
+
+        assertThat(result).task(":child:compileRecommendedProductDependencies").succeeded();
+
+        ProductDependency dep = Iterables.getOnlyElement(readRecommendedProductDeps(
+                        child.buildDir().file("libs/child.jar").path().toFile())
+                .recommendedProductDependencies());
+        assertThat(dep.getMinimumVersion()).isEqualTo("1.0.0");
     }
 
     private static RecommendedProductDependencies readRecommendedProductDeps(File jarFile) throws IOException {

--- a/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationTest.java
+++ b/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationTest.java
@@ -29,6 +29,7 @@ import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.maven.MavenArtifact;
 import com.palantir.gradle.testing.maven.MavenRepo;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.SubProject;
 import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipEntry;
@@ -177,6 +178,32 @@ class RecommendedProductDependenciesPluginIntegrationTest {
         assertThat(dep.getProductName()).isEqualTo("name");
         assertThat(dep.getMinimumVersion()).isEqualTo("1.0.0");
         assertThat(dep.getMaximumVersion()).isEqualTo("1.x.x");
+    }
+
+    @Test
+    void productDependency_minimumVersionFrom_resolves_via_gcv_under_parallel(
+            GradleInvoker gradle, RootProject rootProject, SubProject child) {
+        rootProject.buildGradle().plugins().add("com.palantir.consistent-versions");
+        rootProject.file("versions.props").createEmpty();
+        rootProject.file("versions.lock").createEmpty();
+
+        child.buildGradle().plugins().add("java").add("com.palantir.recommended-product-dependencies");
+        child.buildGradle().append("""
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'group'
+                    productName = 'name'
+                    minimumVersionFrom = 'group:name'
+                    maximumVersion = '1.x.x'
+                }
+            }
+            """);
+
+        InvocationResult result =
+                gradle.withArgs(":child:compileRecommendedProductDependencies").buildsWithFailure();
+        assertThat(result)
+                .output()
+                .contains("Unable to resolve minimumVersionFrom 'group:name' for product dependency group:name");
     }
 
     private static RecommendedProductDependencies readRecommendedProductDeps(File jarFile) throws IOException {

--- a/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationTest.java
+++ b/gradle-recommended-product-dependencies/src/test/java/com/palantir/gradle/dist/RecommendedProductDependenciesPluginIntegrationTest.java
@@ -29,7 +29,6 @@ import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.maven.MavenArtifact;
 import com.palantir.gradle.testing.maven.MavenRepo;
 import com.palantir.gradle.testing.project.RootProject;
-import com.palantir.gradle.testing.project.SubProject;
 import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipEntry;
@@ -178,40 +177,6 @@ class RecommendedProductDependenciesPluginIntegrationTest {
         assertThat(dep.getProductName()).isEqualTo("name");
         assertThat(dep.getMinimumVersion()).isEqualTo("1.0.0");
         assertThat(dep.getMaximumVersion()).isEqualTo("1.x.x");
-    }
-
-    @Test
-    void works_with_consistent_versions_in_subproject(
-            GradleInvoker gradle, RootProject rootProject, SubProject child, MavenRepo repo) throws IOException {
-        repo.publish(MavenArtifact.of("group:name:1.0.0"));
-        rootProject.buildGradle().plugins().add("com.palantir.consistent-versions");
-        rootProject.buildGradle().withMavenRepo(repo);
-        rootProject.buildGradle().append("allprojects { repositories { maven { url '%s' } } }", repo.path().toUri());
-
-        child.buildGradle().plugins().add("java").add("com.palantir.recommended-product-dependencies");
-        child.buildGradle().append("""
-            dependencies {
-                implementation 'group:name:1.0.0'
-            }
-
-            recommendedProductDependencies {
-                productDependency {
-                    productGroup = 'group'
-                    productName = 'name'
-                    minimumVersion = getVersion('group:name')
-                    maximumVersion = '1.x.x'
-                }
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("--write-locks", ":child:jar").buildsSuccessfully();
-
-        assertThat(result).task(":child:compileRecommendedProductDependencies").succeeded();
-
-        ProductDependency dep = Iterables.getOnlyElement(readRecommendedProductDeps(
-                        child.buildDir().file("libs/child.jar").path().toFile())
-                .recommendedProductDependencies());
-        assertThat(dep.getMinimumVersion()).isEqualTo("1.0.0");
     }
 
     private static RecommendedProductDependencies readRecommendedProductDeps(File jarFile) throws IOException {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -333,7 +333,7 @@ public class BaseDistributionExtension {
         this.productDependenciesConfig = productDependenciesConfig;
     }
 
-    static String generateMaxVersion(String minimumVersion) {
+    public static String generateMaxVersion(String minimumVersion) {
         return String.format("%s.x.x", Iterables.getFirst(Splitter.on(".").split(minimumVersion), null));
     }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -17,9 +17,7 @@
 package com.palantir.gradle.dist;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.palantir.gradle.dist.artifacts.ArtifactLocator;
 import com.palantir.gradle.dist.pdeps.ProductDependencies;
 import com.palantir.logsafe.SafeArg;
@@ -187,7 +185,7 @@ public class BaseDistributionExtension {
                 matcher.group("group"),
                 matcher.group("name"),
                 minVersion,
-                generateMaxVersion(minVersion),
+                ProductDependency.generateMaxVersion(minVersion),
                 recommendedVersion));
     }
 
@@ -210,7 +208,7 @@ public class BaseDistributionExtension {
                 dependencyGroup,
                 dependencyName,
                 minVersion,
-                maxVersion == null ? generateMaxVersion(minVersion) : maxVersion,
+                maxVersion == null ? ProductDependency.generateMaxVersion(minVersion) : maxVersion,
                 recommendedVersion));
     }
 
@@ -221,7 +219,7 @@ public class BaseDistributionExtension {
             try {
                 project.configure(dep, closure);
                 if (dep.getMinimumVersion() != null && dep.getMaximumVersion() == null) {
-                    dep.setMaximumVersion(generateMaxVersion(dep.getMinimumVersion()));
+                    dep.setMaximumVersion(ProductDependency.generateMaxVersion(dep.getMinimumVersion()));
                 }
                 dep.isValid();
             } catch (Exception e) {
@@ -331,9 +329,5 @@ public class BaseDistributionExtension {
         });
         consumableProductDependenciesConfigurationName.set(consumableConfigName);
         this.productDependenciesConfig = productDependenciesConfig;
-    }
-
-    public static String generateMaxVersion(String minimumVersion) {
-        return String.format("%s.x.x", Iterables.getFirst(Splitter.on(".").split(minimumVersion), null));
     }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
@@ -17,7 +17,7 @@
 package com.palantir.gradle.dist.pdeps;
 
 import com.palantir.gradle.dist.BaseDistributionExtension;
-import com.palantir.gradle.dist.ProductDependency;
+import com.palantir.gradle.dist.MinimumVersionFromResolver;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.RecommendedProductDependencies;
 import com.palantir.gradle.dist.RecommendedProductDependenciesPlugin;
@@ -25,20 +25,12 @@ import com.palantir.gradle.dist.artifacts.DependencyDiscovery;
 import com.palantir.gradle.dist.artifacts.ExtractSingleFileOrManifest;
 import com.palantir.gradle.dist.artifacts.PreferProjectCompatibilityRule;
 import com.palantir.gradle.dist.artifacts.SelectSingleFile;
-import com.palantir.gradle.versions.VersionsLockExtension;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
@@ -91,7 +83,9 @@ public final class ProductDependencies {
         Provider<ArtifactView> discoveredDependencies = productDependencyClasspath.map(
                 conf -> DependencyDiscovery.getFilteredArtifact(project, conf, PRODUCT_DEPENDENCIES));
 
-        NamedDomainObjectProvider<Configuration> versionLookup = registerVersionLookupConfiguration(project, ext);
+        NamedDomainObjectProvider<Configuration> versionLookup =
+                MinimumVersionFromResolver.registerVersionLookupConfiguration(
+                        project, PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME, ext.getAllProductDependencies());
 
         return project.getTasks().register("resolveProductDependencies", ResolveProductDependenciesTask.class, task -> {
             task.getServiceName().set(ext.getDistributionServiceName());
@@ -101,7 +95,9 @@ public final class ProductDependencies {
                     .set(project.provider(
                             () -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(project.getRootProject())
                                     .keySet()));
-            task.getProductDependencies().set(resolveMinimumVersionsFrom(ext, versionLookup));
+            task.getProductDependencies()
+                    .set(MinimumVersionFromResolver.resolveMinimumVersions(
+                            ext.getAllProductDependencies(), versionLookup));
             task.getOptionalProductIds().set(ext.getOptionalProductDependencies());
             task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
 
@@ -111,77 +107,6 @@ public final class ProductDependencies {
 
             task.getManifestFile().set(pdepsDir.map(dir -> dir.file("pdeps-manifest.json")));
         });
-    }
-
-    private static Provider<List<ProductDependency>> resolveMinimumVersionsFrom(
-            BaseDistributionExtension ext, NamedDomainObjectProvider<Configuration> versionLookup) {
-        Provider<Map<String, String>> versionsByCoordinate = versionLookup.map(configuration ->
-                configuration.getIncoming().getResolutionResult().getAllComponents().stream()
-                        .map(ResolvedComponentResult::getModuleVersion)
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toMap(
-                                moduleVersion -> moduleVersion.getGroup() + ":" + moduleVersion.getName(),
-                                ModuleVersionIdentifier::getVersion)));
-
-        return ext.getAllProductDependencies()
-                .zip(
-                        versionsByCoordinate,
-                        (productDependencies, versionsForCoordinate) -> productDependencies.stream()
-                                .map(productDependency ->
-                                        withResolvedMinimumVersion(productDependency, versionsForCoordinate))
-                                .toList());
-    }
-
-    private static ProductDependency withResolvedMinimumVersion(
-            ProductDependency original, Map<String, String> versionsByCoordinate) {
-        Optional<String> coordinate = original.getMinimumVersionFrom();
-        if (coordinate.isEmpty()) {
-            return original;
-        }
-        String resolvedVersion = Optional.ofNullable(versionsByCoordinate.get(coordinate.get()))
-                .orElseThrow(() -> new GradleException(String.format(
-                        "Unable to resolve minimumVersionFrom '%s' for product dependency %s:%s",
-                        coordinate.get(), original.getProductGroup(), original.getProductName())));
-        return new ProductDependency(
-                original.getProductGroup(),
-                original.getProductName(),
-                resolvedVersion,
-                original.getMaximumVersion() != null
-                        ? original.getMaximumVersion()
-                        : BaseDistributionExtension.generateMaxVersion(resolvedVersion),
-                original.getRecommendedVersion(),
-                original.getOptional());
-    }
-
-    /**
-     * Registers a resolvable configuration that the plugin populates with the {@code group:name} entries declared via
-     * {@link ProductDependency#getMinimumVersionFrom()}. When gradle-consistent-versions is applied the configuration
-     * is also added to the {@code versionsLock} extension so that lockfile-driven constraints apply when it is
-     * resolved.
-     */
-    private static NamedDomainObjectProvider<Configuration> registerVersionLookupConfiguration(
-            Project project, BaseDistributionExtension ext) {
-        Provider<List<Dependency>> versionLookupDeps = ext.getAllProductDependencies()
-                .map(productDependencies -> productDependencies.stream()
-                        .flatMap(productDependency -> productDependency.getMinimumVersionFrom().stream())
-                        .distinct()
-                        .map(coordinate -> project.getDependencies().create(coordinate))
-                        .collect(Collectors.toList()));
-
-        NamedDomainObjectProvider<Configuration> versionLookup = project.getConfigurations()
-                .register(PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME, configuration -> {
-                    configuration.setCanBeResolved(true);
-                    configuration.setCanBeConsumed(false);
-                    configuration.getDependencies().addAllLater(versionLookupDeps);
-                });
-
-        project.getRootProject().getPluginManager().withPlugin("com.palantir.consistent-versions", _appliedPlugin -> {
-            VersionsLockExtension versionsLock = project.getExtensions().getByType(VersionsLockExtension.class);
-            versionsLock.production(
-                    scopeConfigurer -> scopeConfigurer.from(PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME));
-        });
-
-        return versionLookup;
     }
 
     private ProductDependencies() {}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
@@ -41,6 +41,8 @@ public final class ProductDependencies {
 
     public static TaskProvider<ResolveProductDependenciesTask> registerProductDependencyTasks(
             Project project, BaseDistributionExtension ext) {
+        Provider<Directory> pdepsDir = project.getLayout().getBuildDirectory().dir("resolved-pdeps");
+
         // Register compatibility rule to ensure that ResourceTransform is applied onto project dependencies so we
         // avoid compilation
         PreferProjectCompatibilityRule.configureRule(project);
@@ -79,34 +81,14 @@ public final class ProductDependencies {
         Provider<ArtifactView> discoveredDependencies = productDependencyClasspath.map(
                 conf -> DependencyDiscovery.getFilteredArtifact(project, conf, PRODUCT_DEPENDENCIES));
 
-        TaskProvider<ResolveProductDependenciesTask> rootWorker =
-                registerRootWorker(project, ext, discoveredDependencies);
-
-        // The subproject keeps the public task name; it just delegates to the root worker.
-        boolean ownsTaskName = project.equals(project.getRootProject());
-        if (!ownsTaskName) {
-            project.getTasks().register("resolveProductDependencies", task -> {
-                task.dependsOn(rootWorker);
-            });
-        }
-
-        return rootWorker;
-    }
-
-    private static TaskProvider<ResolveProductDependenciesTask> registerRootWorker(
-            Project project, BaseDistributionExtension ext, Provider<ArtifactView> discoveredDependencies) {
-        Project rootProject = project.getRootProject();
-        String taskName = rootWorkerTaskName(project);
-        Provider<Directory> pdepsDir =
-                rootProject.getLayout().getBuildDirectory().dir(rootWorkerOutputDir(project));
-
-        return rootProject.getTasks().register(taskName, ResolveProductDependenciesTask.class, task -> {
+        return project.getTasks().register("resolveProductDependencies", ResolveProductDependenciesTask.class, task -> {
             task.getServiceName().set(ext.getDistributionServiceName());
             task.getServiceGroup().set(ext.getDistributionServiceGroup());
 
             task.getInRepoProductIds()
-                    .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(rootProject)
-                            .keySet()));
+                    .set(project.provider(
+                            () -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(project.getRootProject())
+                                    .keySet()));
             task.getProductDependencies().set(ext.getAllProductDependencies());
             task.getOptionalProductIds().set(ext.getOptionalProductDependencies());
             task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
@@ -117,20 +99,6 @@ public final class ProductDependencies {
 
             task.getManifestFile().set(pdepsDir.map(dir -> dir.file("pdeps-manifest.json")));
         });
-    }
-
-    private static String rootWorkerTaskName(Project project) {
-        if (project.equals(project.getRootProject())) {
-            return "resolveProductDependencies";
-        }
-        return "resolveProductDependenciesFor" + project.getPath().replace(':', '_');
-    }
-
-    private static String rootWorkerOutputDir(Project project) {
-        if (project.equals(project.getRootProject())) {
-            return "resolved-pdeps";
-        }
-        return "resolved-pdeps" + project.getPath().replace(':', '/');
     }
 
     private ProductDependencies() {}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.dist.pdeps;
 
 import com.palantir.gradle.dist.BaseDistributionExtension;
+import com.palantir.gradle.dist.ProductDependency;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.RecommendedProductDependencies;
 import com.palantir.gradle.dist.RecommendedProductDependenciesPlugin;
@@ -24,12 +25,20 @@ import com.palantir.gradle.dist.artifacts.DependencyDiscovery;
 import com.palantir.gradle.dist.artifacts.ExtractSingleFileOrManifest;
 import com.palantir.gradle.dist.artifacts.PreferProjectCompatibilityRule;
 import com.palantir.gradle.dist.artifacts.SelectSingleFile;
+import com.palantir.gradle.versions.VersionsLockExtension;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
@@ -38,6 +47,7 @@ public final class ProductDependencies {
 
     private static final String PRODUCT_DEPENDENCIES = "product-dependencies";
     public static final String PRODUCT_DEPENDENCY_DISCOVERY_CONFIGURATION_NAME = "productDependencyDiscovery";
+    public static final String PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME = "productDependencyVersionLookup";
 
     public static TaskProvider<ResolveProductDependenciesTask> registerProductDependencyTasks(
             Project project, BaseDistributionExtension ext) {
@@ -81,6 +91,8 @@ public final class ProductDependencies {
         Provider<ArtifactView> discoveredDependencies = productDependencyClasspath.map(
                 conf -> DependencyDiscovery.getFilteredArtifact(project, conf, PRODUCT_DEPENDENCIES));
 
+        NamedDomainObjectProvider<Configuration> versionLookup = registerVersionLookupConfiguration(project, ext);
+
         return project.getTasks().register("resolveProductDependencies", ResolveProductDependenciesTask.class, task -> {
             task.getServiceName().set(ext.getDistributionServiceName());
             task.getServiceGroup().set(ext.getDistributionServiceGroup());
@@ -89,7 +101,7 @@ public final class ProductDependencies {
                     .set(project.provider(
                             () -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(project.getRootProject())
                                     .keySet()));
-            task.getProductDependencies().set(ext.getAllProductDependencies());
+            task.getProductDependencies().set(resolveMinimumVersionsFrom(ext, versionLookup));
             task.getOptionalProductIds().set(ext.getOptionalProductDependencies());
             task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
 
@@ -99,6 +111,77 @@ public final class ProductDependencies {
 
             task.getManifestFile().set(pdepsDir.map(dir -> dir.file("pdeps-manifest.json")));
         });
+    }
+
+    private static Provider<List<ProductDependency>> resolveMinimumVersionsFrom(
+            BaseDistributionExtension ext, NamedDomainObjectProvider<Configuration> versionLookup) {
+        Provider<Map<String, String>> versionsByCoordinate = versionLookup.map(configuration ->
+                configuration.getIncoming().getResolutionResult().getAllComponents().stream()
+                        .map(ResolvedComponentResult::getModuleVersion)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toMap(
+                                moduleVersion -> moduleVersion.getGroup() + ":" + moduleVersion.getName(),
+                                ModuleVersionIdentifier::getVersion)));
+
+        return ext.getAllProductDependencies()
+                .zip(
+                        versionsByCoordinate,
+                        (productDependencies, versionsForCoordinate) -> productDependencies.stream()
+                                .map(productDependency ->
+                                        withResolvedMinimumVersion(productDependency, versionsForCoordinate))
+                                .toList());
+    }
+
+    private static ProductDependency withResolvedMinimumVersion(
+            ProductDependency original, Map<String, String> versionsByCoordinate) {
+        Optional<String> coordinate = original.getMinimumVersionFrom();
+        if (coordinate.isEmpty()) {
+            return original;
+        }
+        String resolvedVersion = Optional.ofNullable(versionsByCoordinate.get(coordinate.get()))
+                .orElseThrow(() -> new GradleException(String.format(
+                        "Unable to resolve minimumVersionFrom '%s' for product dependency %s:%s",
+                        coordinate.get(), original.getProductGroup(), original.getProductName())));
+        return new ProductDependency(
+                original.getProductGroup(),
+                original.getProductName(),
+                resolvedVersion,
+                original.getMaximumVersion() != null
+                        ? original.getMaximumVersion()
+                        : BaseDistributionExtension.generateMaxVersion(resolvedVersion),
+                original.getRecommendedVersion(),
+                original.getOptional());
+    }
+
+    /**
+     * Registers a resolvable configuration that the plugin populates with the {@code group:name} entries declared via
+     * {@link ProductDependency#getMinimumVersionFrom()}. When gradle-consistent-versions is applied the configuration
+     * is also added to the {@code versionsLock} extension so that lockfile-driven constraints apply when it is
+     * resolved.
+     */
+    private static NamedDomainObjectProvider<Configuration> registerVersionLookupConfiguration(
+            Project project, BaseDistributionExtension ext) {
+        Provider<List<Dependency>> versionLookupDeps = ext.getAllProductDependencies()
+                .map(productDependencies -> productDependencies.stream()
+                        .flatMap(productDependency -> productDependency.getMinimumVersionFrom().stream())
+                        .distinct()
+                        .map(coordinate -> project.getDependencies().create(coordinate))
+                        .collect(Collectors.toList()));
+
+        NamedDomainObjectProvider<Configuration> versionLookup = project.getConfigurations()
+                .register(PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME, configuration -> {
+                    configuration.setCanBeResolved(true);
+                    configuration.setCanBeConsumed(false);
+                    configuration.getDependencies().addAllLater(versionLookupDeps);
+                });
+
+        project.getRootProject().getPluginManager().withPlugin("com.palantir.consistent-versions", _appliedPlugin -> {
+            VersionsLockExtension versionsLock = project.getExtensions().getByType(VersionsLockExtension.class);
+            versionsLock.production(
+                    scopeConfigurer -> scopeConfigurer.from(PRODUCT_DEPENDENCY_VERSION_LOOKUP_CONFIGURATION_NAME));
+        });
+
+        return versionLookup;
     }
 
     private ProductDependencies() {}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/pdeps/ProductDependencies.java
@@ -41,8 +41,6 @@ public final class ProductDependencies {
 
     public static TaskProvider<ResolveProductDependenciesTask> registerProductDependencyTasks(
             Project project, BaseDistributionExtension ext) {
-        Provider<Directory> pdepsDir = project.getLayout().getBuildDirectory().dir("resolved-pdeps");
-
         // Register compatibility rule to ensure that ResourceTransform is applied onto project dependencies so we
         // avoid compilation
         PreferProjectCompatibilityRule.configureRule(project);
@@ -81,14 +79,34 @@ public final class ProductDependencies {
         Provider<ArtifactView> discoveredDependencies = productDependencyClasspath.map(
                 conf -> DependencyDiscovery.getFilteredArtifact(project, conf, PRODUCT_DEPENDENCIES));
 
-        return project.getTasks().register("resolveProductDependencies", ResolveProductDependenciesTask.class, task -> {
+        TaskProvider<ResolveProductDependenciesTask> rootWorker =
+                registerRootWorker(project, ext, discoveredDependencies);
+
+        // The subproject keeps the public task name; it just delegates to the root worker.
+        boolean ownsTaskName = project.equals(project.getRootProject());
+        if (!ownsTaskName) {
+            project.getTasks().register("resolveProductDependencies", task -> {
+                task.dependsOn(rootWorker);
+            });
+        }
+
+        return rootWorker;
+    }
+
+    private static TaskProvider<ResolveProductDependenciesTask> registerRootWorker(
+            Project project, BaseDistributionExtension ext, Provider<ArtifactView> discoveredDependencies) {
+        Project rootProject = project.getRootProject();
+        String taskName = rootWorkerTaskName(project);
+        Provider<Directory> pdepsDir =
+                rootProject.getLayout().getBuildDirectory().dir(rootWorkerOutputDir(project));
+
+        return rootProject.getTasks().register(taskName, ResolveProductDependenciesTask.class, task -> {
             task.getServiceName().set(ext.getDistributionServiceName());
             task.getServiceGroup().set(ext.getDistributionServiceGroup());
 
             task.getInRepoProductIds()
-                    .set(project.provider(
-                            () -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(project.getRootProject())
-                                    .keySet()));
+                    .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(rootProject)
+                            .keySet()));
             task.getProductDependencies().set(ext.getAllProductDependencies());
             task.getOptionalProductIds().set(ext.getOptionalProductDependencies());
             task.getIgnoredProductIds().set(ext.getIgnoredProductDependencies());
@@ -99,6 +117,20 @@ public final class ProductDependencies {
 
             task.getManifestFile().set(pdepsDir.map(dir -> dir.file("pdeps-manifest.json")));
         });
+    }
+
+    private static String rootWorkerTaskName(Project project) {
+        if (project.equals(project.getRootProject())) {
+            return "resolveProductDependencies";
+        }
+        return "resolveProductDependenciesFor" + project.getPath().replace(':', '_');
+    }
+
+    private static String rootWorkerOutputDir(Project project) {
+        if (project.equals(project.getRootProject())) {
+            return "resolved-pdeps";
+        }
+        return "resolved-pdeps" + project.getPath().replace(':', '/');
     }
 
     private ProductDependencies() {}

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
@@ -41,8 +41,7 @@ class ProductDependencyClosureGcvSubprojectIntegrationTest {
     }
 
     @Test
-    void productDependency_minimumVersionFrom_resolves_via_gcv_under_parallel(
-            GradleInvoker gradle, SubProject child) {
+    void productDependency_minimumVersionFrom_resolves_via_gcv_under_parallel(GradleInvoker gradle, SubProject child) {
         child.buildGradle().plugins().add("java").add("com.palantir.sls-java-service-distribution");
         child.buildGradle().append("""
             distribution {

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
@@ -41,7 +41,7 @@ class ProductDependencyClosureGcvSubprojectIntegrationTest {
     }
 
     @Test
-    void productDependency_closure_can_call_getVersion_from_subproject_under_parallel(
+    void productDependency_minimumVersionFrom_resolves_via_gcv_under_parallel(
             GradleInvoker gradle, SubProject child) {
         child.buildGradle().plugins().add("java").add("com.palantir.sls-java-service-distribution");
         child.buildGradle().append("""
@@ -51,7 +51,7 @@ class ProductDependencyClosureGcvSubprojectIntegrationTest {
                 productDependency {
                     productGroup = 'group'
                     productName = 'name'
-                    minimumVersion = getVersion('group:name')
+                    minimumVersionFrom = 'group:name'
                     maximumVersion = '1.x.x'
                 }
             }
@@ -61,6 +61,6 @@ class ProductDependencyClosureGcvSubprojectIntegrationTest {
                 .buildsWithFailure();
         assertThat(result)
                 .output()
-                .contains("Unable to find 'group:name' in configuration ':unifiedClasspath'");
+                .contains("Unable to resolve minimumVersionFrom 'group:name' for product dependency group:name");
     }
 }

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.service;
+
+import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.execution.InvocationResult;
+import com.palantir.gradle.testing.junit.AdditionallyRunWithGradle;
+import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.SubProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+@DisabledConfigurationCache
+@AdditionallyRunWithGradle("9.3.1")
+class ProductDependencyClosureGcvSubprojectIntegrationTest {
+
+    @BeforeEach
+    void setup(RootProject rootProject) {
+        rootProject.buildGradle().plugins().add("com.palantir.consistent-versions");
+        rootProject.file("versions.props").createEmpty();
+        rootProject.file("versions.lock").createEmpty();
+    }
+
+    @Test
+    void productDependency_closure_can_call_getVersion_from_subproject_under_parallel(
+            GradleInvoker gradle, SubProject child) {
+        child.buildGradle().plugins().add("java").add("com.palantir.sls-java-service-distribution");
+        child.buildGradle().append("""
+            distribution {
+                serviceName 'service-name'
+                mainClass 'dummy.Main'
+                productDependency {
+                    productGroup = 'group'
+                    productName = 'name'
+                    minimumVersion = getVersion('group:name')
+                    maximumVersion = '1.x.x'
+                }
+            }
+            """);
+
+        InvocationResult result = gradle.withArgs(":child:resolveProductDependencies", "--parallel")
+                .buildsWithFailure();
+        assertThat(result)
+                .output()
+                .contains("Unable to find 'group:name' in configuration ':unifiedClasspath'");
+    }
+}

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
@@ -57,8 +57,10 @@ class ProductDependencyClosureGcvSubprojectIntegrationTest {
             }
             """);
 
-        InvocationResult result =
-                gradle.withArgs(":child:resolveProductDependencies").buildsWithFailure();
-        assertThat(result).output().contains("Unable to find 'group:name' in configuration ':unifiedClasspath'");
+        InvocationResult result = gradle.withArgs(":child:resolveProductDependencies", "--parallel")
+                .buildsWithFailure();
+        assertThat(result)
+                .output()
+                .contains("Unable to find 'group:name' in configuration ':unifiedClasspath'");
     }
 }

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/ProductDependencyClosureGcvSubprojectIntegrationTest.java
@@ -57,10 +57,8 @@ class ProductDependencyClosureGcvSubprojectIntegrationTest {
             }
             """);
 
-        InvocationResult result = gradle.withArgs(":child:resolveProductDependencies", "--parallel")
-                .buildsWithFailure();
-        assertThat(result)
-                .output()
-                .contains("Unable to find 'group:name' in configuration ':unifiedClasspath'");
+        InvocationResult result =
+                gradle.withArgs(":child:resolveProductDependencies").buildsWithFailure();
+        assertThat(result).output().contains("Unable to find 'group:name' in configuration ':unifiedClasspath'");
     }
 }


### PR DESCRIPTION
## Before this PR

Declaring a product dependency requires hard-coding `minimumVersion`, which then drifts from the actual version GCV resolves for the corresponding Maven coordinate. Keeping them in sync is manual and error-prone.

## After this PR

Adds a `minimumVersionFrom` option to the `distribution` extension's `productDependency` block, so the minimum version can be sourced from a locked Maven coordinate instead of being hard-coded:

```groovy
distribution {
    productDependency {
        productGroup = 'group'
        productName = 'name'
        minimumVersionFrom = 'group:name'
        maximumVersion = '1.x.x'
    }
}
```

> [!IMPORTANT]
> **Closing in favour of a GCV-side fix.** `minimumVersionFrom` does fix the product-dependency case, but it has a separate flaw. It requires building a `Provider<List<Dependency>>` from the declared `productDependencies` and locking that configuration via GCV's `versionsLock` (`lock.production { from(configurationName) }`). When `versionsLock` runs, it must evaluate that provider during **configuration time**, which in turn forces any *old-style* `getVersion('group:name')` in the product-dependency closures to run at configuration time and resolve `unifiedClasspath`

## Possible downsides?

N/A — closing unmerged.
