### PR TITLE
Make service distribution runtime classpath consistent

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -276,9 +276,8 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
 
         // HACKHACK setClasspath of JavaExec is eager so we configure it after evaluation to ensure everything has
         // been correctly configured
-        project.afterEvaluate(p -> runTask.configure(task -> {
-            task.setClasspath(project.files(
-                    jarTask.get().getArchiveFile().get(), p.getConfigurations().getByName("runtimeClasspath")));
+        project.afterEvaluate(_p -> runTask.configure(task -> {
+            task.setClasspath(serviceRuntimeClasspath(project));
             task.setArgs(distributionExtension.getArgs().get());
         }));
 

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -148,16 +148,10 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                                     .getOutputs()
                                     .getFiles();
 
-                            String classPath = runtimeClasspath.plus(jarOutputs).getFiles().stream()
+                            String classPath = jarOutputs.plus(runtimeClasspath).getFiles().stream()
                                     .map(File::getName)
                                     .collect(Collectors.joining(" "));
-                            task.getManifest()
-                                    .getAttributes()
-                                    .put(
-                                            "Class-Path",
-                                            classPath
-                                                    + " "
-                                                    + task.getArchiveFileName().get());
+                            task.getManifest().getAttributes().put("Class-Path", classPath);
                         }
                     });
                     task.onlyIf(_unused ->

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -43,11 +43,9 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.JavaExec;
@@ -139,16 +137,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
                     task.doFirst(new Action<Task>() {
                         @Override
                         public void execute(Task _task) {
-                            FileCollection runtimeClasspath =
-                                    project.getConfigurations().getByName("runtimeClasspath");
-
-                            FileCollection jarOutputs = project.getTasks()
-                                    .withType(Jar.class)
-                                    .getByName(JavaPlugin.JAR_TASK_NAME)
-                                    .getOutputs()
-                                    .getFiles();
-
-                            String classPath = jarOutputs.plus(runtimeClasspath).getFiles().stream()
+                            String classPath = serviceRuntimeClasspath(project).getFiles().stream()
                                     .map(File::getName)
                                     .collect(Collectors.joining(" "));
                             task.getManifest().getAttributes().put("Class-Path", classPath);
@@ -197,14 +186,10 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
             task.setDefaultJvmOpts(distributionExtension.getDefaultJvmOpts().get());
             task.dependsOn(manifestClassPathTask);
 
-            JavaPluginExtension javaPlugin = project.getExtensions().getByType(JavaPluginExtension.class);
             if (distributionExtension.getEnableManifestClasspath().get()) {
                 task.setClasspath(manifestClassPathTask.get().getOutputs().getFiles());
             } else {
-                task.setClasspath(jarTask.get()
-                        .getOutputs()
-                        .getFiles()
-                        .plus(javaPlugin.getSourceSets().getByName("main").getRuntimeClasspath()));
+                task.setClasspath(serviceRuntimeClasspath(project));
             }
         }));
 
@@ -318,10 +303,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         project.afterEvaluate(_p -> launchConfigTask.configure(task -> {
             task.getJavaAgents().setFrom(javaAgentConfiguration);
 
-            ConfigurableFileCollection fullClasspath = project.getObjects()
-                    .fileCollection()
-                    .from(jarTask.get().getOutputs().getFiles())
-                    .from(project.getConfigurations().named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+            FileCollection fullClasspath = serviceRuntimeClasspath(project);
 
             task.getFullClasspath().from(fullClasspath);
             task.getClasspath()
@@ -336,6 +318,13 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         }));
 
         project.getArtifacts().add(SlsBaseDistPlugin.SLS_CONFIGURATION_NAME, distTar);
+    }
+
+    private static FileCollection serviceRuntimeClasspath(Project project) {
+        return project.getObjects()
+                .fileCollection()
+                .from(project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class))
+                .from(project.getConfigurations().named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
     }
 
     private static Provider<Map<String, String>> userConfiguredEnvWithJdkEnvVars(

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
@@ -39,10 +39,12 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.jar.Attributes;
+import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipOutputStream;
@@ -929,9 +931,54 @@ class JavaServiceDistributionPluginTests {
         String zipManifest = TestUtils.readFromZip(classpathJar.get(), "META-INF/MANIFEST.MF")
                 .replace("\r\n ", "");
         assertThat(zipManifest).contains("Class-Path: ");
-        assertThat(zipManifest).contains("guava-19.0.jar");
-        assertThat(zipManifest).contains("root-project-0.0.1.jar");
+        assertThat(zipManifest)
+                .as("the project's own jar should be listed before its runtime dependencies on the Class-Path")
+                .containsSubsequence("root-project-0.0.1.jar", "guava-19.0.jar");
         assertThat(zipManifest).doesNotContain("root-project-manifest-classpath-0.0.1.jar");
+    }
+
+    @Test
+    void manifest_classpath_lists_jars_in_the_same_order_as_the_non_manifest_classpath(
+            GradleInvoker gradle, RootProject rootProject) throws Exception {
+        createUntarBuildFile(rootProject);
+        rootProject.settingsGradle().rootProjectName("root-project");
+        rootProject.buildGradle().append("""
+            distribution {
+                enableManifestClasspath findProperty('manifestClasspath') == 'true'
+            }
+            dependencies {
+              implementation "com.google.guava:guava:19.0"
+            }
+            """);
+
+        // Without the manifest classpath jar, the full classpath is written directly into the start script.
+        gradle.withArgs(":distTar", ":untar", "-PmanifestClasspath=false").buildsSuccessfully();
+        List<String> nonManifestClasspath =
+                TestUtils.extractClasspathEntriesFromScript(rootProject, "0.0.1", "service-name").stream()
+                        .map(JavaServiceDistributionPluginTests::jarFileName)
+                        .toList();
+
+        // With the manifest classpath jar, that same classpath instead lives in the jar's Class-Path attribute.
+        gradle.withArgs(":distTar", ":untar", "-PmanifestClasspath=true").buildsSuccessfully();
+        Optional<File> classpathJar =
+                TestUtils.findJarInLibDirectory(rootProject, "0.0.1", ".*-manifest-classpath-0\\.0\\.1\\.jar");
+        assertThat(classpathJar).isPresent();
+        List<String> manifestClasspath;
+        try (JarFile jarFile = new JarFile(classpathJar.get())) {
+            String classPathAttribute =
+                    jarFile.getManifest().getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
+            manifestClasspath = Arrays.stream(classPathAttribute.split(" "))
+                    .map(JavaServiceDistributionPluginTests::jarFileName)
+                    .toList();
+        }
+
+        assertThat(manifestClasspath)
+                .as("the manifest Class-Path should list the same jars in the same order as the plain classpath")
+                .containsExactlyElementsOf(nonManifestClasspath);
+    }
+
+    private static String jarFileName(String classpathEntry) {
+        return Path.of(classpathEntry).getFileName().toString();
     }
 
     @Test

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/service/JavaServiceDistributionPluginTests.java
@@ -930,8 +930,8 @@ class JavaServiceDistributionPluginTests {
                 .replace("\r\n ", "");
         assertThat(zipManifest).contains("Class-Path: ");
         assertThat(zipManifest).contains("guava-19.0.jar");
-        assertThat(zipManifest).contains("root-project-manifest-classpath-0.0.1.jar");
         assertThat(zipManifest).contains("root-project-0.0.1.jar");
+        assertThat(zipManifest).doesNotContain("root-project-manifest-classpath-0.0.1.jar");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR

Four places in the plugin built what should be the same runtime classpath, and had drifted:

- The manifest jar's `Class-Path` listed runtime deps before the project jar (reverse of the non-manifest order) and re-added itself, a no-op per the [JAR spec](https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#classpath).
- `startScripts` (non-manifest) used `SourceSet.runtimeClasspath`, dragging in `build/classes` and `build/resources` dirs that aren't packaged into `service/lib/`. Accidental drift in [#385](https://github.com/palantir/sls-packaging/pull/385) (Groovy → Java migration): changed from [`project.configurations.runtimeClasspath`](https://github.com/palantir/sls-packaging/blob/1e68b08/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/tasks/CreateStartScriptsTask.groovy#L31) to [`sourceSets.main.runtimeClasspath`](https://github.com/palantir/sls-packaging/blob/1829651/gradle-sls-packaging/src/main/groovy/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java#L133-L134).

## After this PR
==COMMIT_MSG==
- Project jar now appears first in the manifest `Class-Path`, matching the non-manifest ordering, and the redundant self-reference is gone.
- The manifest jar, `startScripts`, `launchConfigTask`, and `runTask` all share a single `serviceRuntimeClasspath` helper so they can't drift again.
==COMMIT_MSG==

## Possible downsides?