### PR TITLE
Allow manifest artifact registries to be overridden

### DIFF
--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -65,6 +65,7 @@ public class BaseDistributionExtension {
     private final SetProperty<ProductId> optionalProductDependencies;
     private final SetProperty<ProductId> ignoredProductDependencies;
     private final DomainObjectSet<ArtifactLocator> artifacts;
+    private final MapProperty<String, String> registryOverrides;
     private final ProviderFactory providerFactory;
     private final MapProperty<String, Object> manifestExtensions;
     private final RegularFileProperty configurationYml;
@@ -83,6 +84,8 @@ public class BaseDistributionExtension {
         optionalProductDependencies = project.getObjects().setProperty(ProductId.class);
         ignoredProductDependencies = project.getObjects().setProperty(ProductId.class);
         artifacts = project.getObjects().domainObjectSet(ArtifactLocator.class);
+        registryOverrides =
+                project.getObjects().mapProperty(String.class, String.class).empty();
         consumableProductDependenciesConfigurationName = project.getObjects().property(String.class);
 
         serviceGroup.set(project.provider(() -> project.getGroup().toString()));
@@ -142,6 +145,14 @@ public class BaseDistributionExtension {
 
     public final DomainObjectSet<ArtifactLocator> getArtifacts() {
         return artifacts;
+    }
+
+    /**
+     * Maps artifact registries to the registries written to the generated manifest. When the same source registry is
+     * configured more than once, the last override wins.
+     */
+    public final MapProperty<String, String> getRegistryOverrides() {
+        return registryOverrides;
     }
 
     /** Lazily configures and adds a {@link ArtifactLocator}. */

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/BaseDistributionExtension.java
@@ -148,8 +148,8 @@ public class BaseDistributionExtension {
     }
 
     /**
-     * Maps artifact registries to the registries written to the generated manifest. When the same source registry is
-     * configured more than once, the last override wins.
+     * Maps OCI artifact registries to the registries written to the generated manifest. When the same source registry
+     * is configured more than once, the last override wins.
      */
     public final MapProperty<String, String> getRegistryOverrides() {
         return registryOverrides;

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -72,6 +72,7 @@ import org.gradle.process.ExecOperations;
 public abstract class CreateManifestTask extends DefaultTask {
 
     public static final String CREATE_MANIFEST_TASK_NAME = "createManifest";
+    private static final String OCI_ARTIFACT_TYPE = "oci";
 
     @Input
     public abstract SetProperty<ProductId> getInRepoProductIds();
@@ -186,6 +187,10 @@ public abstract class CreateManifestTask extends DefaultTask {
 
     private static JsonArtifactLocator applyRegistryOverride(
             JsonArtifactLocator artifact, Map<String, String> registryOverrides) {
+        if (!OCI_ARTIFACT_TYPE.equals(artifact.type())) {
+            return artifact;
+        }
+
         int firstPathSeparator = artifact.uri().indexOf('/');
         if (firstPathSeparator < 0) {
             return artifact;

--- a/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
+++ b/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/tasks/CreateManifestTask.java
@@ -46,6 +46,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -89,6 +90,9 @@ public abstract class CreateManifestTask extends DefaultTask {
 
     @Nested
     public abstract SetProperty<ArtifactLocator> getArtifacts();
+
+    @Input
+    public abstract MapProperty<String, String> getRegistryOverrides();
 
     @InputFile
     public abstract RegularFileProperty getProductDependenciesFile();
@@ -159,6 +163,7 @@ public abstract class CreateManifestTask extends DefaultTask {
         }
 
         validateEmptyArtifactsExtension();
+        Map<String, String> registryOverrides = getRegistryOverrides().get();
 
         ObjectMappers.jsonMapper.writeValue(
                 getManifestFile().getAsFile().get(),
@@ -174,8 +179,23 @@ public abstract class CreateManifestTask extends DefaultTask {
                                 "artifacts",
                                 getArtifacts().get().stream()
                                         .map(JsonArtifactLocator::from)
+                                        .map(artifact -> applyRegistryOverride(artifact, registryOverrides))
                                         .collect(Collectors.toList()))
                         .build());
+    }
+
+    private static JsonArtifactLocator applyRegistryOverride(
+            JsonArtifactLocator artifact, Map<String, String> registryOverrides) {
+        int firstPathSeparator = artifact.uri().indexOf('/');
+        if (firstPathSeparator < 0) {
+            return artifact;
+        }
+
+        String registry = artifact.uri().substring(0, firstPathSeparator);
+        return Optional.ofNullable(registryOverrides.get(registry))
+                .map(registryOverride -> JsonArtifactLocator.from(
+                        artifact.type(), registryOverride + artifact.uri().substring(firstPathSeparator)))
+                .orElse(artifact);
     }
 
     private void validateEmptyArtifactsExtension() {
@@ -343,6 +363,7 @@ public abstract class CreateManifestTask extends DefaultTask {
                                     ResolveProductDependenciesTask::getManifestFile));
                     task.getManifestExtensions().set(ext.getManifestExtensions());
                     task.getArtifacts().addAll(ext.getArtifacts());
+                    task.getRegistryOverrides().set(ext.getRegistryOverrides());
                     task.getInRepoProductIds()
                             .set(project.provider(() -> ProductDependencyIntrospectionPlugin.getInRepoProductIds(
                                             project.getRootProject())

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -370,7 +370,7 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         buildResult.wasExecuted(':createManifest')
         readArtifactsExtension() == [
             JsonArtifactLocator.from('oci', 'first-mirror.example.io/foo/bar:v1.3.0'),
-            JsonArtifactLocator.from('other', 'first-mirror.example.io/foo/baz:v1.3.0'),
+            JsonArtifactLocator.from('other', 'registry.example.io/foo/baz:v1.3.0'),
             JsonArtifactLocator.from('oci', 'registry.example.io.invalid/foo/qux:v1.3.0')
         ]
 

--- a/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
+++ b/gradle-sls-packaging/src/test/groovy/com/palantir/gradle/dist/tasks/CreateManifestTaskIntegrationSpec.groovy
@@ -342,6 +342,67 @@ class CreateManifestTaskIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
     }
 
+    def "#gradleVersionNumber: applies registry overrides to manifest artifacts"() {
+        given:
+        gradleVersion = gradleVersionNumber
+        buildFile << """
+            distribution {
+                registryOverrides.put('registry.example.io', 'first-mirror.example.io')
+                artifact {
+                    type = 'oci'
+                    uri = 'registry.example.io/foo/bar:v1.3.0'
+                }
+                artifact {
+                    type = 'other'
+                    uri = 'registry.example.io/foo/baz:v1.3.0'
+                }
+                artifact {
+                    type = 'oci'
+                    uri = 'registry.example.io.invalid/foo/qux:v1.3.0'
+                }
+            }
+        """.stripIndent(true)
+
+        when:
+        def buildResult = runTasksSuccessfully('createManifest')
+
+        then:
+        buildResult.wasExecuted(':createManifest')
+        readArtifactsExtension() == [
+            JsonArtifactLocator.from('oci', 'first-mirror.example.io/foo/bar:v1.3.0'),
+            JsonArtifactLocator.from('other', 'first-mirror.example.io/foo/baz:v1.3.0'),
+            JsonArtifactLocator.from('oci', 'registry.example.io.invalid/foo/qux:v1.3.0')
+        ]
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+    }
+
+    def "#gradleVersionNumber: last registry override for the same registry wins"() {
+        given:
+        gradleVersion = gradleVersionNumber
+        buildFile << """
+            distribution {
+                registryOverrides.put('registry.example.io', 'first-mirror.example.io')
+                registryOverrides.put('registry.example.io', 'second-mirror.example.io')
+                artifact {
+                    type = 'oci'
+                    uri = 'registry.example.io/foo/bar:v1.3.0'
+                }
+            }
+        """.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('createManifest')
+
+        then:
+        readArtifactsExtension() ==
+                [JsonArtifactLocator.from('oci', 'second-mirror.example.io/foo/bar:v1.3.0')]
+
+        where:
+        gradleVersionNumber << GradleTestVersions.GRADLE_VERSIONS
+    }
+
     private List<JsonArtifactLocator> readArtifactsExtension() {
         def manifest = ObjectMappers.jsonMapper.readValue(file('build/deployment/manifest.yml').text, SlsManifest)
         ObjectMappers.jsonMapper.convertValue(manifest.extensions().get("artifacts"), new TypeReference<List<JsonArtifactLocator>>() {})

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,16 @@ distribution {
 }
 ```
 
+Registry overrides replace the registry component of matching artifact URIs when the manifest is generated. For example, the following writes `mirror.example.io/foo/bar:v1.3.0` to the manifest:
+
+```gradle
+distribution {
+    registryOverrides.put('registry.example.io', 'mirror.example.io')
+}
+```
+
+Only an exact match for the URI component before the first `/` is replaced. If the same source registry is configured more than once, the last override wins.
+
 The result will be embedded in the `deployment/manifest.yml` file. The file will look something like this:
 
 ```json

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ distribution {
 }
 ```
 
-Registry overrides replace the registry component of matching artifact URIs when the manifest is generated. For example, the following writes `mirror.example.io/foo/bar:v1.3.0` to the manifest:
+Registry overrides replace the registry component of matching OCI artifact URIs when the manifest is generated. For example, the following writes `mirror.example.io/foo/bar:v1.3.0` to the manifest:
 
 ```gradle
 distribution {
@@ -198,7 +198,7 @@ distribution {
 }
 ```
 
-Only an exact match for the URI component before the first `/` is replaced. If the same source registry is configured more than once, the last override wins.
+Only `oci` artifacts with an exact match for the URI component before the first `/` are changed. If the same source registry is configured more than once, the last override wins.
 
 The result will be embedded in the `deployment/manifest.yml` file. The file will look something like this:
 


### PR DESCRIPTION
## Before this PR

Artifact registries written to the SLS manifest could only be changed by mutating each `ArtifactLocator`. This requires reading provider-backed artifact URIs before `createManifest`, which is unsafe for URIs produced lazily by other tasks.

## After this PR

==COMMIT_MSG==
==COMMIT_MSG==

The `distribution.registryOverrides` map replaces exact leading registry components when `createManifest` writes OCI artifact URIs. The last value configured for a source registry wins.

## Testing

- `./gradlew format compileAllErrorProne checkstyleMain checkstyleTest --continue -PerrorProneApply`
- `./gradlew test`

## Possible downsides?

None known.

## Are Docs needed?

Yes. The README documents OCI-only configuration, exact matching, and last-write-wins behavior.
