### PR TITLE
`product-dependencies.lock` lists required dependencies before optional ones

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/ProductDependencyLockFile.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.dist;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.Splitter;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -56,15 +57,21 @@ public final class ProductDependencyLockFile {
     public static String asString(
             ProductId productId, List<ProductDependency> deps, Set<ProductId> servicesDeclaredInProject) {
         return deps.stream()
-                .map(dep -> String.format(
-                        "%s:%s (%s, %s)%s",
-                        dep.getProductGroup(),
-                        dep.getProductName(),
-                        renderDepMinimumVersion(servicesDeclaredInProject, dep),
-                        dep.getMaximumVersion(),
-                        dep.getOptional() ? " optional" : ""))
-                .sorted()
+                // Required dependencies are listed before optional ones; each group is sorted alphabetically.
+                .sorted(Comparator.comparing(ProductDependency::getOptional)
+                        .thenComparing(dep -> renderLine(dep, servicesDeclaredInProject)))
+                .map(dep -> renderLine(dep, servicesDeclaredInProject))
                 .collect(Collectors.joining("\n", HEADER + PRODUCT_ID_PREFIX + productId + "\n", "\n"));
+    }
+
+    private static String renderLine(ProductDependency dep, Set<ProductId> servicesDeclaredInProject) {
+        return String.format(
+                "%s:%s (%s, %s)%s",
+                dep.getProductGroup(),
+                dep.getProductName(),
+                renderDepMinimumVersion(servicesDeclaredInProject, dep),
+                dep.getMaximumVersion(),
+                dep.getOptional() ? " optional" : "");
     }
 
     /**

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -38,6 +38,27 @@ class ProductDependencyLockFileTest extends Specification {
         """.stripIndent(true)
     }
 
+    def 'serialize lists all required dependencies before optional ones'() {
+        when:
+        List<ProductDependency> sample = [
+                new ProductDependency("com.example", "product-a", "1.0.0", "1.x.x", null, true),
+                new ProductDependency("com.example", "product-b", "2.0.0", "2.x.x", null),
+                new ProductDependency("com.example", "product-c", "3.0.0", "3.x.x", null, true),
+                new ProductDependency("com.example", "product-d", "4.0.0", "4.x.x", null),
+        ]
+
+        then:
+        // Required product-b and product-d come first, then optional product-a and product-c; each group is alphabetical.
+        ProductDependencyLockFile.asString(new ProductId("com.example", "my-service"), sample, [] as Set<ProductId>) == """\
+        # Run ./gradlew writeProductDependenciesLocks to regenerate this file
+        product-id: com.example:my-service
+        com.example:product-b (2.0.0, 2.x.x)
+        com.example:product-d (4.0.0, 4.x.x)
+        com.example:product-a (1.0.0, 1.x.x) optional
+        com.example:product-c (3.0.0, 3.x.x) optional
+        """.stripIndent(true)
+    }
+
     def 'serialize project version'() {
         when:
         def result = ProductDependencyLockFile.asString(

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/ProductDependencyLockFileTest.groovy
@@ -29,11 +29,12 @@ class ProductDependencyLockFileTest extends Specification {
         ]
 
         then:
+        // The required dependency comes first even though the optional one sorts earlier alphabetically.
         ProductDependencyLockFile.asString(new ProductId("com.palantir.test", "my-service"), sample, [] as Set<ProductId>) == """\
         # Run ./gradlew writeProductDependenciesLocks to regenerate this file
         product-id: com.palantir.test:my-service
-        com.palantir.other:bar (0.2.0, 0.x.x) optional
         com.palantir.product:foo (1.20.0, 1.x.x)
+        com.palantir.other:bar (0.2.0, 0.x.x) optional
         """.stripIndent(true)
     }
 

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ com.palantir.email:email-service (1.200.3, 2.x.x) optional
 
 _The `$projectVersion` string is a placeholder that will appear if your repo publishes multiple services, and one of them depends on another.  The actual manifest will contain a concrete version._
 
-The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default. Required dependencies are listed first, followed by optional ones, so that reviewers can see the required set at a glance.
+The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default. Required dependencies are listed first, followed by optional ones, so that reviewers can see the required set at a glance. The lockfile represents an unordered set of product dependencies: nothing that reads it relies on line order, so this ordering exists only to keep diffs stable and reviews easy.
 
 It's possible to further restrict the acceptable version range for a dependency by declaring a tighter constraint in a
 `productDependency` block - this will be merged with any constraints detected from other jars.

--- a/readme.md
+++ b/readme.md
@@ -78,19 +78,19 @@ distribution {
 ```
 
 #### Product dependencies lock file
-`sls-packaging` also maintains a lockfile, `product-dependencies.lock`, which should be checked in to Git.  This file is an accurate reflection of all the inferred and explicitly defined product dependencies. Run **`./gradlew --write-locks`** or **`./gradlew writeProductDependenciesLocks`** to update it. e.g.
+`sls-packaging` also maintains a lockfile, `product-dependencies.lock`, which should be checked in to Git.  This file is an accurate reflection of all the inferred and explicitly defined product dependencies. It exists so that product dependency changes surface in code review; nothing reads it at deploy time, because the packaged `manifest.yml` is generated separately. Run **`./gradlew --write-locks`** or **`./gradlew writeProductDependenciesLocks`** to update it. e.g.
 
 ```
 # Run ./gradlew writeProductDependenciesLocks to regenerate this file
 com.palantir.auth:auth-service (1.2.0, 1.6.x)
+com.palantir.foo:foo-service ($projectVersion, 1.x.x)
 com.palantir.storage:storage-service (3.56.0, 3.x.x)
 com.palantir.email:email-service (1.200.3, 2.x.x) optional
-com.palantir.foo:foo-service ($projectVersion, 1.x.x)
 ```
 
 _The `$projectVersion` string is a placeholder that will appear if your repo publishes multiple services, and one of them depends on another.  The actual manifest will contain a concrete version._
 
-The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default.
+The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default. Required dependencies are listed first, followed by optional ones, so that reviewers can see the required set at a glance.
 
 It's possible to further restrict the acceptable version range for a dependency by declaring a tighter constraint in a
 `productDependency` block - this will be merged with any constraints detected from other jars.

--- a/readme.md
+++ b/readme.md
@@ -78,19 +78,19 @@ distribution {
 ```
 
 #### Product dependencies lock file
-`sls-packaging` also maintains a lockfile, `product-dependencies.lock`, which should be checked in to Git.  This file is an accurate reflection of all the inferred and explicitly defined product dependencies. It exists so that product dependency changes surface in code review; nothing reads it at deploy time, because the packaged `manifest.yml` is generated separately. Run **`./gradlew --write-locks`** or **`./gradlew writeProductDependenciesLocks`** to update it. e.g.
+`sls-packaging` also maintains a lockfile, `product-dependencies.lock`, which should be checked in to Git. This file accurately reflects all inferred and explicitly defined product dependencies. Run **`./gradlew --write-locks`** or **`./gradlew writeProductDependenciesLocks`** to update it. e.g.
 
 ```
 # Run ./gradlew writeProductDependenciesLocks to regenerate this file
 com.palantir.auth:auth-service (1.2.0, 1.6.x)
-com.palantir.foo:foo-service ($projectVersion, 1.x.x)
 com.palantir.storage:storage-service (3.56.0, 3.x.x)
 com.palantir.email:email-service (1.200.3, 2.x.x) optional
+com.palantir.foo:foo-service ($projectVersion, 1.x.x)
 ```
 
 _The `$projectVersion` string is a placeholder that will appear if your repo publishes multiple services, and one of them depends on another.  The actual manifest will contain a concrete version._
 
-The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default. Required dependencies are listed first, followed by optional ones, so that reviewers can see the required set at a glance. The lockfile represents an unordered set of product dependencies: nothing that reads it relies on line order, so this ordering exists only to keep diffs stable and reviews easy.
+The suffix `optional` will be added for `optional = true` in the `productDependency` declaration. All dependencies are required by default. The ordering of dependencies in the lockfile does not matter.
 
 It's possible to further restrict the acceptable version range for a dependency by declaring a tighter constraint in a
 `productDependency` block - this will be merged with any constraints detected from other jars.


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
```
com.palantir:pdep-a (1.0.0, 1.x.x) optional
com.palantir:pdep-b (1.0.0, 1.x.x)
com.palantir:pdep-c (4.0.0, 4.x.x) optional
```

There's a marker for optional pdeps but not for required ones. this makes it hard to ctrl+f for required pdeps in a large lockfile

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`product-dependencies.lock` lists required dependencies before optional ones
==COMMIT_MSG==

Explicate that product-dependencies.lock is a set in the README. 