### PR TITLE
Propagate task dependencies for lazily-added artifacts

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -26,6 +26,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,7 +35,6 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
-import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.RegularFileProperty;
@@ -64,7 +64,9 @@ public class BaseDistributionExtension {
     private final ListProperty<ProductDependency> productDependencies;
     private final SetProperty<ProductId> optionalProductDependencies;
     private final SetProperty<ProductId> ignoredProductDependencies;
-    private final DomainObjectSet<ArtifactLocator> artifacts;
+    private final SetProperty<ArtifactLocator> artifacts;
+    private final SetProperty<ArtifactLocator> configuredArtifacts;
+    private final List<Action<? super ArtifactLocator>> artifactConfigurations = new ArrayList<>();
     private final ProviderFactory providerFactory;
     private final MapProperty<String, Object> manifestExtensions;
     private final RegularFileProperty configurationYml;
@@ -82,7 +84,10 @@ public class BaseDistributionExtension {
         productDependencies = project.getObjects().listProperty(ProductDependency.class);
         optionalProductDependencies = project.getObjects().setProperty(ProductId.class);
         ignoredProductDependencies = project.getObjects().setProperty(ProductId.class);
-        artifacts = project.getObjects().domainObjectSet(ArtifactLocator.class);
+        artifacts = project.getObjects().setProperty(ArtifactLocator.class).empty();
+        configuredArtifacts = project.getObjects().setProperty(ArtifactLocator.class);
+        configuredArtifacts.set(artifacts.map(this::applyArtifactConfigurations));
+        configuredArtifacts.finalizeValueOnRead();
         consumableProductDependenciesConfigurationName = project.getObjects().property(String.class);
 
         serviceGroup.set(project.provider(() -> project.getGroup().toString()));
@@ -140,8 +145,24 @@ public class BaseDistributionExtension {
         this.productType.set(productType);
     }
 
-    public final DomainObjectSet<ArtifactLocator> getArtifacts() {
+    public final SetProperty<ArtifactLocator> getArtifacts() {
         return artifacts;
+    }
+
+    /** Lazily configures every artifact when the collection is queried. */
+    public final void configureArtifacts(Action<? super ArtifactLocator> configureAction) {
+        artifactConfigurations.add(configureAction);
+    }
+
+    /** A lazy view of the artifacts after actions registered with {@link #configureArtifacts} have been applied. */
+    public final Provider<Set<ArtifactLocator>> getConfiguredArtifacts() {
+        return configuredArtifacts;
+    }
+
+    private Set<ArtifactLocator> applyArtifactConfigurations(Set<ArtifactLocator> artifactLocators) {
+        artifactLocators.forEach(
+                artifactLocator -> artifactConfigurations.forEach(action -> action.execute(artifactLocator)));
+        return artifactLocators;
     }
 
     /** Lazily configures and adds a {@link ArtifactLocator}. */

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -169,13 +169,13 @@ public class BaseDistributionExtension {
     public final void artifact(@DelegatesTo(ArtifactLocator.class) Closure<ArtifactLocator> closure) {
         ArtifactLocator artifactLocator = project.getObjects().newInstance(ArtifactLocator.class);
         project.configure(artifactLocator, closure);
-        artifacts.add(artifactLocator);
+        artifacts.add(artifactLocator.asProvider());
     }
 
     public final void artifact(Action<ArtifactLocator> action) {
         ArtifactLocator artifactLocator = project.getObjects().newInstance(ArtifactLocator.class);
         action.execute(artifactLocator);
-        artifacts.add(artifactLocator);
+        artifacts.add(artifactLocator.asProvider());
     }
 
     /**

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ArtifactLocator.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ArtifactLocator.java
@@ -17,12 +17,19 @@
 package com.palantir.gradle.dist.artifacts;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.api.tasks.Input;
 
-public interface ArtifactLocator {
+public interface ArtifactLocator extends ProviderConvertible<ArtifactLocator> {
     @Input
     Property<String> getType();
 
     @Input
     Property<String> getUri();
+
+    @Override
+    default Provider<ArtifactLocator> asProvider() {
+        return getType().zip(getUri(), (_type, _uri) -> this);
+    }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -47,6 +47,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.StartParameter;
@@ -57,6 +58,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
@@ -89,6 +91,10 @@ public abstract class CreateManifestTask extends DefaultTask {
 
     @Nested
     public abstract SetProperty<ArtifactLocator> getArtifacts();
+
+    /** Allows Gradle to establish producers of the collection before traversing its nested elements. */
+    @Input
+    public abstract Property<Integer> getArtifactCount();
 
     @InputFile
     public abstract RegularFileProperty getProductDependenciesFile();
@@ -342,7 +348,9 @@ public abstract class CreateManifestTask extends DefaultTask {
                             .set(resolveProductDependenciesTask.flatMap(
                                     ResolveProductDependenciesTask::getManifestFile));
                     task.getManifestExtensions().set(ext.getManifestExtensions());
-                    task.getArtifacts().addAll(ext.getArtifacts());
+                    Provider<Set<ArtifactLocator>> artifacts = ext.getConfiguredArtifacts();
+                    task.getArtifacts().set(artifacts);
+                    task.getArtifactCount().set(artifacts.map(Set::size));
                     task.getInRepoProductIds()
                             .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(
                                             project.getRootProject())

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -47,7 +47,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.StartParameter;
@@ -58,7 +57,6 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
@@ -91,10 +89,6 @@ public abstract class CreateManifestTask extends DefaultTask {
 
     @Nested
     public abstract SetProperty<ArtifactLocator> getArtifacts();
-
-    /** Allows Gradle to establish producers of the collection before traversing its nested elements. */
-    @Input
-    public abstract Property<Integer> getArtifactCount();
 
     @InputFile
     public abstract RegularFileProperty getProductDependenciesFile();
@@ -348,9 +342,7 @@ public abstract class CreateManifestTask extends DefaultTask {
                             .set(resolveProductDependenciesTask.flatMap(
                                     ResolveProductDependenciesTask::getManifestFile));
                     task.getManifestExtensions().set(ext.getManifestExtensions());
-                    Provider<Set<ArtifactLocator>> artifacts = ext.getConfiguredArtifacts();
-                    task.getArtifacts().set(artifacts);
-                    task.getArtifactCount().set(artifacts.map(Set::size));
+                    task.getArtifacts().set(ext.getConfiguredArtifacts());
                     task.getInRepoProductIds()
                             .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(
                                             project.getRootProject())

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -61,7 +61,6 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
@@ -87,7 +86,7 @@ public abstract class CreateManifestTask extends DefaultTask {
     @Input
     public abstract MapProperty<String, Object> getManifestExtensions();
 
-    @Nested
+    @Input
     public abstract SetProperty<ArtifactLocator> getArtifacts();
 
     @InputFile

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -342,6 +342,49 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
+    def "#gradleVersionNumber: createManifest depends on task whose artifacts are added to the extension via addAllLater"() {
+        given:
+        gradleVersion = gradleVersionNumber
+        buildFile << """
+            import com.palantir.gradle.dist.artifacts.ArtifactLocator
+            import org.gradle.api.file.RegularFileProperty
+            import org.gradle.api.tasks.OutputFile
+            import org.gradle.api.tasks.TaskAction
+            import java.nio.file.Files
+
+            abstract class ProduceArtifactsTask extends DefaultTask {
+                @OutputFile
+                abstract RegularFileProperty getOutput();
+
+                @TaskAction
+                final void action() throws Exception {
+                    Files.writeString(getOutput().getAsFile().get().toPath(), "registry.example.io/foo/bar:v1.3.0")
+                }
+            }
+
+            def produceArtifacts = tasks.register('produceArtifacts', ProduceArtifactsTask) {
+                output.fileValue(file("build/artifact-url"))
+            }
+
+            distribution.artifacts.addAllLater(produceArtifacts.map { producer ->
+                def locator = project.objects.newInstance(ArtifactLocator)
+                locator.type.set("oci")
+                locator.uri.set(Files.readString(producer.output.getAsFile().get().toPath()))
+                return [locator]
+            })
+        """.stripIndent(true)
+
+        when:
+        def buildResult = runTasksSuccessfully('createManifest')
+
+        then:
+        buildResult.wasExecuted(':produceArtifacts')
+        readArtifactsExtension() == [JsonArtifactLocator.from("oci", "registry.example.io/foo/bar:v1.3.0")]
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+    }
+
     private List<JsonArtifactLocator> readArtifactsExtension() {
         def manifest = ObjectMappers.jsonMapper.readValue(file('build/deployment/manifest.yml').text, SlsManifest)
         ObjectMappers.jsonMapper.convertValue(manifest.extensions().get("artifacts"), new TypeReference<List<JsonArtifactLocator>>() {})

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -380,7 +380,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def "#gradleVersionNumber: createManifest depends on task whose artifacts are added to the extension via a provider"() {
+    def "#gradleVersionNumber: createManifest lazily consumes task-produced artifacts added via a provider"() {
         given:
         gradleVersion = gradleVersionNumber
         buildFile << """
@@ -407,7 +407,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
             distribution.artifacts.addAll(produceArtifacts.map { producer ->
                 def locator = project.objects.newInstance(ArtifactLocator)
                 locator.type.set("oci")
-                locator.uri.set(producer.output.map { output -> Files.readString(output.getAsFile().toPath()) })
+                locator.uri.set(Files.readString(producer.output.getAsFile().get().toPath()))
                 return [locator]
             })
         """.stripIndent(true)

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -269,6 +269,43 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
+    def '#gradleVersionNumber: lazily configures matching artifacts'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
+        buildFile << """
+        distribution {
+            artifact {
+                type = "oci"
+                uri = "registry.example.io/foo/bar:v1.3.0"
+            }
+            artifact {
+                type = "other"
+                uri = "registry.example.io/foo/baz:v1.3.0"
+            }
+        }
+
+        distribution.configureArtifacts { artifact ->
+            if (artifact.type.getOrNull() == "oci") {
+                artifact.uri.set("transformed." + artifact.uri.get())
+            }
+        }
+        """.stripIndent(true)
+
+        when:
+        def buildResult = runTasksSuccessfully('createManifest')
+
+        then:
+        buildResult.wasExecuted('createManifest')
+        readArtifactsExtension().toSet() == [
+            JsonArtifactLocator.from("oci", "transformed.registry.example.io/foo/bar:v1.3.0"),
+            JsonArtifactLocator.from("other", "registry.example.io/foo/baz:v1.3.0")
+        ].toSet()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+    }
+
     def '#gradleVersionNumber: fails if invalid'() {
         setup:
         gradleVersion = gradleVersionNumber
@@ -329,6 +366,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                     uri = artifactOutput.flatMap { it.output }.map { Files.readString(it.getAsFile().toPath())}
                 }
             }
+
         """.stripIndent(true)
 
         when:
@@ -342,7 +380,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
-    def "#gradleVersionNumber: createManifest depends on task whose artifacts are added to the extension via addAllLater"() {
+    def "#gradleVersionNumber: createManifest depends on task whose artifacts are added to the extension via a provider"() {
         given:
         gradleVersion = gradleVersionNumber
         buildFile << """
@@ -366,7 +404,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
                 output.fileValue(file("build/artifact-url"))
             }
 
-            distribution.artifacts.addAllLater(produceArtifacts.map { producer ->
+            distribution.artifacts.addAll(produceArtifacts.map { producer ->
                 def locator = project.objects.newInstance(ArtifactLocator)
                 locator.type.set("oci")
                 locator.uri.set(Files.readString(producer.output.getAsFile().get().toPath()))

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -407,7 +407,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
             distribution.artifacts.addAll(produceArtifacts.map { producer ->
                 def locator = project.objects.newInstance(ArtifactLocator)
                 locator.type.set("oci")
-                locator.uri.set(Files.readString(producer.output.getAsFile().get().toPath()))
+                locator.uri.set(producer.output.map { output -> Files.readString(output.getAsFile().toPath()) })
                 return [locator]
             })
         """.stripIndent(true)


### PR DESCRIPTION
## Before this PR

`BaseDistributionExtension` stored artifacts in a `DomainObjectSet<ArtifactLocator>`, and `createManifest` copied them into its task property with:

```java
task.getArtifacts().addAll(ext.getArtifacts());
```

This works for artifacts known during configuration, but not when the collection itself is supplied by a task-backed provider. Although `DomainObjectSet.addAllLater(provider)` defers realisation, `DomainObjectSet` is neither a `Provider` nor `Buildable`: it does not expose the provider's producer metadata to a downstream task. Passing it to `SetProperty.addAll(Iterable)` therefore treats it as an ordinary collection.

For example, if the provider creates an `ArtifactLocator` by reading a producer task's output, Gradle does not add that producer to the task graph. It attempts to evaluate `createManifest.artifacts` while preparing `createManifest`, before the output exists:

```
Execution failed for task ':createManifest'.
> Failed to query the value of task ':createManifest' property 'artifacts'.
   > java.lang.reflect.UndeclaredThrowableException

Caused by: java.nio.file.NoSuchFileException: .../build/artifact-url
```

The producer was not scheduled, so its output could not be read. Fixing this with an explicit `dependsOn` or an unrelated `inputs.files(...)` declaration would duplicate dependency information that should flow through the artifact value itself.

## After this PR
==COMMIT_MSG==
Change the distribution extension's artifacts from a `DomainObjectSet<ArtifactLocator>` to a `SetProperty<ArtifactLocator>`.

`SetProperty` is itself a `Provider` and aggregates producer metadata from values supplied through `add(Provider)` and `addAll(Provider)`. `createManifest` now consumes the configured artifact provider with `set(...)`, so Gradle infers the producing task and only evaluates the collection after that task has completed. No explicit task dependency or separate file input is required.

The task treats the provider-backed collection as a single `@Input` rather than `@Nested`. A nested input requires Gradle to realise the collection in order to discover and traverse each locator before task execution; that cannot work when the collection's contents are constructed by reading another task's output. The aggregate input preserves the producer relationship until input snapshotting.

 `ArtifactLocator` implements Gradle's standard `ProviderConvertible<ArtifactLocator>` contract. Its `asProvider()` implementation combines `type` and `uri` using `zip`, producing a Gradle-owned provider that carries the producers of both properties. The existing `artifact { ... }` methods add this provider to the `SetProperty`, ensuring that a locator with a task-backed `type` or `uri` is also wired correctly.

This keeps the public usage straightforward:

- The `artifact { ... }` DSL is unchanged.
- Static locators can still be added with `artifacts.add(locator)`.
- A task-backed locator can be added with `artifacts.add(locator.asProvider())`.
- A task-backed collection is added with `artifacts.addAll(provider)`; this replaces `DomainObjectSet.addAllLater(provider)`.

Some consumers previously used the live `DomainObjectCollection` API to transform artifacts in place, for example `getArtifacts().matching(spec).configureEach(...)`. `SetProperty` has no equivalent live filtered view, so this PR adds `configureArtifacts(Action<? super ArtifactLocator>)`. Registered actions are applied lazily when the artifact collection is queried, and `createManifest` consumes the resulting `getConfiguredArtifacts()` provider.

Tests cover both lazy shapes: an individual locator whose URI comes from a task output, and a provider that reads a task output while constructing the entire locator collection. They also verify that `configureArtifacts` still transforms the resolved values.
==COMMIT_MSG==

> Note: This is needed to allow for the addition of [ManifestOciArtifactsPlugin](https://github.com/palantir/sls-packaging/pull/2117/changes#diff-524a2e51a932f24430607bce696814865f080be6c49d4d14f6fa433941c4f2feR39) in a future PR

## Possible downsides?

`getArtifacts()` changes its return type from `DomainObjectSet<ArtifactLocator>` to `SetProperty<ArtifactLocator>`. This is a source-breaking change for consumers using `DomainObjectCollection` methods such as `.matching(...).configureEach(...)`; they must migrate to `configureArtifacts(...)` and perform any filtering inside the action.

Similarly, callers using `addLater` or `addAllLater` must use the corresponding `SetProperty.add(provider)` or `SetProperty.addAll(provider)` method. A downstream plugin that rewrites artifact URIs through the old live-collection API will require a follow-up change.
