### PR TITLE
Add project-published OCI artifacts to SLS manifests

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -149,7 +149,7 @@ public class BaseDistributionExtension {
 
     /** Adds a dependency whose published OCI artifacts are included in the manifest. */
     public final Dependency manifestOciArtifacts(Object dependencyNotation) {
-        return project.getDependencies().add(ManifestOciArtifacts.CONFIGURATION_NAME, dependencyNotation);
+        return project.getDependencies().add(ManifestOciArtifacts.DEPENDENCY_SCOPE, dependencyNotation);
     }
 
     /** Adds a project dependency and selects one named OCI coordinates artifact. */
@@ -157,7 +157,7 @@ public class BaseDistributionExtension {
         ModuleDependency dependency = (ModuleDependency) manifestOciArtifacts(dependencyProject);
         dependency.artifact(artifact -> {
             artifact.setName(artifactName);
-            artifact.setType(ManifestOciArtifacts.COORDINATES_ARTIFACT_TYPE);
+            artifact.setType("json");
         });
         return dependency;
     }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -21,6 +21,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.palantir.gradle.dist.artifacts.ArtifactLocator;
+import com.palantir.gradle.dist.artifacts.ManifestOciArtifacts;
 import com.palantir.gradle.dist.pdeps.ProductDependencies;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -37,6 +38,8 @@ import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
@@ -142,6 +145,21 @@ public class BaseDistributionExtension {
 
     public final DomainObjectSet<ArtifactLocator> getArtifacts() {
         return artifacts;
+    }
+
+    /** Adds a dependency whose published OCI artifacts are included in the manifest. */
+    public final Dependency manifestOciArtifacts(Object dependencyNotation) {
+        return project.getDependencies().add(ManifestOciArtifacts.CONFIGURATION_NAME, dependencyNotation);
+    }
+
+    /** Adds a project dependency and selects one named OCI coordinates artifact. */
+    public final ModuleDependency manifestOciArtifacts(Project dependencyProject, String artifactName) {
+        ModuleDependency dependency = (ModuleDependency) manifestOciArtifacts(dependencyProject);
+        dependency.artifact(artifact -> {
+            artifact.setName(artifactName);
+            artifact.setType(ManifestOciArtifacts.COORDINATES_ARTIFACT_TYPE);
+        });
+        return dependency;
     }
 
     /** Lazily configures and adds a {@link ArtifactLocator}. */

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ArtifactLocator.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ArtifactLocator.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.dist.artifacts;
 
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 
 public interface ArtifactLocator {
     @Input
@@ -25,4 +26,9 @@ public interface ArtifactLocator {
 
     @Input
     Property<String> getUri();
+
+    @Internal
+    default boolean isPublished() {
+        return true;
+    }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifacts.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifacts.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.artifacts;
+
+/** Contract between producers of OCI coordinates and SLS distributions which reference them in a manifest. */
+public final class ManifestOciArtifacts {
+
+    /** Declarable configuration where consumers place dependencies on OCI artifact producers. */
+    public static final String CONFIGURATION_NAME = "manifestOciArtifacts";
+
+    /** Internal resolvable configuration used to resolve artifact coordinates. */
+    static final String RESOLVABLE_CONFIGURATION_NAME = "manifestOciArtifactsResolvable";
+
+    /** Usage attribute identifying an OCI artifact coordinates variant. */
+    public static final String USAGE = "sls-manifest-oci-artifacts";
+
+    /** Gradle artifact type used by OCI coordinates files. */
+    public static final String COORDINATES_ARTIFACT_TYPE = "json";
+
+    private ManifestOciArtifacts() {}
+}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifacts.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifacts.java
@@ -16,20 +16,13 @@
 
 package com.palantir.gradle.dist.artifacts;
 
-/** Contract between producers of OCI coordinates and SLS distributions which reference them in a manifest. */
 public final class ManifestOciArtifacts {
-
-    /** Declarable configuration where consumers place dependencies on OCI artifact producers. */
-    public static final String CONFIGURATION_NAME = "manifestOciArtifacts";
-
-    /** Internal resolvable configuration used to resolve artifact coordinates. */
-    static final String RESOLVABLE_CONFIGURATION_NAME = "manifestOciArtifactsResolvable";
-
     /** Usage attribute identifying an OCI artifact coordinates variant. */
     public static final String USAGE = "sls-manifest-oci-artifacts";
 
-    /** Gradle artifact type used by OCI coordinates files. */
-    public static final String COORDINATES_ARTIFACT_TYPE = "json";
+    public static final String DEPENDENCY_SCOPE = "manifestOciArtifacts";
+
+    static final String RESOLVABLE = "manifestOciArtifactsResolvable";
 
     private ManifestOciArtifacts() {}
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
@@ -1,0 +1,126 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.artifacts;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.gradle.dist.BaseDistributionExtension;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import javax.inject.Inject;
+import org.gradle.api.GradleException;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ArtifactCollection;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+
+public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Inject
+    protected abstract ObjectFactory getObjects();
+
+    @Override
+    public final void apply(Project project) {
+        NamedDomainObjectProvider<Configuration> manifestOciArtifacts = project.getConfigurations()
+                .register(ManifestOciArtifacts.CONFIGURATION_NAME, configuration -> {
+                    configuration.setCanBeConsumed(false);
+                    configuration.setCanBeResolved(false);
+                    configuration.setDescription(
+                            "Projects whose published OCI artifacts are added to this project's SLS manifest");
+                });
+
+        NamedDomainObjectProvider<Configuration> manifestOciArtifactsResolvable = project.getConfigurations()
+                .register(ManifestOciArtifacts.RESOLVABLE_CONFIGURATION_NAME, configuration -> {
+                    configuration.setCanBeConsumed(false);
+                    configuration.setCanBeResolved(true);
+                    configuration.extendsFrom(manifestOciArtifacts.get());
+                    configuration
+                            .getAttributes()
+                            .attribute(
+                                    Usage.USAGE_ATTRIBUTE,
+                                    project.getObjects().named(Usage.class, ManifestOciArtifacts.USAGE));
+                });
+
+        Provider<List<ArtifactLocator>> artifactLocators = manifestArtifactLocators(manifestOciArtifactsResolvable);
+        project.getExtensions()
+                .getByType(BaseDistributionExtension.class)
+                .getArtifacts()
+                .addAll(artifactLocators);
+    }
+
+    private Provider<List<ArtifactLocator>> manifestArtifactLocators(
+            NamedDomainObjectProvider<Configuration> resolvable) {
+        return coordinateArtifacts(resolvable)
+                .flatMap(ArtifactCollection::getResolvedArtifacts)
+                .zip(resolvable, this::toArtifactLocators);
+    }
+
+    private static Provider<ArtifactCollection> coordinateArtifacts(
+            NamedDomainObjectProvider<Configuration> resolvable) {
+        return resolvable.map(configuration -> configuration
+                .getIncoming()
+                .artifactView(view -> view.lenient(true))
+                .getArtifacts());
+    }
+
+    private List<ArtifactLocator> toArtifactLocators(
+            Set<ResolvedArtifactResult> coordinateArtifacts, Configuration resolvable) {
+        List<ArtifactLocator> published = coordinateArtifacts.stream()
+                .map(location -> parse(location.getFile().toPath()))
+                .filter(OciArtifactCoordinates::publish)
+                .map(this::artifactLocator)
+                .toList();
+
+        if (published.isEmpty() && !resolvable.getAllDependencies().isEmpty()) {
+            throw noPublishedArtifacts();
+        }
+        return published;
+    }
+
+    private ArtifactLocator artifactLocator(OciArtifactCoordinates coordinates) {
+        ArtifactLocator locator = getObjects().newInstance(ArtifactLocator.class);
+        locator.getType().set(coordinates.type());
+        locator.getUri().set(coordinates.uri());
+        return locator;
+    }
+
+    private static GradleException noPublishedArtifacts() {
+        return new GradleException("""
+            No published OCI artifact coordinates were found for dependencies in the '%s' configuration. A dependency \
+            must expose OCI artifact coordinates as a consumable configuration with the '%s' usage attribute, and at \
+            least one matching artifact must be published.\
+            """.formatted(ManifestOciArtifacts.CONFIGURATION_NAME, ManifestOciArtifacts.USAGE));
+    }
+
+    private static OciArtifactCoordinates parse(Path file) {
+        try {
+            return MAPPER.readValue(Files.readString(file), OciArtifactCoordinates.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read OCI artifact coordinates from " + file, e);
+        }
+    }
+}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
@@ -65,7 +65,8 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
                                     project.getObjects().named(Usage.class, ManifestOciArtifacts.USAGE));
                 });
 
-        Provider<List<ArtifactLocator>> artifactLocators = manifestArtifactLocators(manifestOciArtifactsResolvable);
+        Provider<List<ArtifactLocator>> artifactLocators =
+                manifestArtifactLocators(manifestOciArtifacts, manifestOciArtifactsResolvable);
         project.getExtensions()
                 .getByType(BaseDistributionExtension.class)
                 .getArtifacts()
@@ -73,10 +74,10 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
     }
 
     private Provider<List<ArtifactLocator>> manifestArtifactLocators(
-            NamedDomainObjectProvider<Configuration> resolvable) {
+            NamedDomainObjectProvider<Configuration> declarable, NamedDomainObjectProvider<Configuration> resolvable) {
         return coordinateArtifacts(resolvable)
                 .flatMap(ArtifactCollection::getResolvedArtifacts)
-                .zip(resolvable, this::toArtifactLocators);
+                .zip(declarable, this::toArtifactLocators);
     }
 
     private static Provider<ArtifactCollection> coordinateArtifacts(
@@ -88,14 +89,14 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
     }
 
     private List<ArtifactLocator> toArtifactLocators(
-            Set<ResolvedArtifactResult> coordinateArtifacts, Configuration resolvable) {
+            Set<ResolvedArtifactResult> coordinateArtifacts, Configuration declarable) {
         List<ArtifactLocator> published = coordinateArtifacts.stream()
                 .map(location -> parse(location.getFile().toPath()))
                 .filter(OciArtifactCoordinates::publish)
                 .map(this::artifactLocator)
                 .toList();
 
-        if (published.isEmpty() && !resolvable.getAllDependencies().isEmpty()) {
+        if (published.isEmpty() && !declarable.getDependencies().isEmpty()) {
             throw noPublishedArtifacts();
         }
         return published;

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
@@ -52,7 +52,7 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
 
     @Override
     public final void apply(Project project) {
-        NamedDomainObjectProvider<Configuration> manifestOciArtifacts = project.getConfigurations()
+        NamedDomainObjectProvider<Configuration> declarable = project.getConfigurations()
                 .register(ManifestOciArtifacts.DEPENDENCY_SCOPE, configuration -> {
                     configuration.setCanBeConsumed(false);
                     configuration.setCanBeResolved(false);
@@ -60,11 +60,11 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
                             "Projects whose published OCI artifacts are added to this project's SLS manifest");
                 });
 
-        NamedDomainObjectProvider<Configuration> manifestOciArtifactsResolvable = project.getConfigurations()
+        NamedDomainObjectProvider<Configuration> resolvable = project.getConfigurations()
                 .register(ManifestOciArtifacts.RESOLVABLE, configuration -> {
                     configuration.setCanBeConsumed(false);
                     configuration.setCanBeResolved(true);
-                    configuration.extendsFrom(manifestOciArtifacts.get());
+                    configuration.extendsFrom(declarable.get());
                     configuration
                             .getAttributes()
                             .attribute(
@@ -72,18 +72,11 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
                                     project.getObjects().named(Usage.class, ManifestOciArtifacts.USAGE));
                 });
 
-        Provider<List<ArtifactLocator>> artifactLocators =
-                manifestArtifactLocators(manifestOciArtifacts, manifestOciArtifactsResolvable);
         project.getExtensions()
                 .getByType(BaseDistributionExtension.class)
                 .getArtifacts()
-                .addAllLater(artifactLocators);
-    }
-
-    private Provider<List<ArtifactLocator>> manifestArtifactLocators(
-            NamedDomainObjectProvider<Configuration> declarable, NamedDomainObjectProvider<Configuration> resolvable) {
-        return coordinateArtifacts(resolvable)
-                .flatMap(artifactCollection -> artifactLocators(artifactCollection, declarable));
+                .addAllLater(coordinateArtifacts(resolvable)
+                        .flatMap(artifactCollection -> artifactLocators(artifactCollection, declarable)));
     }
 
     private static Provider<ArtifactCollection> coordinateArtifacts(

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
@@ -53,7 +53,7 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
     @Override
     public final void apply(Project project) {
         NamedDomainObjectProvider<Configuration> manifestOciArtifacts = project.getConfigurations()
-                .register(ManifestOciArtifacts.CONFIGURATION_NAME, configuration -> {
+                .register(ManifestOciArtifacts.DEPENDENCY_SCOPE, configuration -> {
                     configuration.setCanBeConsumed(false);
                     configuration.setCanBeResolved(false);
                     configuration.setDescription(
@@ -61,7 +61,7 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
                 });
 
         NamedDomainObjectProvider<Configuration> manifestOciArtifactsResolvable = project.getConfigurations()
-                .register(ManifestOciArtifacts.RESOLVABLE_CONFIGURATION_NAME, configuration -> {
+                .register(ManifestOciArtifacts.RESOLVABLE, configuration -> {
                     configuration.setCanBeConsumed(false);
                     configuration.setCanBeResolved(true);
                     configuration.extendsFrom(manifestOciArtifacts.get());
@@ -148,7 +148,7 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
             No published OCI artifact coordinates were found for dependencies in the '%s' configuration. A dependency \
             must expose OCI artifact coordinates as a consumable configuration with the '%s' usage attribute, and at \
             least one matching artifact must be published.\
-            """.formatted(ManifestOciArtifacts.CONFIGURATION_NAME, ManifestOciArtifacts.USAGE));
+            """.formatted(ManifestOciArtifacts.DEPENDENCY_SCOPE, ManifestOciArtifacts.USAGE));
     }
 
     private static OciArtifactCoordinates parse(Path file) {

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPlugin.java
@@ -18,12 +18,15 @@ package com.palantir.gradle.dist.artifacts;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.gradle.dist.BaseDistributionExtension;
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
@@ -34,7 +37,11 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 
 public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
 
@@ -70,14 +77,13 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
         project.getExtensions()
                 .getByType(BaseDistributionExtension.class)
                 .getArtifacts()
-                .addAll(artifactLocators);
+                .addAllLater(artifactLocators);
     }
 
     private Provider<List<ArtifactLocator>> manifestArtifactLocators(
             NamedDomainObjectProvider<Configuration> declarable, NamedDomainObjectProvider<Configuration> resolvable) {
         return coordinateArtifacts(resolvable)
-                .flatMap(ArtifactCollection::getResolvedArtifacts)
-                .zip(declarable, this::toArtifactLocators);
+                .flatMap(artifactCollection -> artifactLocators(artifactCollection, declarable));
     }
 
     private static Provider<ArtifactCollection> coordinateArtifacts(
@@ -88,25 +94,53 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
                 .getArtifacts());
     }
 
-    private List<ArtifactLocator> toArtifactLocators(
-            Set<ResolvedArtifactResult> coordinateArtifacts, Configuration declarable) {
-        List<ArtifactLocator> published = coordinateArtifacts.stream()
-                .map(location -> parse(location.getFile().toPath()))
-                .filter(OciArtifactCoordinates::publish)
-                .map(this::artifactLocator)
-                .toList();
+    private Provider<List<ArtifactLocator>> artifactLocators(
+            ArtifactCollection artifactCollection, Provider<Configuration> declarable) {
+        Provider<Set<ResolvedArtifactResult>> artifacts = artifactCollection.getResolvedArtifacts();
+        MapProperty<File, OciArtifactCoordinates> coordinatesByFile =
+                getObjects().mapProperty(File.class, OciArtifactCoordinates.class);
+        coordinatesByFile.set(artifacts.map(ManifestOciArtifactsPlugin::parseAndValidateArtifacts));
+        coordinatesByFile.finalizeValueOnRead();
 
-        if (published.isEmpty() && !declarable.getDependencies().isEmpty()) {
-            throw noPublishedArtifacts();
-        }
-        return published;
+        return artifacts.zip(
+                declarable,
+                (resolvedArtifacts, configuration) ->
+                        createArtifactLocators(resolvedArtifacts, configuration, coordinatesByFile));
     }
 
-    private ArtifactLocator artifactLocator(OciArtifactCoordinates coordinates) {
-        ArtifactLocator locator = getObjects().newInstance(ArtifactLocator.class);
-        locator.getType().set(coordinates.type());
-        locator.getUri().set(coordinates.uri());
+    private List<ArtifactLocator> createArtifactLocators(
+            Set<ResolvedArtifactResult> artifacts,
+            Configuration declarable,
+            MapProperty<File, OciArtifactCoordinates> coordinatesByFile) {
+        if (artifacts.isEmpty() && !declarable.getDependencies().isEmpty()) {
+            throw noPublishedArtifacts();
+        }
+
+        return artifacts.stream()
+                .map(ResolvedArtifactResult::getFile)
+                .map(coordinatesByFile::getting)
+                .map(this::artifactLocator)
+                .toList();
+    }
+
+    private ArtifactLocator artifactLocator(Provider<OciArtifactCoordinates> coordinates) {
+        PublishedOciArtifactLocator locator = getObjects().newInstance(PublishedOciArtifactLocator.class);
+        locator.getType().set(coordinates.map(OciArtifactCoordinates::type));
+        locator.getUri().set(coordinates.map(OciArtifactCoordinates::uri));
+        locator.getPublish().set(coordinates.map(OciArtifactCoordinates::publish));
         return locator;
+    }
+
+    private static Map<File, OciArtifactCoordinates> parseAndValidateArtifacts(
+            Set<ResolvedArtifactResult> artifactResults) {
+        Map<File, OciArtifactCoordinates> artifacts = artifactResults.stream()
+                .collect(Collectors.toMap(
+                        ResolvedArtifactResult::getFile,
+                        artifact -> parse(artifact.getFile().toPath())));
+        if (artifacts.values().stream().noneMatch(OciArtifactCoordinates::publish)) {
+            throw noPublishedArtifacts();
+        }
+        return artifacts;
     }
 
     private static GradleException noPublishedArtifacts() {
@@ -122,6 +156,17 @@ public abstract class ManifestOciArtifactsPlugin implements Plugin<Project> {
             return MAPPER.readValue(Files.readString(file), OciArtifactCoordinates.class);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read OCI artifact coordinates from " + file, e);
+        }
+    }
+
+    interface PublishedOciArtifactLocator extends ArtifactLocator {
+        @Input
+        Property<Boolean> getPublish();
+
+        @Override
+        @Internal
+        default boolean isPublished() {
+            return getPublish().get();
         }
     }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/OciArtifactCoordinates.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/OciArtifactCoordinates.java
@@ -18,13 +18,15 @@ package com.palantir.gradle.dist.artifacts;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 /** Coordinates of a single OCI artifact published by a producer. */
 @Value.Immutable
 @JsonDeserialize(as = ImmutableOciArtifactCoordinates.class)
+@JsonSerialize(as = ImmutableOciArtifactCoordinates.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-interface OciArtifactCoordinates {
+public interface OciArtifactCoordinates {
 
     @Value.Parameter
     String type();
@@ -34,4 +36,8 @@ interface OciArtifactCoordinates {
 
     @Value.Parameter
     boolean publish();
+
+    static OciArtifactCoordinates of(String type, String uri, boolean publish) {
+        return ImmutableOciArtifactCoordinates.of(type, uri, publish);
+    }
 }

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/OciArtifactCoordinates.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/artifacts/OciArtifactCoordinates.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.artifacts;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/** Coordinates of a single OCI artifact published by a producer. */
+@Value.Immutable
+@JsonDeserialize(as = ImmutableOciArtifactCoordinates.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+interface OciArtifactCoordinates {
+
+    @Value.Parameter
+    String type();
+
+    @Value.Parameter
+    String uri();
+
+    @Value.Parameter
+    boolean publish();
+}

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/asset/AssetDistributionPlugin.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.dist.asset;
 import com.palantir.gradle.dist.DeploymentDirInclusion;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.SlsBaseDistPlugin;
+import com.palantir.gradle.dist.artifacts.ManifestOciArtifactsPlugin;
 import com.palantir.gradle.dist.service.JavaServiceDistributionPlugin;
 import com.palantir.gradle.dist.tasks.ConfigTarTask;
 import com.palantir.gradle.dist.tasks.CreateManifestTask;
@@ -57,6 +58,7 @@ public final class AssetDistributionPlugin implements Plugin<Project> {
         @SuppressWarnings({"for-rollout:GradleTypesAsFields", "for-rollout:NonAbstractGradleType"})
         AssetDistributionExtension distributionExtension =
                 project.getExtensions().create("distribution", AssetDistributionExtension.class, project);
+        project.getPluginManager().apply(ManifestOciArtifactsPlugin.class);
         distributionExtension.setProductDependenciesConfig(assetConfiguration);
 
         TaskProvider<CreateManifestTask> manifest =

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/JavaServiceDistributionPlugin.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.palantir.gradle.dist.ProductDependencyIntrospectionPlugin;
 import com.palantir.gradle.dist.SlsBaseDistPlugin;
+import com.palantir.gradle.dist.artifacts.ManifestOciArtifactsPlugin;
 import com.palantir.gradle.dist.asset.AssetDistributionPlugin;
 import com.palantir.gradle.dist.service.tasks.CreateCheckScriptTask;
 import com.palantir.gradle.dist.service.tasks.CreateInitScriptTask;
@@ -81,6 +82,7 @@ public final class JavaServiceDistributionPlugin implements Plugin<Project> {
         @SuppressWarnings({"for-rollout:GradleTypesAsFields", "for-rollout:NonAbstractGradleType"})
         JavaServiceDistributionExtension distributionExtension =
                 project.getExtensions().create("distribution", JavaServiceDistributionExtension.class, project);
+        project.getPluginManager().apply(ManifestOciArtifactsPlugin.class);
 
         // In baseline 3.52.0 we added this new plugin as a one-liner to add the --enable-preview flag wherever
         // necessary (https://github.com/palantir/gradle-baseline/pull/1549). We're using the extraProperties thing to

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -173,6 +173,7 @@ public abstract class CreateManifestTask extends DefaultTask {
                         .putExtensions(
                                 "artifacts",
                                 getArtifacts().get().stream()
+                                        .filter(ArtifactLocator::isPublished)
                                         .map(JsonArtifactLocator::from)
                                         .collect(Collectors.toList()))
                         .build());

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
@@ -178,7 +178,7 @@ class ManifestOciArtifactsPluginTests {
             """);
         addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
         consumer.buildGradle().append("""
-            distribution.configureArtifacts { artifact ->
+            distribution.artifacts.configureEach { artifact ->
                 artifact.uri.set(artifact.uri.get().replace('registry.example.com', 'mirror.example.com'))
             }
             """);

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
@@ -163,7 +163,7 @@ class ManifestOciArtifactsPluginTests {
             configurations.named('%s').configure {
                 throw new GradleException('OCI artifact configuration was realized')
             }
-            """, ManifestOciArtifacts.RESOLVABLE_CONFIGURATION_NAME);
+            """, ManifestOciArtifacts.RESOLVABLE);
 
         gradle.withArgs("help").buildsSuccessfully();
     }
@@ -202,7 +202,7 @@ class ManifestOciArtifactsPluginTests {
 
         assertThat(failure.output())
                 .contains("No published OCI artifact coordinates")
-                .contains(ManifestOciArtifacts.CONFIGURATION_NAME);
+                .contains(ManifestOciArtifacts.DEPENDENCY_SCOPE);
     }
 
     @Test

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
@@ -147,11 +147,11 @@ class ManifestOciArtifactsPluginTests {
                 manifestOciArtifacts project(':producer')
             }
             """);
-        addImageBuiltByTask(producer, "generateCoordinates", "image-a", "registry.example.com/group/image-a:1.0.0");
+        addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
 
         InvocationResult result = gradle.withArgs("createManifest").buildsSuccessfully();
 
-        result.assertThat().task(":producer:generateCoordinates").succeeded();
+        result.assertThat().task(":producer:image-a").succeeded();
         assertThat(manifestArtifacts(consumer))
                 .containsExactly(JsonArtifactLocator.from("oci", "registry.example.com/group/image-a:1.0.0"));
     }
@@ -169,7 +169,7 @@ class ManifestOciArtifactsPluginTests {
     }
 
     @Test
-    void applies_distribution_artifact_configuration_to_resolved_artifacts(
+    void applies_matching_distribution_artifact_configuration_to_resolved_artifacts(
             GradleInvoker gradle, RootProject consumer, SubProject producer) throws IOException {
         consumer.buildGradle().append("""
             distribution {
@@ -177,16 +177,28 @@ class ManifestOciArtifactsPluginTests {
             }
             """);
         addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
+        addImage(producer, "image-b", "other.example.com/group/image-b:1.0.0", true);
         consumer.buildGradle().append("""
-            distribution.artifacts.configureEach { artifact ->
-                artifact.uri.set(artifact.uri.get().replace('registry.example.com', 'mirror.example.com'))
-            }
+            distribution.artifacts
+                    .matching { artifact ->
+                        artifact.type != null &&
+                                artifact.type.getOrNull() == 'oci' &&
+                                artifact.uri != null &&
+                                artifact.uri.getOrNull() != null &&
+                                artifact.uri.getOrNull().startsWith('registry.example.com/')
+                    }
+                    .configureEach { artifact ->
+                        artifact.uri.set(artifact.uri.get().replaceFirst(
+                                'registry.example.com', 'mirror.example.com'))
+                    }
             """);
 
         gradle.withArgs("createManifest").buildsSuccessfully();
 
         assertThat(manifestArtifacts(consumer))
-                .containsExactly(JsonArtifactLocator.from("oci", "mirror.example.com/group/image-a:1.0.0"));
+                .containsExactlyInAnyOrder(
+                        JsonArtifactLocator.from("oci", "mirror.example.com/group/image-a:1.0.0"),
+                        JsonArtifactLocator.from("oci", "other.example.com/group/image-b:1.0.0"));
     }
 
     @Test
@@ -229,30 +241,14 @@ class ManifestOciArtifactsPluginTests {
     private static void addImage(SubProject producer, String name, String uri, boolean publish) {
         producer.buildGradle().append("""
             configurations.manifestOciArtifactsElements.outgoing.artifact(
-                    layout.buildDirectory.file("coords/%1$s.json").get().asFile.tap {
-                        it.parentFile.mkdirs()
-                        it.text = '{"type":"oci","uri":"%2$s","publish":%3$b}'
-                    })
+                    tasks.register('%1$s') {
+                        outputs.file(layout.buildDirectory.file("coords/${name}.json"))
+                        doLast {
+                            outputs.files.singleFile.parentFile.mkdirs()
+                            outputs.files.singleFile.text = '{"type":"oci","uri":"%2$s","publish":%3$b}'
+                        }
+                    }.map { coordinatesTask -> coordinatesTask.outputs.files.singleFile })
             """, name, uri, publish);
-    }
-
-    private static void addImageBuiltByTask(SubProject producer, String taskName, String name, String uri) {
-        producer.buildGradle().append("""
-            def %1$s = tasks.register('%1$s') {
-                def outputFile = layout.buildDirectory.file('coords/%2$s.json')
-                outputs.file(outputFile)
-                doLast {
-                    def file = outputFile.get().asFile
-                    file.parentFile.mkdirs()
-                    file.text = '{"type":"oci","uri":"%3$s","publish":true}'
-                }
-            }
-            configurations.manifestOciArtifactsElements.outgoing.artifact(%1$s.map {
-                it.outputs.files.singleFile
-            }) {
-                builtBy %1$s
-            }
-            """, taskName, name, uri);
     }
 
     private static List<JsonArtifactLocator> manifestArtifacts(GradleProject project) throws IOException {

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
@@ -1,0 +1,269 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.dist.artifacts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.execution.InvocationResult;
+import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.GradleProject;
+import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.SubProject;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+@DisabledConfigurationCache
+class ManifestOciArtifactsPluginTests {
+
+    private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
+
+    @BeforeEach
+    void before(RootProject consumer, SubProject producer) {
+        consumer.buildGradle().plugins().add("com.palantir.sls-java-service-distribution");
+        consumer.buildGradle().append("""
+            project.version = '1.0.0'
+            distribution {
+                serviceName 'consumer-service'
+                serviceGroup 'service-group'
+            }
+            """);
+
+        producer.buildGradle().append("""
+            import org.gradle.api.attributes.Usage
+
+            group = 'com.example'
+            version = '2.0.0'
+
+            configurations.consumable('manifestOciArtifactsElements') {
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, '%s'))
+                }
+            }
+            """, ManifestOciArtifacts.USAGE);
+    }
+
+    @Test
+    void adds_all_published_coordinates_from_a_project_dependency(
+            GradleInvoker gradle, RootProject consumer, SubProject producer) throws IOException {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer')
+            }
+            """);
+        addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
+        addImage(producer, "image-b", "registry.example.com/group/image-b:1.0.0", true);
+
+        gradle.withArgs("createManifest").buildsSuccessfully();
+
+        assertThat(manifestArtifacts(consumer))
+                .containsExactlyInAnyOrder(
+                        JsonArtifactLocator.from("oci", "registry.example.com/group/image-a:1.0.0"),
+                        JsonArtifactLocator.from("oci", "registry.example.com/group/image-b:1.0.0"));
+    }
+
+    @Test
+    void excludes_coordinates_not_marked_for_publication(
+            GradleInvoker gradle, RootProject consumer, SubProject producer) throws IOException {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer')
+            }
+            """);
+        addImage(producer, "published", "registry.example.com/group/published:1.0.0", true);
+        addImage(producer, "unpublished", "registry.example.com/group/unpublished:1.0.0", false);
+
+        gradle.withArgs("createManifest").buildsSuccessfully();
+
+        assertThat(manifestArtifacts(consumer))
+                .containsExactly(JsonArtifactLocator.from("oci", "registry.example.com/group/published:1.0.0"));
+    }
+
+    @Test
+    void selects_an_artifact_by_name(GradleInvoker gradle, RootProject consumer, SubProject producer)
+            throws IOException {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer'), 'image-a'
+            }
+            """);
+        addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
+        addImage(producer, "image-b", "registry.example.com/group/image-b:1.0.0", true);
+
+        gradle.withArgs("createManifest").buildsSuccessfully();
+
+        assertThat(manifestArtifacts(consumer))
+                .containsExactly(JsonArtifactLocator.from("oci", "registry.example.com/group/image-a:1.0.0"));
+    }
+
+    @Test
+    void combines_direct_and_resolved_artifacts(GradleInvoker gradle, RootProject consumer, SubProject producer)
+            throws IOException {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer')
+                artifact {
+                    type = 'direct'
+                    uri = 'https://example.com/direct-artifact'
+                }
+            }
+            """);
+        addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
+
+        gradle.withArgs("createManifest").buildsSuccessfully();
+
+        assertThat(manifestArtifacts(consumer))
+                .containsExactlyInAnyOrder(
+                        JsonArtifactLocator.from("direct", "https://example.com/direct-artifact"),
+                        JsonArtifactLocator.from("oci", "registry.example.com/group/image-a:1.0.0"));
+    }
+
+    @Test
+    void runs_the_coordinate_producer_through_artifact_dependency_inference(
+            GradleInvoker gradle, RootProject consumer, SubProject producer) throws IOException {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer')
+            }
+            """);
+        addImageBuiltByTask(producer, "generateCoordinates", "image-a", "registry.example.com/group/image-a:1.0.0");
+
+        InvocationResult result = gradle.withArgs("createManifest").buildsSuccessfully();
+
+        result.assertThat().task(":producer:generateCoordinates").succeeded();
+        assertThat(manifestArtifacts(consumer))
+                .containsExactly(JsonArtifactLocator.from("oci", "registry.example.com/group/image-a:1.0.0"));
+    }
+
+    @Test
+    void does_not_realize_the_resolvable_configuration_for_an_unrelated_task(
+            GradleInvoker gradle, RootProject consumer) {
+        consumer.buildGradle().append("""
+            configurations.named('%s').configure {
+                throw new GradleException('OCI artifact configuration was realized')
+            }
+            """, ManifestOciArtifacts.RESOLVABLE_CONFIGURATION_NAME);
+
+        gradle.withArgs("help").buildsSuccessfully();
+    }
+
+    @Test
+    void applies_distribution_artifact_configuration_to_resolved_artifacts(
+            GradleInvoker gradle, RootProject consumer, SubProject producer) throws IOException {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer')
+            }
+            """);
+        addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
+        consumer.buildGradle().append("""
+            distribution.configureArtifacts { artifact ->
+                artifact.uri.set(artifact.uri.get().replace('registry.example.com', 'mirror.example.com'))
+            }
+            """);
+
+        gradle.withArgs("createManifest").buildsSuccessfully();
+
+        assertThat(manifestArtifacts(consumer))
+                .containsExactly(JsonArtifactLocator.from("oci", "mirror.example.com/group/image-a:1.0.0"));
+    }
+
+    @Test
+    void fails_when_all_coordinates_are_unpublished(GradleInvoker gradle, RootProject consumer, SubProject producer) {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer')
+            }
+            """);
+        addImage(producer, "unpublished", "registry.example.com/group/unpublished:1.0.0", false);
+
+        InvocationResult failure = gradle.withArgs("createManifest").buildsWithFailure();
+
+        assertThat(failure.output())
+                .contains("No published OCI artifact coordinates")
+                .contains(ManifestOciArtifacts.CONFIGURATION_NAME);
+    }
+
+    @Test
+    void fails_when_a_dependency_exposes_no_matching_coordinates_variant(
+            GradleInvoker gradle, RootProject consumer, SubProject producer) {
+        consumer.buildGradle().append("""
+            distribution {
+                manifestOciArtifacts project(':producer')
+            }
+            """);
+        producer.buildGradle().append("""
+            configurations.manifestOciArtifactsElements.attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'some-other-usage'))
+            }
+            """);
+
+        InvocationResult failure = gradle.withArgs("createManifest").buildsWithFailure();
+
+        assertThat(failure.output())
+                .contains("No published OCI artifact coordinates")
+                .contains(ManifestOciArtifacts.USAGE);
+    }
+
+    private static void addImage(SubProject producer, String name, String uri, boolean publish) {
+        producer.buildGradle().append("""
+            configurations.manifestOciArtifactsElements.outgoing.artifact(
+                    layout.buildDirectory.file("coords/%1$s.json").get().asFile.tap {
+                        it.parentFile.mkdirs()
+                        it.text = '{"type":"oci","uri":"%2$s","publish":%3$b}'
+                    })
+            """, name, uri, publish);
+    }
+
+    private static void addImageBuiltByTask(SubProject producer, String taskName, String name, String uri) {
+        producer.buildGradle().append("""
+            def %1$s = tasks.register('%1$s') {
+                def outputFile = layout.buildDirectory.file('coords/%2$s.json')
+                outputs.file(outputFile)
+                doLast {
+                    def file = outputFile.get().asFile
+                    file.parentFile.mkdirs()
+                    file.text = '{"type":"oci","uri":"%3$s","publish":true}'
+                }
+            }
+            configurations.manifestOciArtifactsElements.outgoing.artifact(%1$s.map {
+                it.outputs.files.singleFile
+            }) {
+                builtBy %1$s
+            }
+            """, taskName, name, uri);
+    }
+
+    private static List<JsonArtifactLocator> manifestArtifacts(GradleProject project) throws IOException {
+        Manifest manifest =
+                YAML.readValue(project.file("build/deployment/manifest.yml").text(), Manifest.class);
+        return manifest.extensions().artifacts();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record Manifest(Extensions extensions) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record Extensions(List<JsonArtifactLocator> artifacts) {}
+}

--- a/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
+++ b/gradle-sls-packaging/src/test/java/com/palantir/gradle/dist/artifacts/ManifestOciArtifactsPluginTests.java
@@ -179,18 +179,15 @@ class ManifestOciArtifactsPluginTests {
         addImage(producer, "image-a", "registry.example.com/group/image-a:1.0.0", true);
         addImage(producer, "image-b", "other.example.com/group/image-b:1.0.0", true);
         consumer.buildGradle().append("""
-            distribution.artifacts
-                    .matching { artifact ->
-                        artifact.type != null &&
-                                artifact.type.getOrNull() == 'oci' &&
-                                artifact.uri != null &&
-                                artifact.uri.getOrNull() != null &&
-                                artifact.uri.getOrNull().startsWith('registry.example.com/')
+            distribution.artifacts.configureEach { artifact ->
+                artifact.uri.replace { uri ->
+                    uri.map { value ->
+                        'oci' == artifact.type.getOrNull() && value.startsWith('registry.example.com/')
+                                ? value.replaceFirst('registry.example.com', 'mirror.example.com')
+                                : value
                     }
-                    .configureEach { artifact ->
-                        artifact.uri.set(artifact.uri.get().replaceFirst(
-                                'registry.example.com', 'mirror.example.com'))
-                    }
+                }
+            }
             """);
 
         gradle.withArgs("createManifest").buildsSuccessfully();

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,43 @@ distribution {
 }
 ```
 
-The result will be embedded in the `deployment/manifest.yml` file. The file will look something like this:
+#### Container images published by another project
+
+OCI coordinates published by another project can be added without manually copying their URI into the distribution:
+
+```groovy
+distribution {
+    manifestOciArtifacts project(':images')
+}
+```
+
+This adds every coordinate from `:images` whose JSON has `publish` set to `true`. To add only one published artifact, supply its outgoing artifact name:
+
+```groovy
+distribution {
+    manifestOciArtifacts project(':images'), 'image-a'
+}
+```
+
+The producer must expose the coordinates from a consumable configuration with the `sls-manifest-oci-artifacts` usage attribute. Each outgoing artifact must be a JSON file containing the manifest artifact type, URI, and whether it should be published, for example:
+
+```json
+{
+  "type": "oci",
+  "uri": "registry.example.io/foo/image-a:v1.3.0",
+  "publish": true
+}
+```
+
+Java producers can create this document using the public coordinate type:
+
+```java
+OciArtifactCoordinates coordinates = OciArtifactCoordinates.of("oci", imageUri, true);
+```
+
+#### Manifest output
+
+In both cases, the result is embedded in `deployment/manifest.yml`. The file will look something like this:
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,7 @@ This adds every coordinate from `:images` whose JSON has `publish` set to `true`
 
 ```groovy
 distribution {
-    manifestOciArtifacts project(':images'), 'image-a'
+    manifestOciArtifacts project(':images'), 'bar'
 }
 ```
 
@@ -213,7 +213,7 @@ The producer must expose the coordinates from a consumable configuration with th
 ```json
 {
   "type": "oci",
-  "uri": "registry.example.io/foo/image-a:v1.3.0",
+  "uri": "registry.example.io/foo/bar:v1.3.0",
   "publish": true
 }
 ```
@@ -221,7 +221,8 @@ The producer must expose the coordinates from a consumable configuration with th
 Java producers can create this document using the public coordinate type:
 
 ```java
-OciArtifactCoordinates coordinates = OciArtifactCoordinates.of("oci", imageUri, true);
+OciArtifactCoordinates coordinates =
+        OciArtifactCoordinates.of("oci", "registry.example.io/foo/bar:v1.3.0", true);
 ```
 
 #### Manifest output


### PR DESCRIPTION
## Before this PR

SLS distributions can declare a container image only when its URI is already known in the consuming project. There is no dependency-based way to add OCI coordinates published by another project, so integrations must resolve producer outputs themselves and risk realising values before the producing task has run.

## After this PR

SLS distributions can use `manifestOciArtifacts project(':images')` to include every published OCI coordinate from another project, or `manifestOciArtifacts project(':images'), 'bar'` to select one named artifact.

Coordinates are resolved lazily from the producer's `sls-manifest-oci-artifacts` variant, preserving producer task dependencies. Coordinates with `publish: false` are excluded, and Java producers can create coordinate documents using `OciArtifactCoordinates.of(...)`.

==COMMIT_MSG==
==COMMIT_MSG==

## Testing

- `./gradlew test`
- `./gradlew format compileAllErrorProne checkstyleMain checkstyleTest --continue -PerrorProneApply`

## Possible downsides?

None known. Projects must opt into the new `manifestOciArtifacts` dependency.

## Are Docs needed?

Yes. The README documents both dependency forms, the producer contract, and the public coordinate factory.
